### PR TITLE
fix: handle dict rainbow_color/key in shrinkwrap and normalize_key

### DIFF
--- a/packages/composition/src/white_composition/shrinkwrap_chain_artifacts.py
+++ b/packages/composition/src/white_composition/shrinkwrap_chain_artifacts.py
@@ -213,17 +213,30 @@ def parse_thread(thread_dir: Path) -> Optional[dict]:
     final = iterations[-1]
 
     rainbow_color = final.get("rainbow_color", {})
-    color_name = rainbow_color.get("color_name", "unknown")
+    if isinstance(rainbow_color, dict):
+        color_name = rainbow_color.get("color_name", "unknown")
+        mnemonic = rainbow_color.get("mnemonic_character_value", "?")
+    else:
+        color_name = str(rainbow_color) if rainbow_color else "unknown"
+        mnemonic = "?"
+
+    raw_key = final.get("key")
+    if isinstance(raw_key, dict):
+        tonic = raw_key.get("tonic", "")
+        mode = raw_key.get("mode", "")
+        key_str = f"{tonic} {mode}".strip() if tonic else None
+    else:
+        key_str = raw_key
 
     return {
         "thread_id": thread_id,
         "title": final.get("title", "untitled"),
         "bpm": final.get("bpm"),
-        "key": final.get("key"),
+        "key": key_str,
         "tempo": final.get("tempo"),
         "concept": final.get("concept", ""),
         "rainbow_color": color_name,
-        "mnemonic": rainbow_color.get("mnemonic_character_value", "?"),
+        "mnemonic": mnemonic,
         "mood": final.get("mood", []),
         "genres": final.get("genres", []),
         "agent_name": final.get("agent_name", ""),

--- a/packages/composition/src/white_composition/shrinkwrap_chain_artifacts.py
+++ b/packages/composition/src/white_composition/shrinkwrap_chain_artifacts.py
@@ -181,6 +181,31 @@ def is_evp_intermediate(filename: str) -> bool:
     return False
 
 
+_ACCIDENTAL_MAP = {"sharp": "#", "flat": "b"}
+
+
+def _flatten_key_dict(d: dict) -> str:
+    """Flatten a KeySignature dict to a 'tonic mode' string.
+
+    Supports two shapes:
+      - KeySignature.model_dump(mode="json"):
+          {"note": {"pitch_name": "F", "accidental": "sharp"}, "mode": {"name": "minor"}}
+      - Legacy flat shape: {"tonic": "F#", "mode": "minor"}
+    """
+    if "note" in d:
+        note = d.get("note") or {}
+        pitch = note.get("pitch_name", "") if isinstance(note, dict) else ""
+        acc = note.get("accidental", "") if isinstance(note, dict) else ""
+        tonic = f"{pitch}{_ACCIDENTAL_MAP.get(acc, '')}" if pitch else ""
+    else:
+        tonic = d.get("tonic", "")
+
+    mode_val = d.get("mode", "")
+    mode_str = mode_val.get("name", "") if isinstance(mode_val, dict) else str(mode_val)
+
+    return f"{tonic} {mode_str}".strip() if tonic else "unknown"
+
+
 def parse_thread(thread_dir: Path) -> Optional[dict]:
     """Parse a thread directory and extract the final song proposal metadata.
 
@@ -222,11 +247,9 @@ def parse_thread(thread_dir: Path) -> Optional[dict]:
 
     raw_key = final.get("key")
     if isinstance(raw_key, dict):
-        tonic = raw_key.get("tonic", "")
-        mode = raw_key.get("mode", "")
-        key_str = f"{tonic} {mode}".strip() if tonic else None
+        key_str = _flatten_key_dict(raw_key)
     else:
-        key_str = raw_key
+        key_str = str(raw_key) if raw_key else "unknown"
 
     return {
         "thread_id": thread_id,

--- a/packages/composition/tests/test_shrinkwrap_chain_artifacts.py
+++ b/packages/composition/tests/test_shrinkwrap_chain_artifacts.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import yaml
+
 from white_composition.shrinkwrap_chain_artifacts import (
     clean_filename,
     copy_thread_files,
@@ -273,6 +274,92 @@ class TestParseThread:
             yaml.dump(proposal, f)
         result = parse_thread(thread_dir)
         assert result is None
+
+    def test_string_rainbow_color(self, tmp_path):
+        thread_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        thread_dir = tmp_path / thread_id
+        yml_dir = thread_dir / "yml"
+        yml_dir.mkdir(parents=True)
+        proposal = {
+            "iterations": [
+                {
+                    "title": "Flat Color Song",
+                    "bpm": 95,
+                    "key": "D minor",
+                    "rainbow_color": "White",
+                    "concept": "plain string color",
+                    "mood": [],
+                    "genres": [],
+                    "agent_name": "W",
+                }
+            ]
+        }
+        with open(yml_dir / f"all_song_proposals_{thread_id}.yml", "w") as f:
+            yaml.dump(proposal, f)
+        result = parse_thread(thread_dir)
+        assert result is not None
+        assert result["rainbow_color"] == "White"
+        assert result["mnemonic"] == "?"
+
+    def test_keysig_dict_key(self, tmp_path):
+        # KeySignature.model_dump(mode="json") shape stored in proposals
+        thread_id = "bbbbbbbb-cccc-dddd-eeee-ffffffffffff"
+        thread_dir = tmp_path / thread_id
+        yml_dir = thread_dir / "yml"
+        yml_dir.mkdir(parents=True)
+        proposal = {
+            "iterations": [
+                {
+                    "title": "Dict Key Song",
+                    "bpm": 110,
+                    "key": {
+                        "note": {"pitch_name": "F", "accidental": "sharp"},
+                        "mode": {"name": "minor", "intervals": [2, 1, 2, 2, 1, 2, 2]},
+                    },
+                    "rainbow_color": {
+                        "color_name": "Blue",
+                        "mnemonic_character_value": "B",
+                    },
+                    "concept": "test",
+                    "mood": [],
+                    "genres": [],
+                    "agent_name": "B",
+                }
+            ]
+        }
+        with open(yml_dir / f"all_song_proposals_{thread_id}.yml", "w") as f:
+            yaml.dump(proposal, f)
+        result = parse_thread(thread_dir)
+        assert result is not None
+        assert result["key"] == "F# minor"
+
+    def test_missing_key_fields_returns_unknown(self, tmp_path):
+        thread_id = "cccccccc-dddd-eeee-ffff-aaaaaaaaaaaa"
+        thread_dir = tmp_path / thread_id
+        yml_dir = thread_dir / "yml"
+        yml_dir.mkdir(parents=True)
+        proposal = {
+            "iterations": [
+                {
+                    "title": "No Key Song",
+                    "bpm": 100,
+                    "key": {},
+                    "rainbow_color": {
+                        "color_name": "Red",
+                        "mnemonic_character_value": "R",
+                    },
+                    "concept": "test",
+                    "mood": [],
+                    "genres": [],
+                    "agent_name": "R",
+                }
+            ]
+        }
+        with open(yml_dir / f"all_song_proposals_{thread_id}.yml", "w") as f:
+            yaml.dump(proposal, f)
+        result = parse_thread(thread_dir)
+        assert result is not None
+        assert result["key"] == "unknown"
 
 
 class TestGenerateDirectoryName:

--- a/packages/extraction/src/white_extraction/util/generate_negative_constraints.py
+++ b/packages/extraction/src/white_extraction/util/generate_negative_constraints.py
@@ -79,7 +79,7 @@ DIALOGUE_OPENER_PHRASES = [
 DIALOGUE_OPENER_THRESHOLD = 0.30
 
 
-def normalize_key(raw_key: str) -> str:
+def normalize_key(raw_key) -> str:
     """Normalize key strings to standard form.
 
     Handles cases like:
@@ -87,9 +87,15 @@ def normalize_key(raw_key: str) -> str:
         "C hromatic Complete" -> "C major"  (known typo/variant)
         "A ll Keys (Chromatic Convergence)" -> "All Keys"
         "F# minor" -> "F# minor"
+        {"tonic": "F#", "mode": "minor"} -> "F# minor"  (KeySignature dict)
     """
     if not raw_key:
         return "unknown"
+
+    if isinstance(raw_key, dict):
+        tonic = raw_key.get("tonic", "")
+        mode = raw_key.get("mode", "")
+        raw_key = f"{tonic} {mode}".strip() if tonic else "unknown"
 
     text = raw_key.strip()
 

--- a/packages/extraction/src/white_extraction/util/generate_negative_constraints.py
+++ b/packages/extraction/src/white_extraction/util/generate_negative_constraints.py
@@ -78,8 +78,32 @@ DIALOGUE_OPENER_PHRASES = [
 # Threshold: flag a dialogue opener if it appears in more than this fraction of responses
 DIALOGUE_OPENER_THRESHOLD = 0.30
 
+_ACCIDENTAL_MAP = {"sharp": "#", "flat": "b"}
 
-def normalize_key(raw_key) -> str:
+
+def _flatten_key_dict(d: dict) -> str:
+    """Flatten a KeySignature dict to a 'tonic mode' string.
+
+    Supports two shapes:
+      - KeySignature.model_dump(mode="json"):
+          {"note": {"pitch_name": "F", "accidental": "sharp"}, "mode": {"name": "minor"}}
+      - Legacy flat shape: {"tonic": "F#", "mode": "minor"}
+    """
+    if "note" in d:
+        note = d.get("note") or {}
+        pitch = note.get("pitch_name", "") if isinstance(note, dict) else ""
+        acc = note.get("accidental", "") if isinstance(note, dict) else ""
+        tonic = f"{pitch}{_ACCIDENTAL_MAP.get(acc, '')}" if pitch else ""
+    else:
+        tonic = d.get("tonic", "")
+
+    mode_val = d.get("mode", "")
+    mode_str = mode_val.get("name", "") if isinstance(mode_val, dict) else str(mode_val)
+
+    return f"{tonic} {mode_str}".strip() if tonic else "unknown"
+
+
+def normalize_key(raw_key: "str | dict") -> str:
     """Normalize key strings to standard form.
 
     Handles cases like:
@@ -87,15 +111,15 @@ def normalize_key(raw_key) -> str:
         "C hromatic Complete" -> "C major"  (known typo/variant)
         "A ll Keys (Chromatic Convergence)" -> "All Keys"
         "F# minor" -> "F# minor"
-        {"tonic": "F#", "mode": "minor"} -> "F# minor"  (KeySignature dict)
+        {"note": {"pitch_name": "F", "accidental": "sharp"}, "mode": {"name": "minor"}}
+            -> "F# minor"  (KeySignature.model_dump(mode="json") shape)
+        {"tonic": "F#", "mode": "minor"} -> "F# minor"  (legacy flat shape)
     """
     if not raw_key:
         return "unknown"
 
     if isinstance(raw_key, dict):
-        tonic = raw_key.get("tonic", "")
-        mode = raw_key.get("mode", "")
-        raw_key = f"{tonic} {mode}".strip() if tonic else "unknown"
+        raw_key = _flatten_key_dict(raw_key)
 
     text = raw_key.strip()
 

--- a/packages/extraction/tests/util/test_generate_negative_constraints.py
+++ b/packages/extraction/tests/util/test_generate_negative_constraints.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import yaml
+
 from white_extraction.util.generate_negative_constraints import (
     analyze_bpm,
     analyze_concepts,
@@ -72,6 +73,35 @@ class TestNormalizeKey:
 
     def test_empty(self):
         assert normalize_key("") == "unknown"
+
+    def test_keysig_dict_sharp(self):
+        # KeySignature.model_dump(mode="json") shape
+        d = {
+            "note": {"pitch_name": "F", "accidental": "sharp"},
+            "mode": {"name": "minor", "intervals": [2, 1, 2, 2, 1, 2, 2]},
+        }
+        assert normalize_key(d) == "F# minor"
+
+    def test_keysig_dict_no_accidental(self):
+        d = {
+            "note": {"pitch_name": "C", "accidental": None},
+            "mode": {"name": "major", "intervals": [2, 2, 1, 2, 2, 2, 1]},
+        }
+        assert normalize_key(d) == "C major"
+
+    def test_keysig_dict_flat(self):
+        d = {
+            "note": {"pitch_name": "B", "accidental": "flat"},
+            "mode": {"name": "minor", "intervals": [2, 1, 2, 2, 1, 2, 2]},
+        }
+        assert normalize_key(d) == "Bb minor"
+
+    def test_legacy_flat_dict(self):
+        # Legacy {tonic, mode} shape
+        assert normalize_key({"tonic": "F#", "mode": "minor"}) == "F# minor"
+
+    def test_empty_dict_returns_unknown(self):
+        assert normalize_key({}) == "unknown"
 
 
 class TestAnalyzeKeys:


### PR DESCRIPTION
## Summary

Two `AttributeError`s surfaced during a live thread run:

- `Auto-shrinkwrap failed: 'str' object has no attribute 'get'` — `parse_thread` in `shrinkwrap_chain_artifacts.py` assumed `rainbow_color` was always a dict, but older thread YAMLs serialize it as a plain string. Also added key dict → string coercion in the same function.
- `'dict' object has no attribute 'strip'` — `normalize_key` in `generate_negative_constraints.py` assumed `key` was always a string, but newer proposals serialize it as a `KeySignature` dict (`{"tonic": "F#", "mode": "minor"}`).

Both bugs are caused by mixed serialization formats across old and new proposals. The fixes handle both shapes at the callsite rather than requiring a data migration.

## Changes
- `parse_thread`: branch on `isinstance(rainbow_color, dict/str)`; coerce `key` dict to `"tonic mode"` string
- `normalize_key`: detect dict input, flatten to `"tonic mode"` string before existing normalisation logic

## Test plan
- [ ] Start a new thread — confirm no shrinkwrap or constraint warnings in logs
- [ ] Confirm existing threads with older YAML formats still parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)