### PR TITLE
spec: fix-chromatic-targets-canonical-source

### DIFF
--- a/openspec/changes/fix-chromatic-targets-canonical-source/design.md
+++ b/openspec/changes/fix-chromatic-targets-canonical-source/design.md
@@ -1,0 +1,84 @@
+## Context
+
+`CHROMATIC_TARGETS` maps each rainbow color to three probability vectors — temporal
+(past/present/future), spatial (thing/place/person), ontological (imagined/forgotten/known)
+— and is the central signal used by every scoring function in the pipeline. It was
+hand-rolled in multiple files and has diverged from the canonical Pydantic model in
+`app/structures/concepts/rainbow_table_color.py`.
+
+## Goals / Non-Goals
+
+- **Goals**: single definition, derived from Pydantic source of truth, imported everywhere,
+  tested against the model, no silent drift possible in future
+- **Non-Goals**: changing the mode label strings or vector ordering (that's a separate,
+  breaking refactor); retroactively re-scoring existing artifacts (recommended but manual)
+
+## Decisions
+
+### Decision: New module at `app/structures/concepts/chromatic_targets.py`
+
+Lives in `app/structures/concepts/` alongside `rainbow_table_color.py`. Derives the dict
+at import time by iterating `the_rainbow_table_colors`. Exports:
+- `CHROMATIC_TARGETS: dict[str, dict[str, list[float]]]`
+- `TEMPORAL_MODES: tuple[str, ...]` = `("past", "present", "future")`
+- `SPATIAL_MODES: tuple[str, ...]` = `("thing", "place", "person")`
+- `ONTOLOGICAL_MODES: tuple[str, ...]` = `("imagined", "forgotten", "known")`
+
+**Why not inline in `rainbow_table_color.py`**: keeps the Pydantic model file focused on
+data definition; the float-vector representation is a derived concern for the ML pipeline,
+not the conceptual model itself.
+
+**Derivation logic**:
+- `temporal_mode`: `PAST→[0.8,0.1,0.1]`, `PRESENT→[0.1,0.8,0.1]`, `FUTURE→[0.1,0.1,0.8]`,
+  `None→[1/3,1/3,1/3]`
+- `objectional_mode`: `THING→[0.8,0.1,0.1]`, `PLACE→[0.1,0.8,0.1]`, `PERSON→[0.1,0.1,0.8]`,
+  `None→[1/3,1/3,1/3]`
+- `ontological_mode` (list): single mode → `0.8` at its index, `0.1` elsewhere;
+  two modes (Indigo: Known+Forgotten) → `0.4` each, `0.1` for the third;
+  `None→[1/3,1/3,1/3]`
+
+### Decision: `training/` files import via `sys.path` insert, not package install
+
+`training/` scripts run in Modal (remote) and locally without package install. They
+currently use `sys.path.insert(0, str(repo_root))` or equivalent. The import will be:
+
+```python
+from app.structures.concepts.chromatic_targets import CHROMATIC_TARGETS
+```
+
+This is already the pattern used by `training/refractor.py` for other imports.
+
+### Decision: `_CDM_CHROMATIC_TARGETS` in `refractor.py` becomes an alias
+
+```python
+from app.structures.concepts.chromatic_targets import CHROMATIC_TARGETS as _CDM_CHROMATIC_TARGETS
+```
+
+The name `_CDM_CHROMATIC_TARGETS` is kept for minimal diff; callers inside `refractor.py`
+don't change.
+
+### Decision: Mode ordering constants are authoritative in `chromatic_targets.py`
+
+`TEMPORAL_MODES`, `SPATIAL_MODES`, `ONTOLOGICAL_MODES` move there. `refractor.py`
+re-exports them for backward compatibility.
+
+## Risks / Trade-offs
+
+- **Existing scored artifacts are stale** — any review.yml or mix_score.yml produced
+  before this fix has wrong chromatic_match values for 7 of 9 colors. No automated
+  migration; the fix recommendation is to re-run scoring pipelines.
+- **CDM validation will change** — accuracy numbers in the HF model card will shift
+  because `_top1_color()` in `validate_mix_scoring.py` uses `CHROMATIC_TARGETS` to
+  pick the predicted color. Could go up or down; requires a re-run to confirm.
+- **No retraining needed for CDM weights** — CDM is a discriminative classifier trained
+  on integer class labels; the weights don't encode target vectors. Only inference-time
+  mapping changes.
+
+## Open Questions
+
+- Should Indigo's temporal and spatial axes use `[1/3, 1/3, 1/3]` or something that
+  reflects its "ghost color" nature differently? Current derivation is uniform because
+  `temporal_mode` and `objectional_mode` are `None` in the Pydantic model.
+- Black and White both derive to fully uniform vectors. Is this intentional, or should
+  Black's transmigrational mode (SPACE→TIME→INFORMATION) encode a directional bias?
+  Leaving as uniform until the user specifies otherwise.

--- a/openspec/changes/fix-chromatic-targets-canonical-source/proposal.md
+++ b/openspec/changes/fix-chromatic-targets-canonical-source/proposal.md
@@ -1,0 +1,77 @@
+# Change: Fix CHROMATIC_TARGETS — derive from canonical Pydantic source of truth
+
+## Why
+
+`CHROMATIC_TARGETS` — the per-color probability vectors used for chromatic scoring, drift
+reporting, and CDM inference — are hardcoded in at least five files and are wrong for 7 of 9
+colors. The single source of truth is `app/structures/concepts/rainbow_table_color.py`
+(`the_rainbow_table_colors`), but no code derives from it: every file hand-rolled its own
+copy and they diverged from each other and from the Pydantic model.
+
+Immediate pipeline impact: chord, bass, drum, and melody candidates for Orange, Yellow,
+Green, Blue, Indigo, Violet, and Black albums have all been scored and pruned against
+incorrect chromatic targets. Drift reports and chromatic match scores for those colors
+are meaningless until this is corrected.
+
+## What the correct targets are
+
+Mode vector ordering (established in pipeline): temporal `[past, present, future]`,
+spatial `[thing, place, person]`, ontological `[imagined, forgotten, known]`.
+
+Derived from `the_rainbow_table_colors`:
+
+| Color  | Temporal          | Spatial           | Ontological       |
+|--------|-------------------|-------------------|-------------------|
+| Red    | [0.8, 0.1, 0.1] ✓ | [0.8, 0.1, 0.1] ✓ | [0.1, 0.1, 0.8] ✓ |
+| Orange | [0.8, 0.1, 0.1]   | [0.8, 0.1, 0.1]   | [0.8, 0.1, 0.1]   |
+| Yellow | [0.1, 0.1, 0.8]   | [0.1, 0.8, 0.1]   | [0.8, 0.1, 0.1]   |
+| Green  | [0.1, 0.1, 0.8]   | [0.1, 0.8, 0.1]   | [0.1, 0.8, 0.1]   |
+| Blue   | [0.1, 0.8, 0.1]   | [0.1, 0.1, 0.8]   | [0.1, 0.8, 0.1]   |
+| Indigo | [1/3, 1/3, 1/3]   | [1/3, 1/3, 1/3]   | [0.1, 0.4, 0.4]   |
+| Violet | [0.1, 0.8, 0.1]   | [0.1, 0.1, 0.8]   | [0.1, 0.1, 0.8]   |
+| White  | [1/3, 1/3, 1/3] ✓ | [1/3, 1/3, 1/3] ✓ | [1/3, 1/3, 1/3] ✓ |
+| Black  | [1/3, 1/3, 1/3]   | [1/3, 1/3, 1/3]   | [1/3, 1/3, 1/3]   |
+
+(✓ = already correct everywhere)
+
+## Current state of each file
+
+| File | Errors |
+|------|--------|
+| `app/generators/midi/pipelines/chord_pipeline.py` | Orange spatial, Yellow temporal+ontological, Green temporal, Blue temporal+ontological, Indigo all, Violet ontological |
+| `training/refractor.py` (`_CDM_CHROMATIC_TARGETS`) | Orange temporal+ontological, Yellow temporal+ontological, Green temporal+ontological, Blue temporal+spatial, Indigo all, Violet temporal+ontological, Black all |
+| `training/validate_mix_scoring.py` | Same errors as `refractor.py` |
+| `training/modal_train_refractor_cdm.py` | Same errors as `refractor.py` |
+| `app/generators/midi/production/score_mix.py` | (uses `compute_chromatic_match` which sources from refractor — needs audit) |
+
+## What Changes
+
+- **NEW: `app/structures/concepts/chromatic_targets.py`** — single module that derives
+  `CHROMATIC_TARGETS` from `the_rainbow_table_colors` at import time; exported as a typed
+  dict. All other files import from here; no hardcoded copies remain.
+- **UPDATED: all five files above** — replace hardcoded dicts with import from
+  `chromatic_targets.py`
+- **UPDATED: `training/refractor.py`** — `_CDM_CHROMATIC_TARGETS` becomes an alias for
+  the shared dict; mode-ordering constants (`TEMPORAL_MODES`, `SPATIAL_MODES`,
+  `ONTOLOGICAL_MODES`) moved to `chromatic_targets.py` and re-exported
+- **NEW: tests** — `tests/structures/test_chromatic_targets.py` asserts the computed
+  vectors match the Pydantic model field values for every color; asserts vectors sum to 1.0;
+  asserts no duplicate target vectors exist across colors
+- **CDM retraining required** — the CDM ONNX inference applies `_CDM_CHROMATIC_TARGETS`
+  at prediction time; once corrected, the loaded `refractor_cdm.onnx` will produce
+  different (correct) score distributions. Retraining is not required (the CDM learns
+  integer class labels, not targets), but `validate_mix_scoring.py` should be re-run to
+  confirm accuracy is not degraded. The HF model card `refractor_cdm` should be updated.
+
+## Impact
+
+- Affected specs: `audio-mix-scoring`, `chord-generation`, `bass-generation`,
+  `melody-generation`, `drum-generation` (all use CHROMATIC_TARGETS for scoring)
+- Affected code: `app/generators/midi/pipelines/chord_pipeline.py`,
+  `app/generators/midi/production/score_mix.py`, `training/refractor.py`,
+  `training/validate_mix_scoring.py`, `training/modal_train_refractor_cdm.py`
+- **Non-breaking for API callers**: dict keys (`temporal`/`spatial`/`ontological`) and
+  mode label strings are unchanged; only the probability values change
+- **Breaking for existing scored artifacts**: any `mix_score.yml`, `review.yml`, or
+  drift report produced before this fix contains wrong chromatic_match and drift values
+  for non-Red/non-White songs. Re-scoring is recommended before production decisions.

--- a/openspec/changes/fix-chromatic-targets-canonical-source/specs/audio-mix-scoring/spec.md
+++ b/openspec/changes/fix-chromatic-targets-canonical-source/specs/audio-mix-scoring/spec.md
@@ -1,0 +1,40 @@
+## MODIFIED Requirements
+
+### Requirement: Mix Chromatic Scoring
+The system SHALL score a rendered audio bounce against the song's chromatic target using
+Refractor in audio-only mode (no MIDI, no concept text), returning temporal, spatial, and
+ontological probability distributions plus a scalar confidence value.
+
+`CHROMATIC_TARGETS` used by `compute_chromatic_match()` and `write_mix_score()` SHALL be
+imported from `app.structures.concepts.chromatic_targets` — not hardcoded inline.
+
+#### Scenario: Audio-only Refractor inference
+- **WHEN** only an audio embedding is provided (no MIDI, no concept embedding)
+- **THEN** Refractor returns a valid score dict with temporal/spatial/ontological dicts and
+  a confidence in [0, 1]
+
+#### Scenario: Chromatic match computed
+- **WHEN** the Refractor result and the color's `CHROMATIC_TARGETS` entry are available
+- **THEN** `compute_chromatic_match()` returns a scalar in [0, 1] representing alignment
+
+#### Scenario: Targets sourced from canonical module
+- **WHEN** `score_mix.py` computes chromatic match for any color
+- **THEN** the probability vectors used match those exported by `chromatic_targets.py`
+  for that color — no inline override is present in `score_mix.py`
+
+---
+
+### Requirement: Per-Dimension Drift Report
+The system SHALL compute a drift report comparing the mix's predicted chromatic distribution
+against the song's target distribution, reporting per-dimension signed deltas.
+
+The target distributions used for drift SHALL be sourced from `chromatic_targets.py`.
+
+#### Scenario: Drift computed for all three dimensions
+- **WHEN** a Refractor result and a `CHROMATIC_TARGETS` target are provided
+- **THEN** the drift report contains temporal_delta, spatial_delta, ontological_delta, and
+  an overall_drift scalar (mean absolute delta across dimensions)
+
+#### Scenario: On-target mix
+- **WHEN** predicted distributions closely match the target
+- **THEN** overall_drift is near 0.0 and all dimension deltas are small

--- a/openspec/changes/fix-chromatic-targets-canonical-source/specs/chromatic-targets/spec.md
+++ b/openspec/changes/fix-chromatic-targets-canonical-source/specs/chromatic-targets/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Canonical Chromatic Targets Module
+The system SHALL provide a single module `app/structures/concepts/chromatic_targets.py`
+that derives `CHROMATIC_TARGETS` at import time from `the_rainbow_table_colors` (the
+authoritative Pydantic instances in `app/structures/concepts/rainbow_table_color.py`).
+No other file in the codebase SHALL define its own copy of these probability vectors.
+
+The module SHALL also export `TEMPORAL_MODES`, `SPATIAL_MODES`, and `ONTOLOGICAL_MODES`
+as tuples of mode label strings in the canonical vector ordering used throughout the pipeline:
+- `TEMPORAL_MODES = ("past", "present", "future")`
+- `SPATIAL_MODES = ("thing", "place", "person")`
+- `ONTOLOGICAL_MODES = ("imagined", "forgotten", "known")`
+
+#### Scenario: Vectors sum to 1.0
+- **WHEN** `CHROMATIC_TARGETS` is imported
+- **THEN** each of the three vectors for every color sums to 1.0 (±1e-6)
+
+#### Scenario: Correct values for canonical colors
+- **WHEN** the module is imported
+- **THEN** `CHROMATIC_TARGETS["Red"]["temporal"]` equals `[0.8, 0.1, 0.1]`,
+  `CHROMATIC_TARGETS["Green"]["temporal"]` equals `[0.1, 0.1, 0.8]`,
+  and `CHROMATIC_TARGETS["Violet"]["ontological"]` equals `[0.1, 0.1, 0.8]`
+
+#### Scenario: Indigo two-mode ontological
+- **WHEN** the module is imported
+- **THEN** `CHROMATIC_TARGETS["Indigo"]["ontological"]` equals `[0.1, 0.4, 0.4]`
+  (split evenly between KNOWN and FORGOTTEN, IMAGINED suppressed to 0.1)
+
+#### Scenario: No duplicate full-target triples among chromatic colors
+- **WHEN** comparing all nine colors' combined (temporal, spatial, ontological) tuples
+- **THEN** no two colors share an identical triple
+  (Yellow and Green MUST differ — this was the root cause of the CDM collapse)
+
+#### Scenario: Pure Python import, no ML dependencies
+- **WHEN** `chromatic_targets.py` is imported in an environment without torch or onnxruntime
+- **THEN** the import succeeds and `CHROMATIC_TARGETS` is fully populated

--- a/openspec/changes/fix-chromatic-targets-canonical-source/tasks.md
+++ b/openspec/changes/fix-chromatic-targets-canonical-source/tasks.md
@@ -53,8 +53,16 @@
 - [ ] 5.3 If overall accuracy drops below 70%: retrain CDM
       (`python training/extract_cdm_embeddings.py` + `modal run modal_train_refractor_cdm.py`)
 
-## 6. Cleanup
+## 6. Re-score affected artifacts
 
-- [ ] 6.1 Run full test suite; confirm 0 new regressions
-- [ ] 6.2 Note in commit message that existing `mix_score.yml` / `review.yml` artifacts
-      for non-Red/non-White songs should be re-scored
+- [ ] 6.1 Identify any approved/promoted `review.yml` files for non-Red/non-White songs
+      (chord, drum, bass, melody) — these have stale `chromatic_match` scores
+- [ ] 6.2 Re-run scoring for any song that has been through the full production pipeline;
+      check whether previously approved candidates still rank at the top with correct targets
+- [ ] 6.3 For the base Refractor ONNX (`refractor.onnx`): **no retraining required** —
+      `modal_midi_fusion.py` trains from per-segment mode labels in the HF dataset, never
+      from `CHROMATIC_TARGETS`; the weights are correct as-is
+
+## 7. Cleanup
+
+- [ ] 7.1 Run full test suite; confirm 0 new regressions

--- a/openspec/changes/fix-chromatic-targets-canonical-source/tasks.md
+++ b/openspec/changes/fix-chromatic-targets-canonical-source/tasks.md
@@ -1,0 +1,60 @@
+## 1. Canonical module
+
+- [ ] 1.1 Create `app/structures/concepts/chromatic_targets.py`:
+      derive `CHROMATIC_TARGETS` at import time from `the_rainbow_table_colors`;
+      export `TEMPORAL_MODES`, `SPATIAL_MODES`, `ONTOLOGICAL_MODES` tuples
+- [ ] 1.2 Derivation logic (see design.md):
+      single ontological mode → 0.8 at index, 0.1 elsewhere;
+      two modes (Indigo) → 0.4 each, 0.1 for third;
+      `None` → uniform `[1/3, 1/3, 1/3]`
+- [ ] 1.3 Verify computed vectors match the table in proposal.md for all 9 colors
+
+## 2. Deep audit & update — generation pipeline
+
+- [ ] 2.1 `app/generators/midi/pipelines/chord_pipeline.py`: replace hardcoded
+      `CHROMATIC_TARGETS` with import from `chromatic_targets.py`; confirm
+      `compute_chromatic_match` uses mode labels that match `TEMPORAL_MODES` etc.
+- [ ] 2.2 Grep entire `app/generators/midi/` for any other hardcoded color target dicts
+      or inline `[0.8, 0.1, 0.1]`-style vectors — update any found
+- [ ] 2.3 Verify `bass_pipeline.py`, `drum_pipeline.py`, `melody_pipeline.py` all
+      source `CHROMATIC_TARGETS` from one place (currently via chord_pipeline import
+      or direct copy — confirm and fix)
+
+## 3. Deep audit & update — training / scoring
+
+- [ ] 3.1 `training/refractor.py`: replace `_CDM_CHROMATIC_TARGETS` with alias import;
+      move `TEMPORAL_MODES`, `SPATIAL_MODES`, `ONTOLOGICAL_MODES` constants to
+      `chromatic_targets.py` and re-import in `refractor.py`
+- [ ] 3.2 `training/validate_mix_scoring.py`: replace hardcoded `CHROMATIC_TARGETS`;
+      confirm `_top1_color()` mode label ordering matches `TEMPORAL_MODES` etc.
+- [ ] 3.3 `training/modal_train_refractor_cdm.py`: replace hardcoded `CHROMATIC_TARGETS`
+- [ ] 3.4 `app/generators/midi/production/score_mix.py`: audit `compute_chromatic_match`
+      and `write_mix_score` — confirm they use the dict keys from `TEMPORAL_MODES` etc.
+      and not any hardcoded strings
+
+## 4. Tests
+
+- [ ] 4.1 Create `tests/structures/test_chromatic_targets.py`:
+      - each color's derived vectors sum to 1.0 (±1e-6)
+      - each vector has exactly 3 elements, all in [0, 1]
+      - Red, White, Black match known-correct values (regression guard)
+      - Indigo ontological = [0.1, 0.4, 0.4] (two-mode case)
+      - no two non-transmigrational colors share identical target triples
+        (catches the Yellow==Green collision that originally masked the CDM bug)
+- [ ] 4.2 Add import-level smoke test: `from app.structures.concepts.chromatic_targets
+      import CHROMATIC_TARGETS` succeeds without torch/onnx (pure Python dep only)
+
+## 5. CDM re-validation
+
+- [ ] 5.1 Re-run `python training/validate_mix_scoring.py` with corrected targets;
+      record new per-color accuracy table
+- [ ] 5.2 Update HF model card at `earthlyframes/refractor_cdm` with corrected color
+      descriptions and new validation numbers
+- [ ] 5.3 If overall accuracy drops below 70%: retrain CDM
+      (`python training/extract_cdm_embeddings.py` + `modal run modal_train_refractor_cdm.py`)
+
+## 6. Cleanup
+
+- [ ] 6.1 Run full test suite; confirm 0 new regressions
+- [ ] 6.2 Note in commit message that existing `mix_score.yml` / `review.yml` artifacts
+      for non-Red/non-White songs should be re-scored


### PR DESCRIPTION
## Summary

- Adds OpenSpec proposal to fix `CHROMATIC_TARGETS` — 7 of 9 colors are wrong across 4+ files
- Source of truth is `app/structures/concepts/rainbow_table_color.py`; no implementation yet, spec only
- Includes `design.md` documenting the canonical derivation logic and what does/doesn't need retraining

## Why now

Caught after validating the Refractor CDM: Green and Yellow shared identical targets (both wrong), masking the confusion as "pipeline-safe." Full audit shows Red and White are the only colors currently correct everywhere.

## No code changes in this PR — spec only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)