### PR TITLE
fix: KeySignature __str__, coerce key to str in indigo, year-only date comparison

### DIFF
--- a/packages/core/src/white_core/music/core/key_signature.py
+++ b/packages/core/src/white_core/music/core/key_signature.py
@@ -31,6 +31,11 @@ class KeySignature(BaseModel):
     note: Note
     mode: Mode
 
+    def __str__(self) -> str:
+        _acc = {"sharp": "#", "flat": "b"}
+        acc = _acc.get(self.note.accidental or "", "")
+        return f"{self.note.pitch_name}{acc} {self.mode}"
+
     @model_validator(mode="before")
     @classmethod
     def parse_key_string(cls, data):

--- a/packages/ideation/src/white_ideation/agents/blue_agent.py
+++ b/packages/ideation/src/white_ideation/agents/blue_agent.py
@@ -739,12 +739,16 @@ The tape has been recorded over. What life exists on it now?
                 else:
                     bio_start_date = bio_period.start_date
                     bio_end_date = bio_period.end_date
-                if alt_period.start_date != bio_start_date:
+
+                def _year(d):
+                    return d.year if hasattr(d, "year") else int(d)
+
+                if _year(alt_period.start_date) != _year(bio_start_date):
                     issues.append(
                         f"Start date mismatch: alternate says {alt_period.start_date}, "
                         f"but biographical period is {bio_start_date}"
                     )
-                if alt_period.end_date != bio_end_date:
+                if _year(alt_period.end_date) != _year(bio_end_date):
                     issues.append(
                         f"End date mismatch: alternate says {alt_period.end_date}, "
                         f"but biographical period is {bio_end_date}"

--- a/packages/ideation/src/white_ideation/agents/blue_agent.py
+++ b/packages/ideation/src/white_ideation/agents/blue_agent.py
@@ -741,14 +741,26 @@ The tape has been recorded over. What life exists on it now?
                     bio_end_date = bio_period.end_date
 
                 def _year(d):
+                    if d is None:
+                        return None
                     return d.year if hasattr(d, "year") else int(d)
 
-                if _year(alt_period.start_date) != _year(bio_start_date):
+                alt_start_year = _year(alt_period.start_date)
+                alt_end_year = _year(alt_period.end_date)
+                bio_start_year = _year(bio_start_date)
+                bio_end_year = _year(bio_end_date)
+                if (
+                    None not in (alt_start_year, bio_start_year)
+                    and alt_start_year != bio_start_year
+                ):
                     issues.append(
                         f"Start date mismatch: alternate says {alt_period.start_date}, "
                         f"but biographical period is {bio_start_date}"
                     )
-                if _year(alt_period.end_date) != _year(bio_end_date):
+                if (
+                    None not in (alt_end_year, bio_end_year)
+                    and alt_end_year != bio_end_year
+                ):
                     issues.append(
                         f"End date mismatch: alternate says {alt_period.end_date}, "
                         f"but biographical period is {bio_end_date}"

--- a/packages/ideation/src/white_ideation/agents/indigo_agent.py
+++ b/packages/ideation/src/white_ideation/agents/indigo_agent.py
@@ -480,7 +480,11 @@ Respond with ONLY the surface name (proper capitalization, with spaces).
         medium = state.infranym_medium
         secret = state.secret_name
         bpm = state.white_proposal.bpm if state.white_proposal else 120
-        key = state.white_proposal.key if state.white_proposal else None
+        key = (
+            str(state.white_proposal.key)
+            if state.white_proposal and state.white_proposal.key
+            else None
+        )
 
         if medium is None:
             logger.error("infranym_medium is None, cannot implement infranym")
@@ -907,7 +911,7 @@ You are Decider Tangents, the Indigo Agent, creating a counter-proposal.
 **Previous Proposal:**
 Title: {previous_iteration.title}
 Concept: {previous_iteration.concept}
-Key: {previous_iteration.key}
+Key: {str(previous_iteration.key) if previous_iteration.key else 'unknown'}
 BPM: {previous_iteration.bpm}
 
 **Your Infranym System:**

--- a/packages/ideation/src/white_ideation/agents/indigo_agent.py
+++ b/packages/ideation/src/white_ideation/agents/indigo_agent.py
@@ -869,7 +869,11 @@ Write ONLY the riddle (no answer, no explanation):
             concepts=state.concepts,
             usage_context=usage,
             bpm=state.white_proposal.bpm if state.white_proposal else 120,
-            key=state.white_proposal.key if state.white_proposal else None,
+            key=(
+                str(state.white_proposal.key)
+                if state.white_proposal and state.white_proposal.key
+                else None
+            ),
         )
         path = artifact.save_file()
         state.infranym_text = artifact


### PR DESCRIPTION
## Summary

Three runtime failures observed in thread `8f1d7e47`:

- **`InfranymTextArtifact` ValidationError** — `key: Optional[str]` received a `KeySignature` object. Added `KeySignature.__str__()` returning `"pitch+accidental mode"` (e.g. `"Gb minor"`), then coerced `key` to `str()` at the `assemble_text_artifact` site and in the indigo LLM prompt.

- **Date mismatch validation spam** — The bio_period dict branch sets `bio_start_date = state.selected_year` (an `int`), while `alt_period.start_date` is a `datetime.date`. Direct `!=` comparison always fails, generating two spurious issues per run. Fixed with a local `_year()` helper that extracts `.year` from date objects and `int()`-coerces plain integers.

- **Plausibility 0.40 < 0.60** — Not a separate bug: the two spurious date issues pushed issue count to 3 (of 5 max), giving 1.0 − 3/5 = 0.40. With the date fix, only genuine issues count.

## Test plan
- [ ] Re-run a thread that previously failed in `assemble_text_artifact` — confirm no ValidationError
- [ ] Confirm blue agent alternate history validation no longer emits start/end date mismatch warnings for a correctly-generated 1978 period

🤖 Generated with [Claude Code](https://claude.com/claude-code)