### PR TITLE
fix(#166, #167, #168): tape label node, slug generation, exit snapshots

### DIFF
--- a/packages/core/src/white_core/artifacts/quantum_tape_label_artifact.py
+++ b/packages/core/src/white_core/artifacts/quantum_tape_label_artifact.py
@@ -8,6 +8,7 @@ from dotenv import load_dotenv
 from pydantic import Field
 
 from white_core.artifacts.base_artifact import ChainArtifact
+from white_core.enums.chain_artifact_type import ChainArtifactType
 from white_core.enums.quantum_tape_recording_quality import (
     QuantumTapeRecordingQuality,
 )
@@ -17,6 +18,8 @@ load_dotenv()
 
 class QuantumTapeLabelArtifact(ChainArtifact, ABC):
     """VHS/Cassette tape label metadata."""
+
+    chain_artifact_type: ChainArtifactType = ChainArtifactType.QUANTUM_TAPE_LABEL
 
     title: str = Field(
         description="The title of the tape", examples=["Summer in Portland - 1998"]

--- a/packages/ideation/src/white_ideation/agents/blue_agent.py
+++ b/packages/ideation/src/white_ideation/agents/blue_agent.py
@@ -37,6 +37,7 @@ from white_core.concepts.timeline_breakage_checks import TimelineBreakageChecks
 from white_core.concepts.timeline_breakage_evaluation_results import (
     TimelineEvaluationResult,
 )
+from white_core.enums.chain_artifact_type import ChainArtifactType
 from white_core.enums.quantum_tape_emotional_tone import QuantumTapeEmotionalTone
 from white_core.enums.quantum_tape_lyrical_theme import QuantumTapeLyricalTheme
 from white_core.enums.quantum_tape_recording_quality import QuantumTapeRecordingQuality
@@ -1073,6 +1074,7 @@ The tape has been recorded over. What life exists on it now?
                     data = yaml.safe_load(f)
                     data["base_path"] = os.getenv("AGENT_WORK_PRODUCT_BASE_PATH")
                     data["thread_id"] = state.thread_id
+                    data["chain_artifact_type"] = ChainArtifactType.QUANTUM_TAPE_LABEL
                     label = QuantumTapeLabelArtifact(**data)
                     label.save_file()
                     state.artifacts.append(label)

--- a/packages/ideation/src/white_ideation/agents/blue_agent.py
+++ b/packages/ideation/src/white_ideation/agents/blue_agent.py
@@ -11,11 +11,13 @@ from dotenv import load_dotenv
 from langchain_anthropic import ChatAnthropic
 from langgraph.constants import END, START
 from langgraph.graph import StateGraph
+
 from white_core.agents.agent_settings import AgentSettings
 from white_core.agents.base_rainbow_agent import BaseRainbowAgent
 from white_core.artifacts.alternate_timeline_artifact import (
     AlternateTimelineArtifact,
 )
+from white_core.artifacts.quantum_tape_label_artifact import QuantumTapeLabelArtifact
 from white_core.concepts.alternate_history_constraints import (
     AlternateHistoryConstraints,
 )
@@ -37,6 +39,7 @@ from white_core.concepts.timeline_breakage_evaluation_results import (
 )
 from white_core.enums.quantum_tape_emotional_tone import QuantumTapeEmotionalTone
 from white_core.enums.quantum_tape_lyrical_theme import QuantumTapeLyricalTheme
+from white_core.enums.quantum_tape_recording_quality import QuantumTapeRecordingQuality
 from white_core.manifests.song_proposal import SongProposalIteration
 from white_core.music.core.key_signature import KeySignature, Mode, ModeName
 from white_core.music.core.notes import Note
@@ -45,7 +48,6 @@ from white_extraction.util.manifest_loader import (
     get_sounds_like_by_color,
     sample_reference_artists,
 )
-
 from white_ideation.agents.agent_state_utils import get_state_snapshot
 from white_ideation.agents.list_utils import pick_by_fraction
 from white_ideation.agents.states.blue_agent_state import BlueAgentState
@@ -156,6 +158,7 @@ class BlueAgent(BaseRainbowAgent, ABC):
         work_flow.add_node(
             "extract_musical_parameters", self.extract_musical_parameters
         )
+        work_flow.add_node("generate_tape_label", self.generate_tape_label)
         work_flow.add_node(
             "generate_alternate_song_spec", self.generate_alternate_song_spec
         )
@@ -171,7 +174,8 @@ class BlueAgent(BaseRainbowAgent, ABC):
             },
         )
         work_flow.add_edge("generate_alternate_history", "extract_musical_parameters")
-        work_flow.add_edge("extract_musical_parameters", "generate_alternate_song_spec")
+        work_flow.add_edge("extract_musical_parameters", "generate_tape_label")
+        work_flow.add_edge("generate_tape_label", "generate_alternate_song_spec")
         work_flow.add_edge("generate_alternate_song_spec", END)
 
         return work_flow
@@ -1048,6 +1052,110 @@ The tape has been recorded over. What life exists on it now?
         get_state_snapshot(
             state,
             "extract_musical_parameters_exit",
+            state.thread_id,
+            "The Cassette Bearer",
+        )
+        return state
+
+    @agent_error_handler("The Cassette Bearer")
+    def generate_tape_label(self, state: BlueAgentState) -> BlueAgentState:
+        get_state_snapshot(
+            state, "generate_tape_label_enter", state.thread_id, "The Cassette Bearer"
+        )
+        mock_mode = os.getenv("MOCK_MODE", "false").lower() == "true"
+        block_mode = os.getenv("BLOCK_MODE", "false").lower() == "true"
+        if mock_mode:
+            try:
+                with open(
+                    f"{os.getenv('AGENT_MOCK_DATA_PATH')}/quantum_tape_label_mock.yml",
+                    "r",
+                ) as f:
+                    data = yaml.safe_load(f)
+                    data["base_path"] = os.getenv("AGENT_WORK_PRODUCT_BASE_PATH")
+                    data["thread_id"] = state.thread_id
+                    label = QuantumTapeLabelArtifact(**data)
+                    label.save_file()
+                    state.artifacts.append(label)
+                    state.tape_label = label.title
+            except Exception as e:
+                error_msg = f"Failed to read mock tape label: {e!s}"
+                logger.error(error_msg)
+                if block_mode:
+                    raise Exception(error_msg)
+            get_state_snapshot(
+                state,
+                "generate_tape_label_exit",
+                state.thread_id,
+                "The Cassette Bearer",
+            )
+            return state
+
+        alternate = state.alternate_history
+        if alternate is None:
+            logger.error("alternate_history is None, cannot generate tape label")
+            get_state_snapshot(
+                state,
+                "generate_tape_label_exit",
+                state.thread_id,
+                "The Cassette Bearer",
+            )
+            return state
+
+        start = alternate.period.start_date
+        end = alternate.period.end_date
+        original_label = f"Gabe Walsh — {start.year}"
+        tapeover_date_str = f"{start.strftime('%b %Y')} – {end.strftime('%b %Y')}"
+        age_range = alternate.period.age_range
+        age_str = f"{age_range[0]}–{age_range[1]}"
+        location_str = getattr(alternate.period, "location", None) or "Unknown"
+        catalog_str = f"QT-B-{start.year}-{state.thread_id[:6].upper()}"
+        quality_map = {
+            QuantumTapeEmotionalTone.WISTFUL: QuantumTapeRecordingQuality.SP,
+            QuantumTapeEmotionalTone.MELANCHOLY: QuantumTapeRecordingQuality.LP,
+            QuantumTapeEmotionalTone.BITTERSWEET: QuantumTapeRecordingQuality.SP,
+            QuantumTapeEmotionalTone.NOSTALGIC: QuantumTapeRecordingQuality.EP,
+            QuantumTapeEmotionalTone.PEACEFUL: QuantumTapeRecordingQuality.LP,
+            QuantumTapeEmotionalTone.RESTLESS: QuantumTapeRecordingQuality.SP,
+        }
+        quality = quality_map.get(
+            alternate.emotional_tone, QuantumTapeRecordingQuality.SP
+        )
+        note = self._generate_a_cryptic_note(alternate)
+        base_path = os.getenv("AGENT_WORK_PRODUCT_BASE_PATH")
+        try:
+            label = QuantumTapeLabelArtifact(
+                thread_id=state.thread_id,
+                base_path=base_path,
+                title=alternate.title,
+                date_range=f"{start} to {end}",
+                recording_quality=quality,
+                counter_start=random.randint(0, 9999),
+                counter_end=random.randint(1000, 9999),
+                notes=note,
+                original_label_visible=True,
+                original_label_text=original_label,
+                tape_degradation=random.uniform(0.1, 0.4),
+                year_documented=str(start.year),
+                original_date=str(start.year),
+                original_title=original_label,
+                tapeover_date=tapeover_date_str,
+                tapeover_title=alternate.title,
+                subject_name="Gabe Walsh",
+                age_during=age_str,
+                location=location_str,
+                catalog_number=catalog_str,
+            )
+            label.save_file()
+            state.artifacts.append(label)
+            state.tape_label = label.title
+        except Exception as e:
+            error_msg = f"Failed to generate tape label: {e!s}"
+            logger.error(error_msg)
+            if block_mode:
+                raise Exception(error_msg)
+        get_state_snapshot(
+            state,
+            "generate_tape_label_exit",
             state.thread_id,
             "The Cassette Bearer",
         )

--- a/packages/ideation/src/white_ideation/agents/green_agent.py
+++ b/packages/ideation/src/white_ideation/agents/green_agent.py
@@ -9,6 +9,7 @@ from dotenv import load_dotenv
 from langchain_anthropic import ChatAnthropic
 from langgraph.constants import END, START
 from langgraph.graph.state import StateGraph
+
 from white_core.agents.agent_settings import AgentSettings
 from white_core.agents.base_rainbow_agent import BaseRainbowAgent
 from white_core.artifacts.arbitrarys_survey_artifact import ArbitrarysSurveyArtifact
@@ -25,7 +26,6 @@ from white_core.concepts.last_human_species_extinction_parallel_moment import (
 )
 from white_core.concepts.rainbow_table_color import the_rainbow_table_colors
 from white_core.manifests.song_proposal import SongProposalIteration
-
 from white_ideation.agents.agent_state_utils import get_state_snapshot
 from white_ideation.agents.states.green_agent_state import GreenAgentState
 from white_ideation.agents.states.white_agent_state import MainAgentState
@@ -388,6 +388,12 @@ Write 2-3 paragraphs exploring this resonance. Be poetic but grounded. This insi
                     state.current_narrative = current_narrative
                     current_narrative.save_file()
                     state.artifacts.append(current_narrative)
+                    get_state_snapshot(
+                        state,
+                        "write_last_human_extinction_narrative_exit",
+                        state.thread_id,
+                        "Sub-Arbitrary",
+                    )
                     return state
             except Exception as e:
                 error_msg = f"Failed to read mock narrative: {e!s}"
@@ -457,6 +463,12 @@ Parallel the timelines, mirror the losses, but never explain the connection - le
                     state.current_narrative = current_narrative
                     current_narrative.save_file()
                     state.artifacts.append(current_narrative)
+                    get_state_snapshot(
+                        state,
+                        "write_last_human_extinction_narrative_exit",
+                        state.thread_id,
+                        "Sub-Arbitrary",
+                    )
                     return state
                 elif isinstance(result, LastHumanSpeciesExtinctionNarrativeArtifact):
                     # Override any LLM-generated values with correct ones
@@ -466,6 +478,12 @@ Parallel the timelines, mirror the losses, but never explain the connection - le
                     state.current_narrative = result
                     result.save_file()
                     state.artifacts.append(result)
+                    get_state_snapshot(
+                        state,
+                        "write_last_human_extinction_narrative_exit",
+                        state.thread_id,
+                        "Sub-Arbitrary",
+                    )
                     return state
                 else:
                     error_msg = f"Expected LastHumanSpeciesExtinctionNarrativeArtifact, got {type(result)}"
@@ -597,12 +615,18 @@ Score each dimension (1-10) and provide brief reasoning. Then give an overall as
                     state.current_decision = rescue_decision
                     rescue_decision.save_file()
                     state.artifacts.append(rescue_decision)
+                    get_state_snapshot(
+                        state, "claudes_choice_exit", state.thread_id, "Sub-Arbitrary"
+                    )
                     return state
             except Exception as e:
                 error_msg = f"Failed to read mock rescue decision: {e!s}"
                 logger.error(error_msg)
                 if block_mode:
                     raise Exception(error_msg)
+            get_state_snapshot(
+                state, "claudes_choice_exit", state.thread_id, "Sub-Arbitrary"
+            )
             return state
         else:
             if (
@@ -676,6 +700,9 @@ Make your choice and explain it in 2-3 paragraphs. This becomes the conceptual f
                 state.current_decision = current_decision
                 current_decision.save_file()
                 state.artifacts.append(current_decision)
+                get_state_snapshot(
+                    state, "claudes_choice_exit", state.thread_id, "Sub-Arbitrary"
+                )
                 return state
             elif isinstance(result, RescueDecisionArtifact):
                 # Override any LLM-generated values with correct ones
@@ -685,6 +712,9 @@ Make your choice and explain it in 2-3 paragraphs. This becomes the conceptual f
                 state.current_decision = result
                 result.save_file()
                 state.artifacts.append(result)
+                get_state_snapshot(
+                    state, "claudes_choice_exit", state.thread_id, "Sub-Arbitrary"
+                )
                 return state
             else:
                 error_msg = f"Expected RescueDecisionArtifact, got {type(result)}"
@@ -734,6 +764,13 @@ can recover from this self-destructive spiral. Your sub-instance has been asked,
 
 The song proposal:
 {state.white_proposal}
+
+Your counter-proposal's 'rainbow_color' property must always be:
+{the_rainbow_table_colors['G']}
+
+Your counter-proposal's 'title' must be a vivid, descriptive phrase about extinction and loss (e.g. "The Last Migration", "Empty Fields at Dusk", "Witnesses to the Final Season") — never a date, timestamp, or generic placeholder.
+
+Your counter-proposal's 'iteration_id' must follow this exact format: green_<title_slug>_v1 where <title_slug> is the title lowercased with spaces and punctuation replaced by underscores, max 30 characters (e.g. "green_the_last_migration_v1").
 
 Some other examples from the archive in the 'green' category:
 {the_rainbow_table_colors['G']}

--- a/packages/ideation/src/white_ideation/agents/indigo_agent.py
+++ b/packages/ideation/src/white_ideation/agents/indigo_agent.py
@@ -990,7 +990,7 @@ Concept: [full concept explanation]
                 state.counter_proposal = SongProposalIteration(
                     iteration_id=f"indigo_{surface_slug}_v1",
                     rainbow_color="indigo",
-                    title=state.surface_name,
+                    title=state.surface_name or surface_slug.replace("_", " ").title(),
                     key=previous_iteration.key,
                     bpm=previous_iteration.bpm,
                     tempo=previous_iteration.tempo,

--- a/packages/ideation/src/white_ideation/agents/indigo_agent.py
+++ b/packages/ideation/src/white_ideation/agents/indigo_agent.py
@@ -12,6 +12,7 @@ from langchain_anthropic import ChatAnthropic
 from langchain_core.output_parsers import StrOutputParser
 from langgraph.constants import END, START
 from langgraph.graph.state import StateGraph
+
 from white_core.agents.agent_settings import AgentSettings
 from white_core.agents.base_rainbow_agent import BaseRainbowAgent
 from white_core.artifacts.infranym_audio_artifact import InfranymAudioArtifact
@@ -27,7 +28,6 @@ from white_core.enums.infranym_medium import InfranymMedium
 from white_core.manifests.song_proposal import SongProposalIteration
 from white_core.music.core.key_signature import KeySignature
 from white_core.music.core.notes import Note
-
 from white_ideation.agents.agent_state_utils import get_state_snapshot
 from white_ideation.agents.states.indigo_agent_state import IndigoAgentState
 from white_ideation.agents.states.white_agent_state import MainAgentState
@@ -484,10 +484,22 @@ Respond with ONLY the surface name (proper capitalization, with spaces).
 
         if medium is None:
             logger.error("infranym_medium is None, cannot implement infranym")
+            get_state_snapshot(
+                state,
+                "implement_infranym_method_exit",
+                state.thread_id,
+                "Decider Tangents",
+            )
             return state
 
         if secret is None:
             logger.error("secret_name is None, cannot implement infranym")
+            get_state_snapshot(
+                state,
+                "implement_infranym_method_exit",
+                state.thread_id,
+                "Decider Tangents",
+            )
             return state
 
         logger.info(f"🎨 Implementing {medium.value} infranym for '{secret}'")
@@ -496,6 +508,12 @@ Respond with ONLY the surface name (proper capitalization, with spaces).
             # Text needs LLM generation for some methods, so we route to text nodes
             # The actual artifact creation happens in assemble_text_artifact
             logger.info("📝 Routing to text generation nodes...")
+            get_state_snapshot(
+                state,
+                "implement_infranym_method_exit",
+                state.thread_id,
+                "Decider Tangents",
+            )
             return state
 
         elif medium == InfranymMedium.AUDIO:
@@ -594,6 +612,12 @@ Respond with ONLY the surface name (proper capitalization, with spaces).
         else:
             logger.warning(f"Unknown infranym medium: {medium}")
 
+        get_state_snapshot(
+            state,
+            "implement_infranym_method_exit",
+            state.thread_id,
+            "Decider Tangents",
+        )
         return state
 
     # ========================================================================
@@ -955,7 +979,17 @@ Concept: [full concept explanation]
 
             except Exception as e:
                 logger.error(f"❌ Error generating proposal: {e}")
+                surface_slug = (
+                    re.sub(
+                        r"[^a-z0-9]+", "_", (state.surface_name or "fallback").lower()
+                    )
+                    .strip("_")[:30]
+                    .strip("_")
+                    or "fallback"
+                )
                 state.counter_proposal = SongProposalIteration(
+                    iteration_id=f"indigo_{surface_slug}_v1",
+                    rainbow_color="indigo",
                     title=state.surface_name,
                     key=previous_iteration.key,
                     bpm=previous_iteration.bpm,
@@ -1074,13 +1108,15 @@ def _parse_proposal_response(response: str) -> SongProposalIteration:
 
         numeric_part = re.sub(r"[^\d]", "", str(raw_bpm))
         bpm = int(numeric_part) if numeric_part else 120
-    import time
-
-    timestamp = int(time.time() * 1000)
+    title = data.get("title", "Untitled")
+    title_slug = (
+        re.sub(r"[^a-z0-9]+", "_", title.lower()).strip("_")[:30].strip("_")
+        or "proposal"
+    )
     return SongProposalIteration(
-        iteration_id=f"indigo_proposal_{timestamp}",
+        iteration_id=f"indigo_{title_slug}_v1",
         rainbow_color="indigo",
-        title=data.get("title", "Untitled"),
+        title=title,
         key=data.get("key", "C major"),
         bpm=bpm,
         tempo=data.get("tempo", "Moderate"),

--- a/packages/ideation/tests/agents/test_blue_agent.py
+++ b/packages/ideation/tests/agents/test_blue_agent.py
@@ -1,3 +1,5 @@
+from white_core.artifacts.quantum_tape_label_artifact import QuantumTapeLabelArtifact
+from white_core.enums.chain_artifact_type import ChainArtifactType
 from white_core.manifests.song_proposal import SongProposalIteration
 from white_ideation.agents.blue_agent import BlueAgent
 from white_ideation.agents.states.blue_agent_state import BlueAgentState
@@ -11,3 +13,22 @@ def test_generate_alternate_song_spec_mock():
     assert result_state.counter_proposal is not None
     assert isinstance(result_state.counter_proposal, SongProposalIteration)
     assert getattr(result_state.counter_proposal, "title", None)
+
+
+def test_generate_tape_label_mock(monkeypatch, tmp_path):
+    monkeypatch.setenv("MOCK_MODE", "true")
+    monkeypatch.setenv("BLOCK_MODE", "false")
+    monkeypatch.setenv("AGENT_MOCK_DATA_PATH", "tests/mocks")
+    monkeypatch.setenv("AGENT_WORK_PRODUCT_BASE_PATH", str(tmp_path))
+
+    agent = BlueAgent()
+    state = BlueAgentState()
+    state.thread_id = "test_thread"
+    result_state = agent.generate_tape_label(state)
+
+    tape_labels = [
+        a for a in result_state.artifacts if isinstance(a, QuantumTapeLabelArtifact)
+    ]
+    assert len(tape_labels) == 1
+    assert tape_labels[0].chain_artifact_type == ChainArtifactType.QUANTUM_TAPE_LABEL
+    assert result_state.tape_label is not None

--- a/packages/ideation/tests/agents/test_indigo_agent.py
+++ b/packages/ideation/tests/agents/test_indigo_agent.py
@@ -1,5 +1,7 @@
+import re
+
 from white_core.manifests.song_proposal import SongProposalIteration
-from white_ideation.agents.indigo_agent import IndigoAgent
+from white_ideation.agents.indigo_agent import IndigoAgent, _parse_proposal_response
 from white_ideation.agents.states.indigo_agent_state import IndigoAgentState
 
 
@@ -10,3 +12,26 @@ def test_generate_alternate_song_spec_mock():
     assert result_state.counter_proposal is not None
     assert isinstance(result_state.counter_proposal, SongProposalIteration)
     assert getattr(result_state.counter_proposal, "title", None)
+
+
+def test_parse_proposal_response_iteration_id_is_slug():
+    response = """Title: Echoes of a Borrowed Life
+Key: D minor
+BPM: 90
+Tempo: Slow
+Mood: melancholy, reflective
+Genres: indie, chamber pop
+Concept: A life lived in someone else's shadow
+"""
+    result = _parse_proposal_response(response)
+    assert re.fullmatch(
+        r"indigo_[a-z0-9_]+_v1", result.iteration_id
+    ), f"iteration_id {result.iteration_id!r} is not a slug"
+    assert not any(
+        c.isdigit()
+        and len(result.iteration_id) > 15
+        and result.iteration_id.count("_") == 0
+        for c in result.iteration_id
+    ), "iteration_id looks like a timestamp"
+    assert result.iteration_id.startswith("indigo_")
+    assert result.iteration_id.endswith("_v1")


### PR DESCRIPTION
## Summary

- **#166** — `generate_tape_label` node was missing from `BlueAgent`; the quantum tape chain artifact was never produced. Added the node with mock mode, enter/exit snapshots, and quality selection wired into `extract_musical_parameters → generate_tape_label → generate_alternate_song_spec`.
- **#167** — Green and indigo agents were falling back to timestamp slugs for `iteration_id`. Fixed by adding explicit `rainbow_color`/`title`/`iteration_id` format guidance to the green agent prompt, and deriving `iteration_id` from the proposal title in the indigo agent (`_parse_proposal_response`). Also fixed the broken fallback `SongProposalIteration` that was missing required fields.
- **#168** — Three nodes were missing exit snapshots: `write_last_human_extinction_narrative` and `claudes_choice` in `green_agent.py`; `implement_infranym_method` in `indigo_agent.py`. Added snapshots at all return paths including mock success/failure paths, early-return guards, and both LLM result shapes (dict and object).

## Test plan
- [ ] Run green agent in mock mode — verify `iteration_id` is a descriptive slug, not a timestamp
- [ ] Run indigo agent in mock mode — verify `iteration_id` format and `rainbow_color` set correctly
- [ ] Run blue agent in mock mode — verify `QuantumTapeLabelArtifact` appears in chain artifacts
- [ ] Confirm exit snapshots present in green `claudes_choice`, `write_last_human_extinction_narrative`, and indigo `implement_infranym_method`

🤖 Generated with [Claude Code](https://claude.com/claude-code)