### PR TITLE
fix: use white_core encoding types in infranym_midi_tools

### DIFF
--- a/packages/ideation/src/white_ideation/agents/tools/infranym_midi_tools.py
+++ b/packages/ideation/src/white_ideation/agents/tools/infranym_midi_tools.py
@@ -3,12 +3,8 @@ import random
 from typing import List
 
 from white_core.artifacts.infranym_midi_artifact import InfranymMidiArtifact
-from white_ideation.agents.tools.encodings.morse_duration_encoding import (
-    MorseDurationEncoding,
-)
-from white_ideation.agents.tools.encodings.note_cipher_encoding import (
-    NoteCipherEncoding,
-)
+from white_core.util.encodings.morse_duration_encoding import MorseDurationEncoding
+from white_core.util.encodings.note_cipher_encoding import NoteCipherEncoding
 
 
 def generate_note_cipher(

--- a/packages/ideation/src/white_ideation/agents/tools/infranym_midi_tools.py
+++ b/packages/ideation/src/white_ideation/agents/tools/infranym_midi_tools.py
@@ -1,97 +1,11 @@
-import os
-import random
-from typing import List
+from white_core.util.infranym.infranym_midi_tools import (
+    add_carrier_melody_to_artifact,
+    generate_morse_duration,
+    generate_note_cipher,
+)
 
-from white_core.artifacts.infranym_midi_artifact import InfranymMidiArtifact
-from white_core.util.encodings.morse_duration_encoding import MorseDurationEncoding
-from white_core.util.encodings.note_cipher_encoding import NoteCipherEncoding
-
-
-def generate_note_cipher(
-    secret_word: str,
-    bpm: int = 120,
-    octave_offset: int = 0,
-    velocity_variation: bool = True,
-) -> InfranymMidiArtifact:
-    """
-    Generate note cipher infranym.
-
-    Args:
-        secret_word: Word to encode
-        bpm: Tempo
-        octave_offset: Shift notes up/down (-2 to +2)
-        velocity_variation: Randomize velocities for naturalness
-
-    Returns:
-        Complete MIDI artifact with note cipher encoding
-    """
-    encoding = NoteCipherEncoding(secret_word=secret_word, octave_offset=octave_offset)
-
-    # Optional: Add velocity variation
-    if velocity_variation:
-        encoding.velocity_pattern = [
-            random.randint(55, 85) for _ in encoding.note_sequence
-        ]
-
-    artifact = InfranymMidiArtifact(
-        base_path=os.getenv("AGENT_WORK_PRODUCT_BASE_PATH", "/tmp"),
-        thread_id=f"midi_cipher_{random.randint(1000, 9999)}",
-        chain_artifact_file_type="midi",
-        chain_artifact_type="infranym_midi",
-        rainbow_color_mnemonic_character_value="I",
-        artifact_name=f"cipher_{secret_word.lower()[:8]}",
-        encoding=encoding,
-        bpm=bpm,
-        time_signature="4/4",
-    )
-
-    return artifact
-
-
-def generate_morse_duration(
-    secret_word: str, bpm: int = 120, carrier_note: int = 60
-) -> InfranymMidiArtifact:
-    """
-    Generate morse duration infranym.
-
-    Args:
-        secret_word: Word to encode
-        bpm: Tempo
-        carrier_note: MIDI note for morse beeps
-
-    Returns:
-        Complete MIDI artifact with morse duration encoding
-    """
-    encoding = MorseDurationEncoding(secret_word=secret_word, carrier_note=carrier_note)
-
-    artifact = InfranymMidiArtifact(
-        base_path=os.getenv("AGENT_WORK_PRODUCT_BASE_PATH", "/tmp"),
-        thread_id=f"midi_morse_{random.randint(1000, 9999)}",
-        chain_artifact_file_type="midi",
-        chain_artifact_type="infranym_midi",
-        rainbow_color_mnemonic_character_value="I",
-        artifact_name=f"morse_{secret_word.lower()[:8]}",
-        encoding=encoding,
-        bpm=bpm,
-        time_signature="4/4",
-    )
-
-    return artifact
-
-
-def add_carrier_melody_to_artifact(
-    artifact: InfranymMidiArtifact, melody: List[int]
-) -> InfranymMidiArtifact:
-    """
-    Add a carrier melody to an existing artifact.
-
-    Args:
-        artifact: MIDI artifact
-        melody: List of MIDI notes for melody
-
-    Returns:
-        Modified artifact with carrier enabled
-    """
-    artifact.carrier_melody = melody
-    artifact.include_carrier = True
-    return artifact
+__all__ = [
+    "add_carrier_melody_to_artifact",
+    "generate_morse_duration",
+    "generate_note_cipher",
+]


### PR DESCRIPTION
## Summary
- `infranym_midi_tools.py` was importing `NoteCipherEncoding` / `MorseDurationEncoding` from the duplicate `white_ideation.agents.tools.encodings` namespace instead of the canonical `white_core.util.encodings` types
- Pydantic's `Union[NoteCipherEncoding, MorseDurationEncoding]` field on `InfranymMidiArtifact` saw these as foreign types and raised a `ValidationError` on every Indigo infranym construction
- Fix: swap imports to `white_core` — the duplicate `white_ideation` encoding classes remain but are no longer used by this tool

## Test plan
- [x] Pre-commit hooks (black, ruff) pass
- [x] Run completed successfully through Indigo agent with infranym MIDI artifacts generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)