### PR TITLE
UI flow: song picker, lyrics handoff, strings generation

### DIFF
--- a/packages/api/src/white_api/candidate_server.py
+++ b/packages/api/src/white_api/candidate_server.py
@@ -380,13 +380,12 @@ def create_app(
         def _run():
             global _run_job
             try:
-                import subprocess
-
                 from white_composition.pipeline_runner import (
                     PHASE_REVIEW_FILES,
                     write_phase_status,
                 )
 
+                write_phase_status(prod, "quartet", "in_progress")
                 singer = (_active_song or {}).get("singer") or "gabriel"
                 cmd = [
                     sys.executable,
@@ -404,6 +403,7 @@ def create_app(
                         write_phase_status(prod, "quartet", "generated")
                         _run_job["status"] = "done"
                     else:
+                        write_phase_status(prod, "quartet", "pending")
                         _run_job["status"] = "error"
                         _run_job["error"] = (
                             f"quartet exited with code {result.returncode}"

--- a/packages/api/src/white_api/candidate_server.py
+++ b/packages/api/src/white_api/candidate_server.py
@@ -361,6 +361,65 @@ def create_app(
     def pipeline_run_status():
         return _run_job
 
+    @app.post("/pipeline/run/quartet")
+    def pipeline_run_quartet():
+        """Run the quartet (strings) generation phase for the active song."""
+        global _run_job
+        if _run_job["status"] == "running":
+            raise HTTPException(status_code=409, detail="A phase is already running")
+        prod = _require_production_dir()
+        now = datetime.now(timezone.utc).isoformat()
+        _run_job = {
+            "status": "running",
+            "phase": "quartet",
+            "started_at": now,
+            "finished_at": None,
+            "error": None,
+        }
+
+        def _run():
+            global _run_job
+            try:
+                import subprocess
+
+                from white_composition.pipeline_runner import (
+                    PHASE_REVIEW_FILES,
+                    write_phase_status,
+                )
+
+                singer = (_active_song or {}).get("singer") or "gabriel"
+                cmd = [
+                    sys.executable,
+                    "-m",
+                    "white_generation.pipelines.quartet_pipeline",
+                    "--production-dir",
+                    str(prod),
+                    "--singer",
+                    singer,
+                ]
+                result = subprocess.run(cmd)
+                review_file = PHASE_REVIEW_FILES.get("quartet")
+                if result.returncode != 0:
+                    if review_file and (prod / review_file).exists():
+                        write_phase_status(prod, "quartet", "generated")
+                        _run_job["status"] = "done"
+                    else:
+                        _run_job["status"] = "error"
+                        _run_job["error"] = (
+                            f"quartet exited with code {result.returncode}"
+                        )
+                else:
+                    write_phase_status(prod, "quartet", "generated")
+                    _run_job["status"] = "done"
+            except Exception as exc:
+                _run_job["status"] = "error"
+                _run_job["error"] = str(exc)
+            finally:
+                _run_job["finished_at"] = datetime.now(timezone.utc).isoformat()
+
+        threading.Thread(target=_run, daemon=True).start()
+        return {"status": "running", "started_at": now}
+
     @app.get("/pipeline/status")
     def pipeline_status():
         """Return phase statuses for the active song."""

--- a/packages/client/app/board/page.tsx
+++ b/packages/client/app/board/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import {
-  fetchSongs, fetchActiveSong, fetchComposition, advanceStage, addVersion,
+  fetchSongs, fetchActiveSong, fetchComposition, activateSong, advanceStage, addVersion,
   updateVersionNotes, runNextPhase, getRunStatus, fetchLyrics, approveLyric, promotePhase,
 } from "@/lib/api";
 import { CompositionEntry, LyricCandidate, LyricsResponse, MIX_STAGES, MixStage, RunJob, SongEntry } from "@/lib/types";
@@ -263,8 +263,19 @@ export default function BoardPage() {
             <select
               className="text-xs font-sans bg-zinc-900 border border-zinc-700 rounded px-2 py-1.5 text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
               value={activeSong?.id ?? ""}
-              onChange={() => {}}
-              disabled
+              onChange={async (e) => {
+                const id = e.target.value;
+                if (!id || id === activeSong?.id) return;
+                setLoadState("loading");
+                try {
+                  await activateSong(id);
+                  await refresh();
+                  await refreshLyrics();
+                } catch {
+                  setLoadState("error");
+                }
+              }}
+              disabled={loadState === "loading"}
             >
               {songs.map(s => (
                 <option key={s.id} value={s.id}>{s.title}</option>

--- a/packages/client/app/candidates/page.tsx
+++ b/packages/client/app/candidates/page.tsx
@@ -380,6 +380,8 @@ export default function CandidatesPage() {
               <span className="text-xs font-sans text-emerald-400">✓ strings</span>
             ) : quartetStatus === "generated" ? (
               <span className="text-xs font-sans text-blue-400">● strings</span>
+            ) : quartetStatus === "in_progress" || runningQuartet ? (
+              <span className="text-xs font-sans text-yellow-400">⟳ strings…</span>
             ) : canRunQuartet ? (
               <button
                 onClick={handleRunQuartet}
@@ -387,8 +389,6 @@ export default function CandidatesPage() {
               >
                 Run Strings
               </button>
-            ) : runningQuartet ? (
-              <span className="text-xs font-sans text-yellow-400">⟳ strings…</span>
             ) : null
           )}
           {needsInit && (

--- a/packages/client/app/candidates/page.tsx
+++ b/packages/client/app/candidates/page.tsx
@@ -3,14 +3,14 @@
 import React, { useEffect, useState, useCallback, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { fetchCandidates, approveCandidate, rejectCandidate, setLabel, setUseCase, midiUrl, promotePhase, evolvePhase, fetchActiveSong, initSong, runNextPhase, getRunStatus, fetchPipelineStatus, startHandoff, getHandoffStatus } from "@/lib/api";
+import { fetchCandidates, approveCandidate, rejectCandidate, setLabel, setUseCase, midiUrl, promotePhase, evolvePhase, fetchActiveSong, initSong, runNextPhase, runQuartetPhase, getRunStatus, fetchPipelineStatus, startHandoff, getHandoffStatus } from "@/lib/api";
 import { Candidate, CandidateStatus, PipelineStatus, RunJob, SongEntry } from "@/lib/types";
 import ScoreBar from "@/components/ScoreBar";
 import ScorePanel from "@/components/ScorePanel";
 import StatusBadge from "@/components/StatusBadge";
 import MidiPlayer from "@/components/MidiPlayer";
 
-const PHASES = ["chords", "drums", "bass", "melody"];
+const PHASES = ["chords", "drums", "bass", "melody", "quartet"];
 const PIPELINE_PHASES = ["chords", "drums", "bass", "melody"];
 
 type SortKey = "phase" | "section" | "id" | "template" | "composite_score" | "status" | "rank";
@@ -32,6 +32,7 @@ export default function CandidatesPage() {
   const [promoting, setPromoting] = useState(false);
   const [evolving, setEvolving] = useState(false);
   const [running, setRunning] = useState(false);
+  const [runningQuartet, setRunningQuartet] = useState(false);
   const [initializing, setInitializing] = useState(false);
   const [handoffing, setHandoffing] = useState(false);
   const [activeSong, setActiveSong] = useState<SongEntry | null>(null);
@@ -189,6 +190,37 @@ export default function CandidatesPage() {
     }, 3000);
   }, [phaseFilter, load, refreshPipeline]);
 
+  const handleRunQuartet = async () => {
+    setError(null);
+    setRunningQuartet(true);
+    try {
+      await runQuartetPhase();
+    } catch (e) {
+      setRunningQuartet(false);
+      setError(e instanceof Error ? e.message : "Strings run failed");
+      return;
+    }
+    runPollRef.current = setInterval(async () => {
+      try {
+        const job = await getRunStatus();
+        if (job.status === "done") {
+          clearInterval(runPollRef.current!);
+          runPollRef.current = null;
+          setRunningQuartet(false);
+          refreshPipeline();
+          load(phaseFilter);
+          showToast("Strings generation complete");
+        } else if (job.status === "error") {
+          clearInterval(runPollRef.current!);
+          runPollRef.current = null;
+          setRunningQuartet(false);
+          setError(job.error ?? "Strings generation failed");
+          refreshPipeline();
+        }
+      } catch { /* transient */ }
+    }, 3000);
+  };
+
   const handlePromote = async () => {
     if (!phaseFilter) return;
     setError(null);
@@ -253,6 +285,8 @@ export default function CandidatesPage() {
   const needsInit = pipeline?.next_phase === "init_production";
   const canRun = !running && !needsInit && pipeline?.next_phase != null;
   const melodyPromoted = pipeline?.phases?.["melody"] === "promoted";
+  const quartetStatus = pipeline?.phases?.["quartet"];
+  const canRunQuartet = melodyPromoted && !quartetStatus && !running && !runningQuartet;
 
   const SortIcon = ({ k }: { k: SortKey }) =>
     sortKey === k ? <span className="ml-1 text-zinc-400">{sortAsc ? "↑" : "↓"}</span> : null;
@@ -340,6 +374,23 @@ export default function CandidatesPage() {
               </span>
             );
           })}
+          {/* Quartet (strings) — parallel phase, shown when melody is promoted */}
+          {melodyPromoted && (
+            quartetStatus === "promoted" ? (
+              <span className="text-xs font-sans text-emerald-400">✓ strings</span>
+            ) : quartetStatus === "generated" ? (
+              <span className="text-xs font-sans text-blue-400">● strings</span>
+            ) : canRunQuartet ? (
+              <button
+                onClick={handleRunQuartet}
+                className="px-3 py-1 text-xs rounded font-medium transition-colors bg-zinc-700 hover:bg-zinc-600 text-zinc-200"
+              >
+                Run Strings
+              </button>
+            ) : runningQuartet ? (
+              <span className="text-xs font-sans text-yellow-400">⟳ strings…</span>
+            ) : null
+          )}
           {needsInit && (
             <button
               onClick={handleInit}
@@ -349,7 +400,7 @@ export default function CandidatesPage() {
               {initializing ? "Initializing…" : "Initialize"}
             </button>
           )}
-          {canRun && (
+          {canRun && pipeline.next_phase !== "lyrics" && (
             <button
               onClick={handleRun}
               disabled={running}
@@ -357,6 +408,14 @@ export default function CandidatesPage() {
             >
               {running ? `Running ${pipeline.next_phase}…` : `Run ${pipeline.next_phase}`}
             </button>
+          )}
+          {canRun && pipeline.next_phase === "lyrics" && (
+            <Link
+              href="/board"
+              className="ml-auto px-3 py-1 text-xs rounded font-medium transition-colors bg-violet-700 hover:bg-violet-600 text-white"
+            >
+              Composition Board →
+            </Link>
           )}
           {running && !canRun && (
             <span className="ml-auto text-xs text-yellow-400 font-sans">Running {pipeline.next_phase}…</span>

--- a/packages/client/lib/api.ts
+++ b/packages/client/lib/api.ts
@@ -140,6 +140,15 @@ export async function getRunStatus(): Promise<import("./types").RunJob> {
   return res.json();
 }
 
+export async function runQuartetPhase(): Promise<{ status: string; started_at: string }> {
+  const res = await fetch(`${BASE}/pipeline/run/quartet`, { method: "POST" });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error((err as { detail?: string }).detail ?? "Quartet run failed");
+  }
+  return res.json();
+}
+
 export async function fetchPipelineStatus(): Promise<import("./types").PipelineStatus> {
   const res = await fetch(`${BASE}/pipeline/status`, { cache: "no-store" });
   if (!res.ok) throw new Error("Failed to fetch pipeline status");

--- a/packages/composition/src/white_composition/pipeline_runner.py
+++ b/packages/composition/src/white_composition/pipeline_runner.py
@@ -134,6 +134,14 @@ def _build_phase_command(
             "--production-dir",
             prod,
         ]
+    if phase == "quartet":
+        return base + [
+            "white_generation.pipelines.quartet_pipeline",
+            "--production-dir",
+            prod,
+            "--singer",
+            singer,
+        ]
     raise ValueError(f"Unknown phase: {phase}")
 
 

--- a/packages/generation/src/white_generation/util/non_gen_mover.py
+++ b/packages/generation/src/white_generation/util/non_gen_mover.py
@@ -1,0 +1,30 @@
+# Configuration for non-generative MIDI processing
+
+from pathlib import Path
+
+from white_composition.promote_part import register_part
+
+MIDI_ROOT = "/Users/gabrielwalsh/Documents/Music Production/Earthly Frames/White/Tracks/violet-fallback-defensive-violet-response/The Cataloguer's Lament/MIDI"
+PRODUCTION_DIR = "/Volumes/LucidNonsense/White/packages/generation/shrink_wrapped/violet-fallback-defensive-violet-response/production/flesh_circuit_taxonomy_v2"
+PHASES = ["bass", "melody", "chords", "drums"]
+
+if __name__ == "__main__":
+
+    midi_root = Path(MIDI_ROOT)
+    for phase in PHASES:
+        phase_dir = midi_root / phase
+        if not phase_dir.exists():
+            continue
+        for midi_file in sorted(phase_dir.glob("*.mid")):
+            label = midi_file.stem
+            try:
+                register_part(
+                    midi_path=midi_file,
+                    phase=phase,
+                    section=label,
+                    label=label,
+                    production_dir=PRODUCTION_DIR,
+                )
+                print(f"  ✓  {phase}/{label}")
+            except ValueError as e:
+                print(f"  ✗  {phase}/{label}: {e}")


### PR DESCRIPTION
## Summary

- **Composition board song selector** — was rendered but hard-disabled; now calls `activateSong()` on change and refreshes composition + lyrics state. Users can switch songs directly from the board without editing the URL.
- **"Run lyrics" → "Composition Board →"** — when the next pipeline phase is `lyrics`, the candidates page now shows a violet nav link to `/board` instead of a run button, since lyrics live in the composition workflow not the generation pipeline.
- **Quartet (strings) wired into the UI** — the phase was fully implemented in the backend but invisible in the frontend:
  - `pipeline_runner.py`: added `quartet` case to `_build_phase_command`
  - `candidate_server.py`: new `POST /pipeline/run/quartet` endpoint (uses shared `_run_job` slot)
  - `lib/api.ts`: `runQuartetPhase()` added
  - Candidates page: `quartet` added to phase filter dropdown; pipeline strip shows `✓ strings` / `● strings` / `⟳ strings…` / "Run Strings" button depending on state (visible once melody is promoted)
- **`non_gen_mover.py`** — utility script for registering hand-edited MIDI files into a production dir via `register_part`.

## Test plan

- [ ] Navigate to Composition Board from home — song selector in header is enabled and switching songs loads the correct composition
- [ ] On candidates page with melody promoted, confirm "Composition Board →" appears in place of "Run lyrics"
- [ ] Clicking "Composition Board →" lands on `/board` with the active song already loaded
- [ ] With melody promoted, confirm "Run Strings" button appears in the pipeline strip
- [ ] After quartet candidates exist, confirm "quartet" appears in phase filter and candidates are browsable/promotable
- [ ] Confirm "Run Strings" button is disabled while any other phase is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)