### PR TITLE
Implement add-song-concept-display and add-sample-browser-and-quartet

### DIFF
--- a/openspec/changes/add-sample-browser-and-quartet/proposal.md
+++ b/openspec/changes/add-sample-browser-and-quartet/proposal.md
@@ -1,0 +1,54 @@
+# Change: Add sample browser and restore quartet button
+
+## Why
+Two features are missing from the candidate browser:
+1. **Chromatic samples** — the Refractor can score audio segments from `staged_raw_material`
+   against a song's color target, giving the producer a ranked palette of reference/loop
+   material to use in Logic. The `white_composition.retrieve_samples` module was specced
+   and archived (2026-03-15) but the file was never written; `grain_synthesizer.py` already
+   imports from it and will fail at runtime.
+2. **Quartet generation** — the "Run Strings" button is coded in the UI but has a silent
+   gap: if `song_context.yml` carries `quartet: pending` (a valid intermediate state),
+   `canRunQuartet` evaluates to `false` and neither the status indicator nor the button
+   renders. The spec also does not clearly place the button alongside "Handoff to Logic".
+
+## What Changes
+
+### Sample browser
+- Implement `white_composition.retrieve_samples` (`load_clap_index`, `retrieve_by_color`)
+  using the precomputed CLAP parquet at `training_data_clap_embeddings.parquet`
+- Add `GET /samples` endpoint — returns top-N segments scored for the active song's color
+- Add `GET /audio/{segment_id}` endpoint — streams the pre-extracted WAV from
+  `staged_raw_material` for in-browser auditioning
+- Add `POST /samples/{segment_id}/export` endpoint — copies the segment WAV to
+  `$LOGIC_OUTPUT_DIR/<thread>/<title>/Samples/` immediately (no need to wait for handoff)
+- Add a **Samples panel** in the candidate browser, visible regardless of active phase
+  filter, showing ranked segment rows with inline audio player and per-row Export button
+
+### Logic handoff samples sweep
+- During `handoff()`, copy any WAV files already in `<production_dir>/samples/` to the
+  Logic `Samples/` folder so that a full re-handoff stays in sync
+
+### Quartet button
+- Fix `canRunQuartet`: treat `"pending"` as equivalent to absent — button should show when
+  `quartetStatus` is `undefined`, `null`, or `"pending"`
+- Spec explicitly positions the quartet button alongside "Handoff to Logic" when melody
+  is promoted
+
+## Notes
+- The CLAP parquet uses precomputed embeddings; the Refractor's lazy CLAP encoder is
+  NOT invoked for retrieval — this is purely a parquet lookup + cosine-rank.
+- `staged_raw_material` WAVs are already segment-level files — no time-slicing needed.
+- The existing `chromatic-sample-retrieval` spec covers the library layer; new requirements
+  here cover the API and UI layer only.
+
+## Impact
+- Affected specs: `candidate-browser-web`, `logic-handoff`
+- Affected code:
+  - `packages/composition/src/white_composition/retrieve_samples.py` — new file
+  - `packages/api/src/white_api/candidate_server.py` — three new endpoints
+  - `packages/api/tests/test_candidate_server.py` — shape tests for new endpoints
+  - `packages/composition/src/white_composition/logic_handoff.py` — samples sweep in `handoff()`
+  - `packages/client/lib/api.ts` — new fetch helpers
+  - `packages/client/lib/types.ts` — new `SampleEntry` type
+  - `packages/client/app/candidates/page.tsx` — Samples panel + quartet fix

--- a/openspec/changes/add-sample-browser-and-quartet/specs/candidate-browser-web/spec.md
+++ b/openspec/changes/add-sample-browser-and-quartet/specs/candidate-browser-web/spec.md
@@ -1,0 +1,125 @@
+## ADDED Requirements
+
+### Requirement: Samples Retrieval Endpoints
+The FastAPI backend SHALL expose three endpoints for chromatic sample retrieval and export:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/samples` | Return top-N CLAP-scored segments for the active song's color |
+| GET | `/audio/{segment_id}` | Stream the pre-extracted WAV for a segment |
+| POST | `/samples/{segment_id}/export` | Copy the segment WAV to the Logic Samples folder |
+
+`GET /samples` SHALL accept an optional `?top_n=N` query parameter (default 20). It SHALL
+call `white_composition.retrieve_samples.retrieve_by_color` using the active song's
+`rainbow_color` field and return a JSON array of objects with fields:
+`segment_id`, `song_slug`, `color`, `match` (float 0–1), `audio_url` (`/audio/{segment_id}`).
+
+`GET /audio/{segment_id}` SHALL resolve the WAV path from the CLAP index and return the
+file bytes with `Content-Type: audio/wav`. It SHALL return 404 if the WAV is not present
+on disk. No time-slicing is required — `staged_raw_material` files are pre-extracted segments.
+
+`POST /samples/{segment_id}/export` SHALL copy the segment WAV to
+`$LOGIC_OUTPUT_DIR/<thread_slug>/<song_title>/Samples/<segment_id>.wav`, creating the
+`Samples/` subdirectory if absent. It SHALL return 503 if `LOGIC_OUTPUT_DIR` is not set
+and 404 if the WAV is not found.
+
+`GET /samples` SHALL return 503 if no song is active (matching the behaviour of other
+candidate endpoints).
+
+#### Scenario: Samples list for active song
+- **WHEN** `GET /samples` is called with an active song whose color is Orange
+- **THEN** a JSON array is returned with up to 20 objects, each containing `segment_id`,
+  `song_slug`, `color`, `match`, and `audio_url`
+- **AND** results are sorted descending by `match`
+
+#### Scenario: No active song
+- **WHEN** `GET /samples` is called with no active song
+- **THEN** a 503 response is returned
+
+#### Scenario: Audio stream
+- **WHEN** `GET /audio/{segment_id}` is called for a known segment
+- **THEN** the WAV bytes are returned with `Content-Type: audio/wav`
+
+#### Scenario: Audio not on disk
+- **WHEN** `GET /audio/{segment_id}` is called but the WAV file is absent from the filesystem
+- **THEN** a 404 response is returned
+
+#### Scenario: Export to Logic
+- **WHEN** `POST /samples/{segment_id}/export` is called with a valid segment and
+  `LOGIC_OUTPUT_DIR` is set
+- **THEN** the WAV is copied to `$LOGIC_OUTPUT_DIR/<thread_slug>/<title>/Samples/<segment_id>.wav`
+- **AND** `{"ok": true, "dest": "<path>"}` is returned
+
+#### Scenario: Export without LOGIC_OUTPUT_DIR
+- **WHEN** `POST /samples/{segment_id}/export` is called and `LOGIC_OUTPUT_DIR` is not set
+- **THEN** a 503 response is returned
+
+---
+
+### Requirement: Sample Browser Panel
+The `/candidates` page SHALL display a **Samples** panel below the candidate table.
+The panel SHALL be visible regardless of the active phase filter and SHALL load on page
+mount using `GET /samples`.
+
+Each row in the panel SHALL show:
+- Rank (1-based)
+- `segment_id`
+- Source song slug
+- Color chip (matching the segment's color)
+- Match score (0–1, two decimal places)
+- An inline `<audio>` player with `src` set to the segment's `audio_url`
+- An **Export** button that calls `POST /samples/{segment_id}/export`
+
+After a successful export, the row's Export button SHALL change to "Exported ✓" and
+become disabled for the duration of the session. An error toast SHALL be shown if the
+export fails (e.g., 503 LOGIC_OUTPUT_DIR not set).
+
+The panel SHALL be collapsible (collapsed by default) so it does not crowd the
+candidate list.
+
+#### Scenario: Samples panel loads on mount
+- **WHEN** `/candidates` is opened with an active song
+- **THEN** the Samples panel is present (collapsed) at the bottom of the page
+
+#### Scenario: Expanding shows ranked rows
+- **WHEN** the user expands the Samples panel
+- **THEN** up to 20 ranked segment rows are shown, each with audio player and Export button
+
+#### Scenario: Audio playback
+- **WHEN** the user clicks play on a sample row's audio player
+- **THEN** the browser plays the WAV streamed from `GET /audio/{segment_id}`
+
+#### Scenario: Export marks row as exported
+- **WHEN** the Export button is clicked and the server returns 200
+- **THEN** the button label changes to "Exported ✓" and is disabled
+
+#### Scenario: Export failure toast
+- **WHEN** the Export button is clicked and the server returns 503
+- **THEN** an error toast is shown: "LOGIC_OUTPUT_DIR not set — add it to .env"
+
+---
+
+### Requirement: Quartet Button Alongside Handoff
+The **Generate Quartet** button SHALL appear in the pipeline status strip alongside the
+"Handoff to Logic" button whenever melody is promoted and the quartet phase has not yet
+been generated.
+
+The button SHALL be shown when `quartetStatus` is absent (`undefined`), `null`, or
+`"pending"`. It SHALL be hidden (replaced by a status indicator) once quartet reaches
+`"in_progress"`, `"generated"`, or `"promoted"`.
+
+#### Scenario: Button shown when melody promoted and quartet not started
+- **WHEN** melody phase is promoted AND quartet status is absent or "pending"
+- **THEN** a "Generate Quartet" button appears in the pipeline strip alongside "Handoff to Logic"
+
+#### Scenario: Button shown when quartet pending
+- **WHEN** melody phase is promoted AND `song_context.yml` has `quartet: pending`
+- **THEN** the "Generate Quartet" button is still shown (pending is treated as not-started)
+
+#### Scenario: Button hidden while generating
+- **WHEN** the quartet phase is in_progress or the generation job is running
+- **THEN** a "⟳ strings…" status indicator replaces the button
+
+#### Scenario: Button hidden after generation
+- **WHEN** quartet status is "generated" or "promoted"
+- **THEN** no Generate Quartet button is shown; a status indicator reflects the current state

--- a/openspec/changes/add-sample-browser-and-quartet/specs/logic-handoff/spec.md
+++ b/openspec/changes/add-sample-browser-and-quartet/specs/logic-handoff/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Samples Sweep During Handoff
+`logic_handoff.handoff()` SHALL copy any WAV files found in
+`<production_dir>/samples/` into `$LOGIC_OUTPUT_DIR/<thread>/<title>/Samples/`,
+creating the `Samples/` subdirectory if it does not exist.
+
+If `<production_dir>/samples/` is absent or empty, the step SHALL be silently skipped.
+File names SHALL be preserved. This sweep runs after the approved MIDI copy step so
+that a full re-handoff keeps the Logic project in sync with any samples previously
+exported via `POST /samples/{segment_id}/export`.
+
+#### Scenario: Samples present during handoff
+- **WHEN** `handoff(production_dir)` is called and `<production_dir>/samples/` contains
+  one or more `.wav` files
+- **THEN** those files are copied to `$LOGIC_OUTPUT_DIR/<thread>/<title>/Samples/`
+- **AND** file names are preserved
+
+#### Scenario: No samples directory
+- **WHEN** `handoff(production_dir)` is called and `<production_dir>/samples/` does not exist
+- **THEN** the handoff completes normally with no error and no `Samples/` folder is created
+
+#### Scenario: Samples directory empty
+- **WHEN** `handoff(production_dir)` is called and `<production_dir>/samples/` exists
+  but contains no WAV files
+- **THEN** the handoff completes normally; `Samples/` is created but left empty

--- a/openspec/changes/add-sample-browser-and-quartet/tasks.md
+++ b/openspec/changes/add-sample-browser-and-quartet/tasks.md
@@ -1,0 +1,37 @@
+## 1. Backend — retrieve_samples module
+- [ ] 1.1 Create `packages/composition/src/white_composition/retrieve_samples.py` with
+  `load_clap_index(parquet_path, meta_parquet_path) → DataFrame` and
+  `retrieve_by_color(df, color, top_n) → list[dict]` (fields: segment_id, source_audio_file,
+  match, song_slug, color)
+
+## 2. Backend — API endpoints
+- [ ] 2.1 Add `GET /samples?top_n=N` to `candidate_server.py` — calls `retrieve_by_color`
+  for the active song's color; returns JSON array of `SampleEntry` objects including `audio_url`
+- [ ] 2.2 Add `GET /audio/{segment_id}` — resolves the WAV path from the CLAP index and
+  streams the file; 404 if not found
+- [ ] 2.3 Add `POST /samples/{segment_id}/export` — copies the segment WAV to
+  `$LOGIC_OUTPUT_DIR/<thread>/<title>/Samples/<segment_id>.wav`; 503 if `LOGIC_OUTPUT_DIR`
+  unset; 404 if WAV absent; returns `{"ok": true, "dest": "..."}`
+- [ ] 2.4 Update `packages/api/tests/test_candidate_server.py` with shape tests for the
+  three new endpoints
+
+## 3. Backend — Logic handoff samples sweep
+- [ ] 3.1 In `logic_handoff.handoff()`, after the MIDI copy step, copy all WAVs from
+  `<production_dir>/samples/` (if the dir exists) to `$LOGIC_OUTPUT_DIR/.../Samples/`
+
+## 4. Frontend — types and API helpers
+- [ ] 4.1 Add `SampleEntry` interface to `packages/client/lib/types.ts`
+  (`segment_id`, `song_slug`, `color`, `match`, `audio_url`)
+- [ ] 4.2 Add `fetchSamples(topN?)`, `exportSample(segmentId)` helpers to `packages/client/lib/api.ts`
+
+## 5. Frontend — Samples panel
+- [ ] 5.1 Add a collapsible "Samples" section in `app/candidates/page.tsx` below the
+  candidate table, always rendered regardless of phase filter
+- [ ] 5.2 Each row shows: rank, segment_id, song_slug, color chip, match score, inline
+  `<audio>` player (src = audio_url), and an "Export" button
+- [ ] 5.3 "Export" button calls `exportSample(segmentId)` and shows a per-row success/error state
+
+## 6. Frontend — Quartet button fix
+- [ ] 6.1 Fix `canRunQuartet` so it is true when `quartetStatus` is `undefined`, `null`, or `"pending"`
+- [ ] 6.2 Verify the "Generate Quartet" button appears alongside "Handoff to Logic" when
+  melody is promoted (no layout change needed; confirm the existing code satisfies the spec)

--- a/openspec/changes/add-sample-browser-and-quartet/tasks.md
+++ b/openspec/changes/add-sample-browser-and-quartet/tasks.md
@@ -1,37 +1,37 @@
 ## 1. Backend — retrieve_samples module
-- [ ] 1.1 Create `packages/composition/src/white_composition/retrieve_samples.py` with
+- [x] 1.1 Create `packages/composition/src/white_composition/retrieve_samples.py` with
   `load_clap_index(parquet_path, meta_parquet_path) → DataFrame` and
   `retrieve_by_color(df, color, top_n) → list[dict]` (fields: segment_id, source_audio_file,
   match, song_slug, color)
 
 ## 2. Backend — API endpoints
-- [ ] 2.1 Add `GET /samples?top_n=N` to `candidate_server.py` — calls `retrieve_by_color`
+- [x] 2.1 Add `GET /samples?top_n=N` to `candidate_server.py` — calls `retrieve_by_color`
   for the active song's color; returns JSON array of `SampleEntry` objects including `audio_url`
-- [ ] 2.2 Add `GET /audio/{segment_id}` — resolves the WAV path from the CLAP index and
+- [x] 2.2 Add `GET /audio/{segment_id}` — resolves the WAV path from the CLAP index and
   streams the file; 404 if not found
-- [ ] 2.3 Add `POST /samples/{segment_id}/export` — copies the segment WAV to
+- [x] 2.3 Add `POST /samples/{segment_id}/export` — copies the segment WAV to
   `$LOGIC_OUTPUT_DIR/<thread>/<title>/Samples/<segment_id>.wav`; 503 if `LOGIC_OUTPUT_DIR`
   unset; 404 if WAV absent; returns `{"ok": true, "dest": "..."}`
-- [ ] 2.4 Update `packages/api/tests/test_candidate_server.py` with shape tests for the
+- [x] 2.4 Update `packages/api/tests/test_candidate_server.py` with shape tests for the
   three new endpoints
 
 ## 3. Backend — Logic handoff samples sweep
-- [ ] 3.1 In `logic_handoff.handoff()`, after the MIDI copy step, copy all WAVs from
+- [x] 3.1 In `logic_handoff.handoff()`, after the MIDI copy step, copy all WAVs from
   `<production_dir>/samples/` (if the dir exists) to `$LOGIC_OUTPUT_DIR/.../Samples/`
 
 ## 4. Frontend — types and API helpers
-- [ ] 4.1 Add `SampleEntry` interface to `packages/client/lib/types.ts`
+- [x] 4.1 Add `SampleEntry` interface to `packages/client/lib/types.ts`
   (`segment_id`, `song_slug`, `color`, `match`, `audio_url`)
-- [ ] 4.2 Add `fetchSamples(topN?)`, `exportSample(segmentId)` helpers to `packages/client/lib/api.ts`
+- [x] 4.2 Add `fetchSamples(topN?)`, `exportSample(segmentId)` helpers to `packages/client/lib/api.ts`
 
 ## 5. Frontend — Samples panel
-- [ ] 5.1 Add a collapsible "Samples" section in `app/candidates/page.tsx` below the
+- [x] 5.1 Add a collapsible "Samples" section in `app/candidates/page.tsx` below the
   candidate table, always rendered regardless of phase filter
-- [ ] 5.2 Each row shows: rank, segment_id, song_slug, color chip, match score, inline
+- [x] 5.2 Each row shows: rank, segment_id, song_slug, color chip, match score, inline
   `<audio>` player (src = audio_url), and an "Export" button
-- [ ] 5.3 "Export" button calls `exportSample(segmentId)` and shows a per-row success/error state
+- [x] 5.3 "Export" button calls `exportSample(segmentId)` and shows a per-row success/error state
 
 ## 6. Frontend — Quartet button fix
-- [ ] 6.1 Fix `canRunQuartet` so it is true when `quartetStatus` is `undefined`, `null`, or `"pending"`
-- [ ] 6.2 Verify the "Generate Quartet" button appears alongside "Handoff to Logic" when
+- [x] 6.1 Fix `canRunQuartet` so it is true when `quartetStatus` is `undefined`, `null`, or `"pending"`
+- [x] 6.2 Verify the "Generate Quartet" button appears alongside "Handoff to Logic" when
   melody is promoted (no layout change needed; confirm the existing code satisfies the spec)

--- a/openspec/changes/add-song-concept-display/proposal.md
+++ b/openspec/changes/add-song-concept-display/proposal.md
@@ -1,0 +1,29 @@
+# Change: Display song concept at the top of the candidate browser
+
+## Why
+When reviewing MIDI candidates the user has no reminder of the song's concept — which
+can be elaborate and "out there" even when the musical parameters look simple. Having
+the concept visible avoids the need to switch windows to the proposal YAML.
+
+## What Changes
+- `scan_songs` in `candidate_server.py` reads `concept` from `song_context.yml` and
+  includes it in each song entry (null if `song_context.yml` is absent or has no concept)
+- `SongEntry` TypeScript interface gains `concept: string | null`
+- `/candidates` page renders the concept in a collapsible block between the breadcrumb
+  and the toolbar — collapsed by default to a 3-line clamp, expandable on click.
+  Hidden when `activeSong.concept` is null (single-song mode with no context file).
+
+## Notes
+- `song_context.yml` is the canonical source; `manifest_bootstrap.yml` does **not**
+  carry concept and should not be changed.
+- The active change `refactor-song-index-navigation` also touches `scan_songs` and
+  `SongEntry` (adds `stage`). This change is additive and does not conflict, but
+  implementers should be aware of the overlap when merging.
+
+## Impact
+- Affected specs: `candidate-browser-web`
+- Affected code:
+  - `packages/api/src/white_api/candidate_server.py` — `scan_songs` adds `concept`
+  - `packages/api/tests/test_candidate_server.py` — shape test updated
+  - `packages/client/lib/types.ts` — `SongEntry` gains `concept`
+  - `packages/client/app/candidates/page.tsx` — concept block rendered

--- a/openspec/changes/add-song-concept-display/specs/candidate-browser-web/spec.md
+++ b/openspec/changes/add-song-concept-display/specs/candidate-browser-web/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Song Concept Field
+The song entry returned by `GET /songs` and `GET /songs/active` SHALL include a
+`concept` field. The value SHALL be read from `song_context.yml` in the production
+directory if that file exists and contains a non-empty `concept` key; otherwise the
+field SHALL be `null`.
+
+`manifest_bootstrap.yml` is NOT modified — concept is sourced exclusively from
+`song_context.yml`.
+
+#### Scenario: Concept present in song_context.yml
+- **WHEN** `GET /songs` is called and a production directory has a `song_context.yml`
+  with a non-empty `concept` field
+- **THEN** the song entry for that production includes `"concept": "<text>"`
+
+#### Scenario: Concept absent — no song_context.yml
+- **WHEN** `GET /songs` is called and a production directory has no `song_context.yml`
+  (song is in ideation stage)
+- **THEN** the song entry for that production includes `"concept": null`
+
+#### Scenario: Concept absent — song_context.yml exists but concept is empty
+- **WHEN** `GET /songs` is called and `song_context.yml` exists but `concept` is an
+  empty string or missing key
+- **THEN** the song entry for that production includes `"concept": null`
+
+#### Scenario: Active song includes concept
+- **WHEN** `GET /songs/active` is called and the active song has a concept
+- **THEN** the returned object includes `"concept": "<text>"`
+
+---
+
+### Requirement: Concept Display in Candidate Browser
+The `/candidates` page SHALL render a concept block between the breadcrumb and the phase
+toolbar when `activeSong.concept` is non-null and non-empty.
+
+The block SHALL:
+- Default to a 3-line clamp (overflow hidden)
+- Show a "Show more" / "Show less" toggle below the text when the content exceeds 3 lines
+- Be hidden (not rendered) when `activeSong` is null or `activeSong.concept` is null
+
+#### Scenario: Concept block visible
+- **WHEN** `/candidates` is loaded and the active song has a non-null concept
+- **THEN** the concept text is displayed above the toolbar, clamped to 3 lines by default
+
+#### Scenario: Toggle expands concept
+- **WHEN** the user clicks "Show more" on the clamped concept block
+- **THEN** the full concept text is revealed and the toggle label changes to "Show less"
+
+#### Scenario: Toggle collapses concept
+- **WHEN** the user clicks "Show less" on the expanded concept block
+- **THEN** the text returns to a 3-line clamp
+
+#### Scenario: Concept block hidden when absent
+- **WHEN** `/candidates` is loaded and `activeSong.concept` is null
+- **THEN** no concept block is rendered and the page layout is unchanged

--- a/openspec/changes/add-song-concept-display/tasks.md
+++ b/openspec/changes/add-song-concept-display/tasks.md
@@ -1,0 +1,9 @@
+## 1. Backend
+- [ ] 1.1 In `scan_songs` (`candidate_server.py`), read `song_context.yml` for the production dir and add `concept: str | None` to the returned dict (empty string → None; missing file → None)
+- [ ] 1.2 Update `packages/api/tests/test_candidate_server.py` song-shape test to include `concept` field
+
+## 2. Frontend types
+- [ ] 2.1 Add `concept: string | null` to `SongEntry` interface in `packages/client/lib/types.ts`
+
+## 3. Frontend UI
+- [ ] 3.1 In `app/candidates/page.tsx`, add a concept block below the breadcrumb and above the toolbar: 3-line clamp, "Show more / Show less" toggle, only rendered when `activeSong?.concept` is non-null

--- a/openspec/changes/add-song-concept-display/tasks.md
+++ b/openspec/changes/add-song-concept-display/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Backend
-- [ ] 1.1 In `scan_songs` (`candidate_server.py`), read `song_context.yml` for the production dir and add `concept: str | None` to the returned dict (empty string → None; missing file → None)
-- [ ] 1.2 Update `packages/api/tests/test_candidate_server.py` song-shape test to include `concept` field
+- [x] 1.1 In `scan_songs` (`candidate_server.py`), read `song_context.yml` for the production dir and add `concept: str | None` to the returned dict (empty string → None; missing file → None)
+- [x] 1.2 Update `packages/api/tests/test_candidate_server.py` song-shape test to include `concept` field
 
 ## 2. Frontend types
-- [ ] 2.1 Add `concept: string | null` to `SongEntry` interface in `packages/client/lib/types.ts`
+- [x] 2.1 Add `concept: string | null` to `SongEntry` interface in `packages/client/lib/types.ts`
 
 ## 3. Frontend UI
-- [ ] 3.1 In `app/candidates/page.tsx`, add a concept block below the breadcrumb and above the toolbar: 3-line clamp, "Show more / Show less" toggle, only rendered when `activeSong?.concept` is non-null
+- [x] 3.1 In `app/candidates/page.tsx`, add a concept block below the breadcrumb and above the toolbar: 3-line clamp, "Show more / Show less" toggle, only rendered when `activeSong?.concept` is non-null

--- a/packages/api/src/white_api/candidate_server.py
+++ b/packages/api/src/white_api/candidate_server.py
@@ -153,6 +153,19 @@ def _has_mix_file(prod_dir: Path) -> bool:
         return False
 
 
+def _read_concept(prod_dir: Path) -> str | None:
+    ctx_path = prod_dir / "song_context.yml"
+    if not ctx_path.exists():
+        return None
+    try:
+        with open(ctx_path) as f:
+            ctx = yaml.safe_load(f) or {}
+        concept = ctx.get("concept")
+        return str(concept).strip() or None if concept else None
+    except Exception:
+        return None
+
+
 def scan_songs(shrink_wrapped_dir: Path) -> list[dict]:
     """Walk shrink_wrapped_dir for manifest_bootstrap.yml files and return song entries."""
     songs = []
@@ -188,6 +201,7 @@ def scan_songs(shrink_wrapped_dir: Path) -> list[dict]:
                 "has_mix": _has_mix_file(prod_dir),
                 "stage": _compute_stage(prod_dir),
                 "proposal_path": str(proposal_path) if proposal_path else None,
+                "concept": _read_concept(prod_dir),
             }
         )
     return songs
@@ -511,6 +525,99 @@ def create_app(
     @app.get("/handoff/status")
     def handoff_status():
         return _handoff_job
+
+    # ------------------------------------------------------------------
+    # Chromatic sample retrieval
+    # ------------------------------------------------------------------
+
+    _CLAP_PARQUET = (
+        Path(__file__).parents[4]
+        / "training"
+        / "data"
+        / "training_data_clap_embeddings.parquet"
+    )
+    _META_PARQUET = (
+        Path(__file__).parents[4]
+        / "training"
+        / "data"
+        / "training_data_with_embeddings.parquet"
+    )
+
+    _clap_df: object = None  # lazy-loaded DataFrame
+
+    def _get_clap_df():
+        nonlocal _clap_df
+        if _clap_df is None:
+            from white_composition.retrieve_samples import load_clap_index
+
+            _clap_df = load_clap_index(str(_CLAP_PARQUET), str(_META_PARQUET))
+        return _clap_df
+
+    @app.get("/samples")
+    def list_samples(top_n: int = 20):
+        if _production_dir is None:
+            raise HTTPException(
+                status_code=503,
+                detail="No song selected — POST /songs/activate first",
+            )
+        color = (_active_song or {}).get("rainbow_color") or None
+        if not color:
+            return []
+        from white_composition.retrieve_samples import retrieve_by_color
+
+        df = _get_clap_df()
+        results = retrieve_by_color(df, color, top_n=top_n)
+        for r in results:
+            r["audio_url"] = f"/audio/{r['segment_id']}"
+        return results
+
+    @app.get("/audio/{segment_id}")
+    def stream_audio(segment_id: str):
+        df = _get_clap_df()
+        row = df[df["segment_id"] == segment_id]
+        if row.empty:
+            raise HTTPException(
+                status_code=404, detail=f"Segment '{segment_id}' not found"
+            )
+        wav_path = Path(row.iloc[0]["source_audio_file"])
+        if not wav_path.exists():
+            raise HTTPException(
+                status_code=404, detail=f"WAV file not found: {wav_path}"
+            )
+        return FileResponse(str(wav_path), media_type="audio/wav")
+
+    @app.post("/samples/{segment_id}/export")
+    def export_sample(segment_id: str):
+        logic_output_dir = os.environ.get("LOGIC_OUTPUT_DIR", "")
+        if not logic_output_dir:
+            raise HTTPException(
+                status_code=503,
+                detail="LOGIC_OUTPUT_DIR not set — add it to .env",
+            )
+        df = _get_clap_df()
+        row = df[df["segment_id"] == segment_id]
+        if row.empty:
+            raise HTTPException(
+                status_code=404, detail=f"Segment '{segment_id}' not found"
+            )
+        wav_path = Path(row.iloc[0]["source_audio_file"])
+        if not wav_path.exists():
+            raise HTTPException(
+                status_code=404, detail=f"WAV file not found: {wav_path}"
+            )
+        if _active_song is None:
+            raise HTTPException(
+                status_code=503,
+                detail="No song selected — POST /songs/activate first",
+            )
+        thread_slug = _active_song.get("thread_slug", "unknown")
+        title = _active_song.get("title", "unknown")
+        safe_title = title.replace("/", "-").replace(":", "-")
+        dest_dir = Path(logic_output_dir) / thread_slug / safe_title / "Samples"
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / f"{segment_id}.wav"
+        shutil.copy2(wav_path, dest)
+        return {"ok": True, "dest": str(dest)}
 
     @app.post("/sync-arrangement")
     def sync_arrangement():

--- a/packages/api/src/white_api/candidate_server.py
+++ b/packages/api/src/white_api/candidate_server.py
@@ -18,6 +18,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import urllib.parse
 import webbrowser
 from dataclasses import asdict
 from datetime import datetime, timezone
@@ -47,6 +48,14 @@ _EVOLVE_PIPELINE = {
     "bass": "white_generation.pipelines.bass_pipeline",
     "melody": "white_generation.pipelines.melody_pipeline",
 }
+
+# ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Audio allowlist root — files served by /audio and /samples/export must live
+# under this directory.  Override in tests by monkeypatching this variable.
+# ---------------------------------------------------------------------------
+
+_AUDIO_ROOT: Path = Path(__file__).parents[4].resolve()
 
 # ---------------------------------------------------------------------------
 # Module-level state (mutated at startup and by /songs/activate)
@@ -160,8 +169,11 @@ def _read_concept(prod_dir: Path) -> str | None:
     try:
         with open(ctx_path) as f:
             ctx = yaml.safe_load(f) or {}
-        concept = ctx.get("concept")
-        return str(concept).strip() or None if concept else None
+        raw = ctx.get("concept")
+        if not raw:
+            return None
+        text = str(raw).strip()
+        return text or None
     except Exception:
         return None
 
@@ -553,6 +565,16 @@ def create_app(
             _clap_df = load_clap_index(str(_CLAP_PARQUET), str(_META_PARQUET))
         return _clap_df
 
+    def _check_audio_path(wav_path: Path) -> Path:
+        resolved = wav_path.resolve()
+        try:
+            resolved.relative_to(_AUDIO_ROOT)
+        except ValueError:
+            raise HTTPException(
+                status_code=403, detail="Audio file is outside allowed directory"
+            )
+        return resolved
+
     @app.get("/samples")
     def list_samples(top_n: int = 20):
         if _production_dir is None:
@@ -568,10 +590,11 @@ def create_app(
         df = _get_clap_df()
         results = retrieve_by_color(df, color, top_n=top_n)
         for r in results:
-            r["audio_url"] = f"/audio/{r['segment_id']}"
+            encoded = urllib.parse.quote(r["segment_id"], safe="")
+            r["audio_url"] = f"/audio/{encoded}"
         return results
 
-    @app.get("/audio/{segment_id}")
+    @app.get("/audio/{segment_id:path}")
     def stream_audio(segment_id: str):
         df = _get_clap_df()
         row = df[df["segment_id"] == segment_id]
@@ -579,7 +602,7 @@ def create_app(
             raise HTTPException(
                 status_code=404, detail=f"Segment '{segment_id}' not found"
             )
-        wav_path = Path(row.iloc[0]["source_audio_file"])
+        wav_path = _check_audio_path(Path(row.iloc[0]["source_audio_file"]))
         if not wav_path.exists():
             raise HTTPException(
                 status_code=404, detail=f"WAV file not found: {wav_path}"
@@ -600,7 +623,7 @@ def create_app(
             raise HTTPException(
                 status_code=404, detail=f"Segment '{segment_id}' not found"
             )
-        wav_path = Path(row.iloc[0]["source_audio_file"])
+        wav_path = _check_audio_path(Path(row.iloc[0]["source_audio_file"]))
         if not wav_path.exists():
             raise HTTPException(
                 status_code=404, detail=f"WAV file not found: {wav_path}"
@@ -610,10 +633,17 @@ def create_app(
                 status_code=503,
                 detail="No song selected — POST /songs/activate first",
             )
+        logic_root = Path(logic_output_dir).resolve()
         thread_slug = _active_song.get("thread_slug", "unknown")
         title = _active_song.get("title", "unknown")
-        safe_title = title.replace("/", "-").replace(":", "-")
-        dest_dir = Path(logic_output_dir) / thread_slug / safe_title / "Samples"
+        safe_title = title.replace("/", "-").replace(":", "-").replace("..", "")
+        dest_dir = (logic_root / thread_slug / safe_title / "Samples").resolve()
+        try:
+            dest_dir.relative_to(logic_root)
+        except ValueError:
+            raise HTTPException(
+                status_code=400, detail="Destination is outside LOGIC_OUTPUT_DIR"
+            )
         dest_dir.mkdir(parents=True, exist_ok=True)
         dest = dest_dir / f"{segment_id}.wav"
         shutil.copy2(wav_path, dest)

--- a/packages/api/tests/test_candidate_server.py
+++ b/packages/api/tests/test_candidate_server.py
@@ -768,99 +768,214 @@ class TestDriftReport:
 # ---------------------------------------------------------------------------
 
 
+def _make_clap_df(tmp_path: Path, segment_id: str = "seg_001"):
+    """Return a minimal DataFrame that satisfies _get_clap_df() consumers."""
+    import pandas as pd
+
+    wav = tmp_path / f"{segment_id}.wav"
+    wav.write_bytes(b"RIFF")
+    return pd.DataFrame([{"segment_id": segment_id, "source_audio_file": str(wav)}])
+
+
 class TestSamplesEndpoints:
-    def _client_with_active_song(self, sw_dir, color="Red"):
-        from fastapi.testclient import TestClient
-
-        from white_api.candidate_server import create_app
-
+    def _active_client(self, sw_dir):
         app = create_app(shrink_wrapped_dir=sw_dir)
         tc = TestClient(app)
         tc.post("/songs/activate", json={"id": "thread-alpha__song_a_v1"})
         return tc
 
+    # -- /samples -----------------------------------------------------------
+
     def test_samples_503_with_no_active_song(self, sw_dir):
-        from fastapi.testclient import TestClient
-
-        from white_api.candidate_server import create_app
-
         app = create_app(shrink_wrapped_dir=sw_dir)
         tc = TestClient(app)
         resp = tc.get("/samples")
         assert resp.status_code == 503
 
-    def test_samples_returns_list(self, sw_dir):
-        tc = self._client_with_active_song(sw_dir)
-        sample_row = {
-            "segment_id": "01_01_seg_0001_track_01",
-            "source_audio_file": "/fake/seg.wav",
-            "match": 0.95,
-            "song_slug": "01_01",
-            "color": "Red",
-        }
-        with patch(
-            "white_composition.retrieve_samples.retrieve_by_color",
-            return_value=[sample_row],
-        ):
-            import pandas as pd
-
-            with patch(
-                "white_composition.retrieve_samples.load_clap_index",
-                return_value=pd.DataFrame([{"segment_id": "01_01_seg_0001_track_01"}]),
-            ):
-                resp = tc.get("/samples")
-        # Without actual parquet the endpoint may 500 — just check shape when mocked
-        assert resp.status_code in (200, 500)
-
-    def test_audio_404_when_segment_missing(self, client):
-        resp = client.get("/audio/nonexistent_segment")
-        assert resp.status_code in (404, 500)
-
-    def test_audio_404_when_wav_absent(self, sw_dir, tmp_path):
-        tc = self._client_with_active_song(sw_dir)
+    def test_samples_returns_200_with_entries(self, sw_dir, tmp_path):
         import pandas as pd
 
-        df = pd.DataFrame(
+        tc = self._active_client(sw_dir)
+        fake_results = [
+            {
+                "segment_id": "seg_001",
+                "source_audio_file": str(tmp_path / "seg_001.wav"),
+                "match": 0.95,
+                "song_slug": "01_01",
+                "color": "Red",
+                "start_seconds": 0.0,
+                "end_seconds": 3.0,
+            }
+        ]
+        fake_df = pd.DataFrame([{"segment_id": "seg_001"}])
+        with (
+            patch(
+                "white_composition.retrieve_samples.load_clap_index",
+                return_value=fake_df,
+            ),
+            patch(
+                "white_composition.retrieve_samples.retrieve_by_color",
+                return_value=fake_results,
+            ),
+        ):
+            resp = tc.get("/samples")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["segment_id"] == "seg_001"
+        assert "audio_url" in data[0]
+
+    def test_samples_audio_url_is_url_encoded(self, sw_dir, tmp_path):
+        import pandas as pd
+
+        tc = self._active_client(sw_dir)
+        fake_results = [
+            {
+                "segment_id": "seg with spaces",
+                "source_audio_file": str(tmp_path / "seg.wav"),
+                "match": 0.9,
+                "song_slug": "01_01",
+                "color": "Red",
+                "start_seconds": None,
+                "end_seconds": None,
+            }
+        ]
+        fake_df = pd.DataFrame([{"segment_id": "seg with spaces"}])
+        with (
+            patch(
+                "white_composition.retrieve_samples.load_clap_index",
+                return_value=fake_df,
+            ),
+            patch(
+                "white_composition.retrieve_samples.retrieve_by_color",
+                return_value=fake_results,
+            ),
+        ):
+            resp = tc.get("/samples")
+        assert resp.status_code == 200
+        assert resp.json()[0]["audio_url"] == "/audio/seg%20with%20spaces"
+
+    # -- /audio -------------------------------------------------------------
+
+    def test_audio_404_when_segment_missing(self, sw_dir, tmp_path):
+        import pandas as pd
+
+        tc = self._active_client(sw_dir)
+        fake_df = pd.DataFrame(
+            [{"segment_id": "other_seg", "source_audio_file": str(tmp_path / "x.wav")}]
+        )
+        with (
+            patch(
+                "white_composition.retrieve_samples.load_clap_index",
+                return_value=fake_df,
+            ),
+            patch("white_api.candidate_server._AUDIO_ROOT", tmp_path),
+        ):
+            resp = tc.get("/audio/nonexistent_segment")
+        assert resp.status_code == 404
+
+    def test_audio_404_when_wav_absent(self, sw_dir, tmp_path):
+        import pandas as pd
+
+        tc = self._active_client(sw_dir)
+        fake_df = pd.DataFrame(
             [
                 {
-                    "segment_id": "fake_seg",
+                    "segment_id": "seg_001",
                     "source_audio_file": str(tmp_path / "absent.wav"),
                 }
             ]
         )
-
-        def mock_get_df():
-            return df
-
-        with patch(
-            "white_composition.retrieve_samples.load_clap_index", return_value=df
+        with (
+            patch(
+                "white_composition.retrieve_samples.load_clap_index",
+                return_value=fake_df,
+            ),
+            patch("white_api.candidate_server._AUDIO_ROOT", tmp_path),
         ):
-            resp = tc.get("/audio/fake_seg")
-        assert resp.status_code in (404, 500)
+            resp = tc.get("/audio/seg_001")
+        assert resp.status_code == 404
+
+    def test_audio_200_when_wav_present(self, sw_dir, tmp_path):
+        import pandas as pd
+
+        tc = self._active_client(sw_dir)
+        wav = tmp_path / "seg_001.wav"
+        wav.write_bytes(b"RIFF")
+        fake_df = pd.DataFrame(
+            [{"segment_id": "seg_001", "source_audio_file": str(wav)}]
+        )
+        with (
+            patch(
+                "white_composition.retrieve_samples.load_clap_index",
+                return_value=fake_df,
+            ),
+            patch("white_api.candidate_server._AUDIO_ROOT", tmp_path),
+        ):
+            resp = tc.get("/audio/seg_001")
+        assert resp.status_code == 200
+        assert "wav" in resp.headers["content-type"]
+
+    # -- /samples/{id}/export -----------------------------------------------
 
     def test_export_503_when_no_logic_output_dir(self, sw_dir, tmp_path):
-        tc = self._client_with_active_song(sw_dir)
+        import pandas as pd
+
+        tc = self._active_client(sw_dir)
+        fake_df = pd.DataFrame(
+            [{"segment_id": "seg_001", "source_audio_file": str(tmp_path / "seg.wav")}]
+        )
         env = {
             k: v for k, v in __import__("os").environ.items() if k != "LOGIC_OUTPUT_DIR"
         }
-        with patch.dict("os.environ", env, clear=True):
-            resp = tc.post("/samples/any_segment/export")
+        with (
+            patch(
+                "white_composition.retrieve_samples.load_clap_index",
+                return_value=fake_df,
+            ),
+            patch.dict("os.environ", env, clear=True),
+        ):
+            resp = tc.post("/samples/seg_001/export")
         assert resp.status_code == 503
 
-    def test_export_copies_wav(self, sw_dir, tmp_path):
-        tc = self._client_with_active_song(sw_dir)
-        wav = tmp_path / "seg.wav"
-        wav.write_bytes(b"RIFF")
-        logic_dir = tmp_path / "logic"
-
+    def test_export_404_when_segment_missing(self, sw_dir, tmp_path):
         import pandas as pd
 
-        df = pd.DataFrame([{"segment_id": "seg_001", "source_audio_file": str(wav)}])
-
-        with patch(
-            "white_composition.retrieve_samples.load_clap_index", return_value=df
+        tc = self._active_client(sw_dir)
+        fake_df = pd.DataFrame(
+            [{"segment_id": "other", "source_audio_file": str(tmp_path / "x.wav")}]
+        )
+        with (
+            patch(
+                "white_composition.retrieve_samples.load_clap_index",
+                return_value=fake_df,
+            ),
+            patch("white_api.candidate_server._AUDIO_ROOT", tmp_path),
+            patch.dict("os.environ", {"LOGIC_OUTPUT_DIR": str(tmp_path / "logic")}),
         ):
-            with patch.dict("os.environ", {"LOGIC_OUTPUT_DIR": str(logic_dir)}):
-                resp = tc.post("/samples/seg_001/export")
+            resp = tc.post("/samples/nonexistent/export")
+        assert resp.status_code == 404
 
-        assert resp.status_code in (200, 500)
+    def test_export_copies_wav_and_returns_dest(self, sw_dir, tmp_path):
+        import pandas as pd
+
+        tc = self._active_client(sw_dir)
+        wav = tmp_path / "seg_001.wav"
+        wav.write_bytes(b"RIFF")
+        logic_dir = tmp_path / "logic"
+        fake_df = pd.DataFrame(
+            [{"segment_id": "seg_001", "source_audio_file": str(wav)}]
+        )
+        with (
+            patch(
+                "white_composition.retrieve_samples.load_clap_index",
+                return_value=fake_df,
+            ),
+            patch("white_api.candidate_server._AUDIO_ROOT", tmp_path),
+            patch.dict("os.environ", {"LOGIC_OUTPUT_DIR": str(logic_dir)}),
+        ):
+            resp = tc.post("/samples/seg_001/export")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ok"] is True
+        assert Path(data["dest"]).exists()

--- a/packages/api/tests/test_candidate_server.py
+++ b/packages/api/tests/test_candidate_server.py
@@ -511,8 +511,29 @@ class TestGetSongs:
             "rainbow_color",
             "has_decisions",
             "stage",
+            "concept",
         ):
             assert field in song
+
+    def test_concept_null_when_no_song_context(self, album_client):
+        songs = album_client.get("/songs").json()
+        assert all(s["concept"] is None for s in songs)
+
+    def test_concept_populated_from_song_context(self, sw_dir):
+        prod_dir = sw_dir / "thread-alpha" / "production" / "song_a_v1"
+        (prod_dir / "song_context.yml").write_text(
+            "title: Song Alpha\nconcept: A haunting ballad about loss.\n"
+        )
+        songs = scan_songs(sw_dir)
+        alpha = next(s for s in songs if s["production_slug"] == "song_a_v1")
+        assert alpha["concept"] == "A haunting ballad about loss."
+
+    def test_concept_null_when_key_absent(self, sw_dir):
+        prod_dir = sw_dir / "thread-alpha" / "production" / "song_a_v1"
+        (prod_dir / "song_context.yml").write_text("title: Song Alpha\n")
+        songs = scan_songs(sw_dir)
+        alpha = next(s for s in songs if s["production_slug"] == "song_a_v1")
+        assert alpha["concept"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -740,3 +761,106 @@ class TestDriftReport:
         tc = TestClient(app)
         assert tc.get("/drift-report").status_code == 503
         assert tc.post("/drift-report").status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# Samples endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestSamplesEndpoints:
+    def _client_with_active_song(self, sw_dir, color="Red"):
+        from fastapi.testclient import TestClient
+
+        from white_api.candidate_server import create_app
+
+        app = create_app(shrink_wrapped_dir=sw_dir)
+        tc = TestClient(app)
+        tc.post("/songs/activate", json={"id": "thread-alpha__song_a_v1"})
+        return tc
+
+    def test_samples_503_with_no_active_song(self, sw_dir):
+        from fastapi.testclient import TestClient
+
+        from white_api.candidate_server import create_app
+
+        app = create_app(shrink_wrapped_dir=sw_dir)
+        tc = TestClient(app)
+        resp = tc.get("/samples")
+        assert resp.status_code == 503
+
+    def test_samples_returns_list(self, sw_dir):
+        tc = self._client_with_active_song(sw_dir)
+        sample_row = {
+            "segment_id": "01_01_seg_0001_track_01",
+            "source_audio_file": "/fake/seg.wav",
+            "match": 0.95,
+            "song_slug": "01_01",
+            "color": "Red",
+        }
+        with patch(
+            "white_composition.retrieve_samples.retrieve_by_color",
+            return_value=[sample_row],
+        ):
+            import pandas as pd
+
+            with patch(
+                "white_composition.retrieve_samples.load_clap_index",
+                return_value=pd.DataFrame([{"segment_id": "01_01_seg_0001_track_01"}]),
+            ):
+                resp = tc.get("/samples")
+        # Without actual parquet the endpoint may 500 — just check shape when mocked
+        assert resp.status_code in (200, 500)
+
+    def test_audio_404_when_segment_missing(self, client):
+        resp = client.get("/audio/nonexistent_segment")
+        assert resp.status_code in (404, 500)
+
+    def test_audio_404_when_wav_absent(self, sw_dir, tmp_path):
+        tc = self._client_with_active_song(sw_dir)
+        import pandas as pd
+
+        df = pd.DataFrame(
+            [
+                {
+                    "segment_id": "fake_seg",
+                    "source_audio_file": str(tmp_path / "absent.wav"),
+                }
+            ]
+        )
+
+        def mock_get_df():
+            return df
+
+        with patch(
+            "white_composition.retrieve_samples.load_clap_index", return_value=df
+        ):
+            resp = tc.get("/audio/fake_seg")
+        assert resp.status_code in (404, 500)
+
+    def test_export_503_when_no_logic_output_dir(self, sw_dir, tmp_path):
+        tc = self._client_with_active_song(sw_dir)
+        env = {
+            k: v for k, v in __import__("os").environ.items() if k != "LOGIC_OUTPUT_DIR"
+        }
+        with patch.dict("os.environ", env, clear=True):
+            resp = tc.post("/samples/any_segment/export")
+        assert resp.status_code == 503
+
+    def test_export_copies_wav(self, sw_dir, tmp_path):
+        tc = self._client_with_active_song(sw_dir)
+        wav = tmp_path / "seg.wav"
+        wav.write_bytes(b"RIFF")
+        logic_dir = tmp_path / "logic"
+
+        import pandas as pd
+
+        df = pd.DataFrame([{"segment_id": "seg_001", "source_audio_file": str(wav)}])
+
+        with patch(
+            "white_composition.retrieve_samples.load_clap_index", return_value=df
+        ):
+            with patch.dict("os.environ", {"LOGIC_OUTPUT_DIR": str(logic_dir)}):
+                resp = tc.post("/samples/seg_001/export")
+
+        assert resp.status_code in (200, 500)

--- a/packages/client/app/candidates/page.tsx
+++ b/packages/client/app/candidates/page.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useState, useCallback, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { fetchCandidates, approveCandidate, rejectCandidate, setLabel, setUseCase, midiUrl, promotePhase, evolvePhase, fetchActiveSong, initSong, runNextPhase, runQuartetPhase, getRunStatus, fetchPipelineStatus, startHandoff, getHandoffStatus, fetchSamples, exportSample } from "@/lib/api";
+import { fetchCandidates, approveCandidate, rejectCandidate, setLabel, setUseCase, midiUrl, promotePhase, evolvePhase, fetchActiveSong, initSong, runNextPhase, runQuartetPhase, getRunStatus, fetchPipelineStatus, startHandoff, getHandoffStatus, fetchSamples, exportSample, audioUrl } from "@/lib/api";
 import { Candidate, CandidateStatus, PipelineStatus, RunJob, SampleEntry, SongEntry } from "@/lib/types";
 import ScoreBar from "@/components/ScoreBar";
 import ScorePanel from "@/components/ScorePanel";
@@ -634,7 +634,7 @@ export default function CandidatesPage() {
                       <td className="px-3 py-2 text-zinc-400 text-xs">{s.match.toFixed(2)}</td>
                       <td className="px-3 py-2">
                         <audio
-                          src={s.audio_url}
+                          src={audioUrl(s.segment_id)}
                           controls
                           className="h-7 w-48"
                           preload="none"

--- a/packages/client/app/candidates/page.tsx
+++ b/packages/client/app/candidates/page.tsx
@@ -3,8 +3,8 @@
 import React, { useEffect, useState, useCallback, useRef } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { fetchCandidates, approveCandidate, rejectCandidate, setLabel, setUseCase, midiUrl, promotePhase, evolvePhase, fetchActiveSong, initSong, runNextPhase, runQuartetPhase, getRunStatus, fetchPipelineStatus, startHandoff, getHandoffStatus } from "@/lib/api";
-import { Candidate, CandidateStatus, PipelineStatus, RunJob, SongEntry } from "@/lib/types";
+import { fetchCandidates, approveCandidate, rejectCandidate, setLabel, setUseCase, midiUrl, promotePhase, evolvePhase, fetchActiveSong, initSong, runNextPhase, runQuartetPhase, getRunStatus, fetchPipelineStatus, startHandoff, getHandoffStatus, fetchSamples, exportSample } from "@/lib/api";
+import { Candidate, CandidateStatus, PipelineStatus, RunJob, SampleEntry, SongEntry } from "@/lib/types";
 import ScoreBar from "@/components/ScoreBar";
 import ScorePanel from "@/components/ScorePanel";
 import StatusBadge from "@/components/StatusBadge";
@@ -39,6 +39,11 @@ export default function CandidatesPage() {
   const [pipeline, setPipeline] = useState<PipelineStatus | null>(null);
   const runPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const handoffPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [conceptExpanded, setConceptExpanded] = useState(false);
+  const [samples, setSamples] = useState<SampleEntry[]>([]);
+  const [samplesExpanded, setSamplesExpanded] = useState(false);
+  const [exportedIds, setExportedIds] = useState<Set<string>>(new Set());
+  const [exportingId, setExportingId] = useState<string | null>(null);
 
   const refreshPipeline = useCallback(() => {
     fetchPipelineStatus().then(setPipeline).catch(() => {});
@@ -47,6 +52,7 @@ export default function CandidatesPage() {
   useEffect(() => {
     fetchActiveSong().then(({ active }) => setActiveSong(active)).catch(() => {});
     refreshPipeline();
+    fetchSamples().then(setSamples).catch(() => {});
   }, [refreshPipeline]);
 
   useEffect(() => () => {
@@ -280,13 +286,30 @@ export default function CandidatesPage() {
     }, 2000);
   };
 
+  const handleExport = async (segmentId: string) => {
+    setExportingId(segmentId);
+    try {
+      await exportSample(segmentId);
+      setExportedIds(prev => new Set(prev).add(segmentId));
+    } catch (e) {
+      const status = (e as { status?: number }).status;
+      showToast(
+        status === 503
+          ? "LOGIC_OUTPUT_DIR not set — add it to .env"
+          : e instanceof Error ? e.message : "Export failed"
+      );
+    } finally {
+      setExportingId(null);
+    }
+  };
+
   const canPromote = !!phaseFilter && phaseFilter !== "all";
   const canEvolve = ["drums", "bass", "melody"].includes(phaseFilter);
   const needsInit = pipeline?.next_phase === "init_production";
   const canRun = !running && !needsInit && pipeline?.next_phase != null;
   const melodyPromoted = pipeline?.phases?.["melody"] === "promoted";
   const quartetStatus = pipeline?.phases?.["quartet"];
-  const canRunQuartet = melodyPromoted && !quartetStatus && !running && !runningQuartet;
+  const canRunQuartet = melodyPromoted && (!quartetStatus || quartetStatus === "pending") && !running && !runningQuartet;
 
   const SortIcon = ({ k }: { k: SortKey }) =>
     sortKey === k ? <span className="ml-1 text-zinc-400">{sortAsc ? "↑" : "↓"}</span> : null;
@@ -308,6 +331,19 @@ export default function CandidatesPage() {
           <Link href="/" className="hover:text-zinc-300 transition-colors">← Songs</Link>
           <span>/</span>
           <span className="text-zinc-300">{activeSong.title}</span>
+        </div>
+      )}
+
+      {/* Concept block */}
+      {activeSong?.concept && (
+        <div className="mb-4 bg-zinc-900/60 border border-zinc-800 rounded p-3 font-sans text-sm text-zinc-400">
+          <div className={conceptExpanded ? "" : "line-clamp-3"}>{activeSong.concept}</div>
+          <button
+            onClick={() => setConceptExpanded(e => !e)}
+            className="mt-1 text-xs text-zinc-600 hover:text-zinc-400 transition-colors"
+          >
+            {conceptExpanded ? "Show less" : "Show more"}
+          </button>
         </div>
       )}
 
@@ -556,6 +592,70 @@ export default function CandidatesPage() {
             ))}
           </tbody>
         </table>
+      </div>
+
+      {/* Samples panel */}
+      <div className="mt-4 border border-zinc-800 rounded-lg overflow-hidden">
+        <button
+          onClick={() => setSamplesExpanded(e => !e)}
+          className="w-full flex items-center justify-between px-4 py-2.5 bg-zinc-900 text-zinc-400 text-sm font-sans hover:bg-zinc-800 transition-colors"
+        >
+          <span className="font-medium text-zinc-300">Chromatic Samples</span>
+          <span className="text-xs text-zinc-600">{samplesExpanded ? "▲ collapse" : `▼ ${samples.length} samples`}</span>
+        </button>
+        {samplesExpanded && (
+          <div className="overflow-x-auto">
+            {samples.length === 0 ? (
+              <div className="px-4 py-6 text-center text-zinc-600 text-sm font-sans">
+                No samples loaded — activate a song with a rainbow color.
+              </div>
+            ) : (
+              <table className="w-full text-sm font-sans">
+                <thead className="bg-zinc-900/80 text-zinc-500 text-xs border-b border-zinc-800">
+                  <tr>
+                    <th className="px-3 py-2 text-left w-10">#</th>
+                    <th className="px-3 py-2 text-left">Segment</th>
+                    <th className="px-3 py-2 text-left">Song</th>
+                    <th className="px-3 py-2 text-left w-20">Color</th>
+                    <th className="px-3 py-2 text-left w-16">Match</th>
+                    <th className="px-3 py-2 text-left">Player</th>
+                    <th className="px-3 py-2 text-left w-28">Export</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {samples.map((s, i) => (
+                    <tr key={s.segment_id} className="border-b border-zinc-800/50 hover:bg-zinc-900/40">
+                      <td className="px-3 py-2 text-zinc-600">{i + 1}</td>
+                      <td className="px-3 py-2 text-zinc-300 font-mono text-xs max-w-xs truncate" title={s.segment_id}>{s.segment_id}</td>
+                      <td className="px-3 py-2 text-zinc-400 text-xs">{s.song_slug}</td>
+                      <td className="px-3 py-2">
+                        <span className="px-1.5 py-0.5 rounded text-xs bg-zinc-800 text-zinc-300">{s.color}</span>
+                      </td>
+                      <td className="px-3 py-2 text-zinc-400 text-xs">{s.match.toFixed(2)}</td>
+                      <td className="px-3 py-2">
+                        <audio
+                          src={s.audio_url}
+                          controls
+                          className="h-7 w-48"
+                          preload="none"
+                        />
+                      </td>
+                      <td className="px-3 py-2">
+                        <button
+                          onClick={() => handleExport(s.segment_id)}
+                          disabled={exportedIds.has(s.segment_id) || exportingId === s.segment_id}
+                          className="px-2 py-0.5 text-xs rounded font-medium transition-colors bg-zinc-700 hover:bg-zinc-600 text-zinc-200 disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          {exportedIds.has(s.segment_id) ? "Exported ✓" : exportingId === s.segment_id ? "…" : "Export"}
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        )}
       </div>
 
       <div className="mt-3 text-xs text-zinc-600 flex gap-4 font-sans flex-wrap">

--- a/packages/client/lib/api.ts
+++ b/packages/client/lib/api.ts
@@ -276,3 +276,29 @@ export async function setMixFile(path: string): Promise<void> {
 export function mixStreamUrl(): string {
   return `${BASE}/production/mix`;
 }
+
+export async function fetchSamples(topN?: number): Promise<import("./types").SampleEntry[]> {
+  const params = topN != null ? `?top_n=${topN}` : "";
+  const res = await fetch(`${BASE}/samples${params}`, { cache: "no-store" });
+  if (res.status === 503) throw Object.assign(new Error("no-active-song"), { status: 503 });
+  if (!res.ok) throw new Error("Failed to fetch samples");
+  return res.json();
+}
+
+export function audioUrl(segmentId: string): string {
+  return `${BASE}/audio/${encodeURIComponent(segmentId)}`;
+}
+
+export async function exportSample(segmentId: string): Promise<{ ok: boolean; dest: string }> {
+  const res = await fetch(`${BASE}/samples/${encodeURIComponent(segmentId)}/export`, {
+    method: "POST",
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw Object.assign(
+      new Error((err as { detail?: string }).detail ?? "Export failed"),
+      { status: res.status }
+    );
+  }
+  return res.json();
+}

--- a/packages/client/lib/types.ts
+++ b/packages/client/lib/types.ts
@@ -16,6 +16,15 @@ export interface SongEntry {
   has_mix: boolean;
   stage: "ideation" | "generation" | "composition";
   proposal_path: string | null;
+  concept: string | null;
+}
+
+export interface SampleEntry {
+  segment_id: string;
+  song_slug: string;
+  color: string;
+  match: number;
+  audio_url: string;
 }
 
 export interface PipelineStatus {

--- a/packages/composition/src/white_composition/logic_handoff.py
+++ b/packages/composition/src/white_composition/logic_handoff.py
@@ -87,6 +87,14 @@ def handoff(production_dir: Path) -> Path:
         for src in production_dir.glob(pattern):
             shutil.copy2(src, song_dir / src.name)
 
+    # 3b. Copy any pre-exported samples into Logic Samples/ folder
+    samples_src = production_dir / "samples"
+    if samples_src.is_dir():
+        samples_dest = song_dir / "Samples"
+        samples_dest.mkdir(exist_ok=True)
+        for wav in samples_src.glob("*.wav"):
+            shutil.copy2(wav, samples_dest / wav.name)
+
     # 4. Sync arrangement.txt back from Logic folder → production dir so that
     # lyric gen and drift report can read it after the human has arranged in Logic.
     logic_arrangement = song_dir / "arrangement.txt"

--- a/packages/composition/src/white_composition/retrieve_samples.py
+++ b/packages/composition/src/white_composition/retrieve_samples.py
@@ -1,34 +1,68 @@
 """Chromatic sample retrieval from the precomputed CLAP embedding index.
 
 Usage::
-    df = load_clap_index(clap_parquet_path, meta_parquet_path)
+    df = load_clap_index()
     results = retrieve_by_color(df, "Red", top_n=20)
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import numpy as np
 import pandas as pd
 
+_DATA_DIR = Path(__file__).parents[4] / "training" / "data"
+_DEFAULT_CLAP_PARQUET = _DATA_DIR / "training_data_clap_embeddings.parquet"
+_DEFAULT_META_PARQUET = _DATA_DIR / "training_data_with_embeddings.parquet"
 
-def load_clap_index(parquet_path: str, meta_parquet_path: str) -> pd.DataFrame:
+_META_COLUMNS = [
+    "segment_id",
+    "rainbow_color",
+    "source_audio_file",
+    "song_id",
+    "start_seconds",
+    "end_seconds",
+]
+
+
+def load_clap_index(
+    parquet_path: str | None = None,
+    meta_parquet_path: str | None = None,
+) -> pd.DataFrame:
     """Load and join CLAP embeddings with segment metadata.
 
     Args:
-        parquet_path: Path to training_data_clap_embeddings.parquet
-            (columns: segment_id, audio_embedding, has_audio_embedding)
-        meta_parquet_path: Path to a metadata parquet with at least
-            (segment_id, rainbow_color, source_audio_file, song_id)
+        parquet_path: Path to training_data_clap_embeddings.parquet.
+            Defaults to the project-local copy when None.
+        meta_parquet_path: Path to a metadata parquet that includes
+            segment_id, rainbow_color, source_audio_file, song_id,
+            start_seconds, end_seconds.  Defaults to the project-local
+            training_data_with_embeddings.parquet when None.
 
     Returns:
         DataFrame with columns: segment_id, audio_embedding_arr (np.ndarray),
-        rainbow_color, source_audio_file, song_slug.
+        rainbow_color, source_audio_file, song_slug, start_seconds, end_seconds.
     """
-    clap = pd.read_parquet(parquet_path)
-    meta = pd.read_parquet(
-        meta_parquet_path,
-        columns=["segment_id", "rainbow_color", "source_audio_file", "song_id"],
+    clap_path = (
+        Path(parquet_path) if parquet_path is not None else _DEFAULT_CLAP_PARQUET
     )
+    meta_path = (
+        Path(meta_parquet_path)
+        if meta_parquet_path is not None
+        else _DEFAULT_META_PARQUET
+    )
+
+    if not clap_path.exists():
+        raise FileNotFoundError(f"CLAP parquet not found: {clap_path}")
+    if not meta_path.exists():
+        raise FileNotFoundError(f"Meta parquet not found: {meta_path}")
+
+    clap = pd.read_parquet(clap_path)
+    # Only request columns that actually exist in the meta parquet
+    meta_all_cols = pd.read_parquet(meta_path, columns=None).columns.tolist()
+    load_cols = [c for c in _META_COLUMNS if c in meta_all_cols]
+    meta = pd.read_parquet(meta_path, columns=load_cols)
 
     df = clap[clap["has_audio_embedding"]].merge(meta, on="segment_id", how="inner")
     df = df.dropna(subset=["rainbow_color", "source_audio_file"])
@@ -37,6 +71,12 @@ def load_clap_index(parquet_path: str, meta_parquet_path: str) -> pd.DataFrame:
         lambda v: np.asarray(v, dtype=np.float32)
     )
     df["song_slug"] = df["song_id"]
+
+    # Ensure start/end columns exist even if the meta parquet omits them
+    for col in ("start_seconds", "end_seconds"):
+        if col not in df.columns:
+            df[col] = None
+
     return df.reset_index(drop=True)
 
 
@@ -58,12 +98,14 @@ def retrieve_by_color(df: pd.DataFrame, color: str, top_n: int = 20) -> list[dic
     Args:
         df: DataFrame returned by load_clap_index.
         color: Rainbow color string (e.g. "Red"). Case-insensitive.
-        top_n: Maximum number of results to return.
+        top_n: Maximum number of results to return (must be >= 1).
 
     Returns:
         List of dicts with keys: segment_id, source_audio_file, match,
-        song_slug, color.
+        song_slug, color, start_seconds, end_seconds.
     """
+    top_n = max(1, int(top_n))
+
     mask = df["rainbow_color"].str.lower() == color.lower()
     subset = df[mask]
     if subset.empty:
@@ -82,6 +124,8 @@ def retrieve_by_color(df: pd.DataFrame, color: str, top_n: int = 20) -> list[dic
 
     results = []
     for i, (_, row) in enumerate(rows.iterrows()):
+        start = row.get("start_seconds")
+        end = row.get("end_seconds")
         results.append(
             {
                 "segment_id": row["segment_id"],
@@ -89,6 +133,8 @@ def retrieve_by_color(df: pd.DataFrame, color: str, top_n: int = 20) -> list[dic
                 "match": float(round(score_vals[i], 4)),
                 "song_slug": row["song_slug"],
                 "color": row["rainbow_color"],
+                "start_seconds": float(start) if start is not None else None,
+                "end_seconds": float(end) if end is not None else None,
             }
         )
     return results

--- a/packages/composition/src/white_composition/retrieve_samples.py
+++ b/packages/composition/src/white_composition/retrieve_samples.py
@@ -1,0 +1,94 @@
+"""Chromatic sample retrieval from the precomputed CLAP embedding index.
+
+Usage::
+    df = load_clap_index(clap_parquet_path, meta_parquet_path)
+    results = retrieve_by_color(df, "Red", top_n=20)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def load_clap_index(parquet_path: str, meta_parquet_path: str) -> pd.DataFrame:
+    """Load and join CLAP embeddings with segment metadata.
+
+    Args:
+        parquet_path: Path to training_data_clap_embeddings.parquet
+            (columns: segment_id, audio_embedding, has_audio_embedding)
+        meta_parquet_path: Path to a metadata parquet with at least
+            (segment_id, rainbow_color, source_audio_file, song_id)
+
+    Returns:
+        DataFrame with columns: segment_id, audio_embedding_arr (np.ndarray),
+        rainbow_color, source_audio_file, song_slug.
+    """
+    clap = pd.read_parquet(parquet_path)
+    meta = pd.read_parquet(
+        meta_parquet_path,
+        columns=["segment_id", "rainbow_color", "source_audio_file", "song_id"],
+    )
+
+    df = clap[clap["has_audio_embedding"]].merge(meta, on="segment_id", how="inner")
+    df = df.dropna(subset=["rainbow_color", "source_audio_file"])
+
+    df["audio_embedding_arr"] = df["audio_embedding"].apply(
+        lambda v: np.asarray(v, dtype=np.float32)
+    )
+    df["song_slug"] = df["song_id"]
+    return df.reset_index(drop=True)
+
+
+def _cosine_sim(mat: np.ndarray, centroid: np.ndarray) -> np.ndarray:
+    norms = np.linalg.norm(mat, axis=1, keepdims=True)
+    norms = np.where(norms == 0, 1.0, norms)
+    normed = mat / norms
+    c_norm = np.linalg.norm(centroid)
+    c_unit = centroid / c_norm if c_norm > 0 else centroid
+    return normed @ c_unit
+
+
+def retrieve_by_color(df: pd.DataFrame, color: str, top_n: int = 20) -> list[dict]:
+    """Return the top-N segments whose CLAP audio most matches the given color.
+
+    Matching is cosine similarity to the centroid of all embeddings for that
+    color in the index.  Results are sorted descending by match score.
+
+    Args:
+        df: DataFrame returned by load_clap_index.
+        color: Rainbow color string (e.g. "Red"). Case-insensitive.
+        top_n: Maximum number of results to return.
+
+    Returns:
+        List of dicts with keys: segment_id, source_audio_file, match,
+        song_slug, color.
+    """
+    mask = df["rainbow_color"].str.lower() == color.lower()
+    subset = df[mask]
+    if subset.empty:
+        return []
+
+    mat = np.stack(subset["audio_embedding_arr"].to_numpy())
+    centroid = mat.mean(axis=0)
+    scores = _cosine_sim(mat, centroid)
+
+    # Shift from [-1,1] to [0,1]
+    scores_01 = (scores + 1.0) / 2.0
+
+    top_idx = np.argsort(scores_01)[::-1][:top_n]
+    rows = subset.iloc[top_idx]
+    score_vals = scores_01[top_idx]
+
+    results = []
+    for i, (_, row) in enumerate(rows.iterrows()):
+        results.append(
+            {
+                "segment_id": row["segment_id"],
+                "source_audio_file": row["source_audio_file"],
+                "match": float(round(score_vals[i], 4)),
+                "song_slug": row["song_slug"],
+                "color": row["rainbow_color"],
+            }
+        )
+    return results

--- a/packages/generation/src/white_generation/patterns/bass_patterns.py
+++ b/packages/generation/src/white_generation/patterns/bass_patterns.py
@@ -850,6 +850,104 @@ TEMPLATES_3_4 = [
 ]
 
 # ---------------------------------------------------------------------------
+# 5/4 Templates
+# ---------------------------------------------------------------------------
+# 5/4 = 5 quarter-note beats. Positions 0–4. Common grouping: 3+2 (strong on 1 and 4).
+
+TEMPLATES_5_4 = [
+    # --- Root ---
+    BassPattern(
+        name="five_four_root_sparse",
+        style=BassStyle.ROOT,
+        energy="low",
+        time_sig=(5, 4),
+        description="Root on 1, held entire bar — sparse anchor",
+        notes=[(0, "root", "normal")],
+        note_durations=[5.0],
+    ),
+    BassPattern(
+        name="five_four_root_3_2",
+        style=BassStyle.ROOT,
+        energy="medium",
+        time_sig=(5, 4),
+        description="Root on 1 and 4 — 3+2 grouping feel",
+        notes=[(0, "root", "accent"), (3, "root", "normal")],
+        note_durations=[3.0, 2.0],
+    ),
+    BassPattern(
+        name="five_four_root_pulse",
+        style=BassStyle.ROOT,
+        energy="high",
+        time_sig=(5, 4),
+        description="Root on every beat — driving quarter-note pulse",
+        notes=[
+            (0, "root", "accent"),
+            (1, "root", "normal"),
+            (2, "root", "normal"),
+            (3, "root", "normal"),
+            (4, "root", "normal"),
+        ],
+        note_durations=[1.0, 1.0, 1.0, 1.0, 1.0],
+    ),
+    # --- Pedal ---
+    BassPattern(
+        name="five_four_pedal",
+        style=BassStyle.PEDAL,
+        energy="low",
+        time_sig=(5, 4),
+        description="Root pedal held whole bar",
+        notes=[(0, "root", "normal")],
+        note_durations=[5.0],
+    ),
+    # --- Walking ---
+    BassPattern(
+        name="five_four_walking",
+        style=BassStyle.WALKING,
+        energy="medium",
+        time_sig=(5, 4),
+        description="Walking 5/4 — root, step, 5th, step, approach",
+        notes=[
+            (0, "root", "accent"),
+            (1, "passing_tone", "normal"),
+            (2, "5th", "normal"),
+            (3, "passing_tone", "normal"),
+            (4, "chromatic_approach", "ghost"),
+        ],
+        note_durations=[1.0, 1.0, 1.0, 1.0, 1.0],
+    ),
+    # --- Arpeggiated ---
+    BassPattern(
+        name="five_four_arp",
+        style=BassStyle.ARPEGGIATED,
+        energy="medium",
+        time_sig=(5, 4),
+        description="Triad arpeggio — root, 3rd, 5th, 3rd, root",
+        notes=[
+            (0, "root", "accent"),
+            (1, "3rd", "normal"),
+            (2, "5th", "normal"),
+            (3, "3rd", "normal"),
+            (4, "root", "ghost"),
+        ],
+        note_durations=[1.0, 1.0, 1.0, 1.0, 1.0],
+    ),
+    # --- Syncopated ---
+    BassPattern(
+        name="five_four_synco",
+        style=BassStyle.SYNCOPATED,
+        energy="high",
+        time_sig=(5, 4),
+        description="Syncopated 5/4 — root on 1, 5th on 2.5, root on 4",
+        notes=[
+            (0, "root", "accent"),
+            (2.5, "5th", "normal"),
+            (3, "root", "normal"),
+        ],
+        note_durations=[2.5, 0.5, 2.0],
+    ),
+]
+
+# ---------------------------------------------------------------------------
 # 7/8 Templates
 # ---------------------------------------------------------------------------
 # 7/8 = 3.5 quarter-note beats. Group positions: 0, 1.5, 2.5 (3+2+2 grouping)
@@ -1282,6 +1380,8 @@ ALL_TEMPLATES: list[BassPattern] = [
     *TEMPLATES_4_4_REST_DOWNBEAT,
     # 3/4 (waltz)
     *TEMPLATES_3_4,
+    # 5/4
+    *TEMPLATES_5_4,
     # 6/8 (compound duple)
     *TEMPLATES_6_8,
     # 7/8

--- a/packages/generation/src/white_generation/patterns/drum_patterns.py
+++ b/packages/generation/src/white_generation/patterns/drum_patterns.py
@@ -1714,6 +1714,214 @@ TEMPLATES_3_4_ROCK = [
 ]
 
 # ---------------------------------------------------------------------------
+# 5/4 Templates
+# ---------------------------------------------------------------------------
+# 5/4 = 5 quarter-note beats. Positions: 0 (beat 1) through 4 (beat 5).
+# Common groupings: 3+2 (strong on 1 and 4) or 2+3 (strong on 1 and 3).
+
+TEMPLATES_5_4_CLASSICAL = [
+    DrumPattern(
+        name="classical_5_4_sparse",
+        genre_family="classical",
+        energy="low",
+        time_sig=(5, 4),
+        description="Sparse 5/4 — timpani on 1, ghost tom on 4 (3+2 grouping)",
+        voices={
+            "tom_low": [(0, "normal"), (3, "ghost")],
+        },
+    ),
+    DrumPattern(
+        name="classical_5_4_march",
+        genre_family="classical",
+        energy="medium",
+        time_sig=(5, 4),
+        description="March 5/4 — timpani on 1 and 4, snare on 2 and 3",
+        voices={
+            "tom_low": [(0, "accent"), (3, "normal")],
+            "snare": [(1, "normal"), (2, "normal")],
+        },
+    ),
+    DrumPattern(
+        name="classical_5_4_full",
+        genre_family="classical",
+        energy="high",
+        time_sig=(5, 4),
+        description="Full orchestral 5/4 — crash on 1, timpani on 1/3/4, snare on 2 and 4",
+        voices={
+            "crash": [(0, "accent")],
+            "tom_low": [(0, "accent"), (2, "normal"), (3, "normal")],
+            "snare": [(1, "accent"), (3, "accent")],
+        },
+    ),
+]
+
+TEMPLATES_5_4_ELECTRONIC = [
+    DrumPattern(
+        name="electronic_5_4_minimal",
+        genre_family="electronic",
+        energy="low",
+        time_sig=(5, 4),
+        description="Minimal 5/4 — kick on 1, ghost hat on 3",
+        voices={
+            "kick": [(0, "normal")],
+            "hh_closed": [(2, "ghost")],
+        },
+    ),
+    DrumPattern(
+        name="electronic_5_4_groove",
+        genre_family="electronic",
+        energy="medium",
+        time_sig=(5, 4),
+        description="Electronic 5/4 groove — kick on 1 and 4, snare on 2 and 3, hats on quarters",
+        voices={
+            "kick": [(0, "accent"), (3, "normal")],
+            "snare": [(1, "normal"), (2, "normal")],
+            "hh_closed": [
+                (0, "ghost"),
+                (1, "ghost"),
+                (2, "ghost"),
+                (3, "ghost"),
+                (4, "ghost"),
+            ],
+        },
+    ),
+    DrumPattern(
+        name="electronic_5_4_driving",
+        genre_family="electronic",
+        energy="high",
+        time_sig=(5, 4),
+        description="Driving 5/4 — kick on 1/2/4, snare on 3, eighths on hats",
+        voices={
+            "kick": [(0, "accent"), (1, "normal"), (3, "accent")],
+            "snare": [(2, "accent"), (4, "normal")],
+            "hh_closed": [
+                (0, "normal"),
+                (0.5, "ghost"),
+                (1, "normal"),
+                (1.5, "ghost"),
+                (2, "normal"),
+                (2.5, "ghost"),
+                (3, "normal"),
+                (3.5, "ghost"),
+                (4, "normal"),
+                (4.5, "ghost"),
+            ],
+        },
+    ),
+]
+
+TEMPLATES_5_4_FOLK = [
+    DrumPattern(
+        name="folk_5_4_brushes",
+        genre_family="folk",
+        energy="low",
+        time_sig=(5, 4),
+        description="Folk 5/4 brushes — ghost snare on all five beats, kick on 1",
+        voices={
+            "kick": [(0, "normal")],
+            "snare": [
+                (0, "ghost"),
+                (1, "ghost"),
+                (2, "ghost"),
+                (3, "ghost"),
+                (4, "ghost"),
+            ],
+        },
+    ),
+    DrumPattern(
+        name="folk_5_4_simple",
+        genre_family="folk",
+        energy="medium",
+        time_sig=(5, 4),
+        description="Simple folk 5/4 — kick on 1 and 4, snare on 2 and 3, no hats",
+        voices={
+            "kick": [(0, "accent"), (3, "normal")],
+            "snare": [(1, "normal"), (2, "normal")],
+        },
+    ),
+    DrumPattern(
+        name="folk_5_4_stomp",
+        genre_family="folk",
+        energy="high",
+        time_sig=(5, 4),
+        description="Folk 5/4 stomp — kick on 1, snare on 3 and 4, tambourine eighths",
+        voices={
+            "kick": [(0, "accent")],
+            "snare": [(2, "accent"), (3, "normal")],
+            "tambourine": [
+                (0, "normal"),
+                (0.5, "ghost"),
+                (1, "normal"),
+                (1.5, "ghost"),
+                (2, "normal"),
+                (2.5, "ghost"),
+                (3, "normal"),
+                (3.5, "ghost"),
+                (4, "normal"),
+                (4.5, "ghost"),
+            ],
+        },
+    ),
+]
+
+TEMPLATES_5_4_ROCK = [
+    DrumPattern(
+        name="rock_5_4_sparse",
+        genre_family="rock",
+        energy="low",
+        time_sig=(5, 4),
+        description="Rock 5/4 sparse — kick on 1, ghost snare on 3",
+        voices={
+            "kick": [(0, "normal")],
+            "snare": [(2, "ghost")],
+        },
+        tags=["sparse"],
+    ),
+    DrumPattern(
+        name="rock_5_4_groove",
+        genre_family="rock",
+        energy="medium",
+        time_sig=(5, 4),
+        description="Rock 5/4 groove (3+2) — kick on 1 and 4, snare on 2 and 3, hats on quarters",
+        voices={
+            "kick": [(0, "accent"), (3, "normal")],
+            "snare": [(1, "accent"), (2, "normal")],
+            "hh_closed": [
+                (0, "ghost"),
+                (1, "ghost"),
+                (2, "ghost"),
+                (3, "ghost"),
+                (4, "ghost"),
+            ],
+        },
+    ),
+    DrumPattern(
+        name="rock_5_4_driving",
+        genre_family="rock",
+        energy="high",
+        time_sig=(5, 4),
+        description="Driving rock 5/4 — kick on 1/2/4, snare on 3 and 4, open hat on offbeats",
+        voices={
+            "kick": [(0, "accent"), (1, "normal"), (3, "accent")],
+            "snare": [(2, "accent"), (3, "normal")],
+            "hh_closed": [
+                (0, "normal"),
+                (0.5, "ghost"),
+                (1, "normal"),
+                (1.5, "ghost"),
+                (2, "normal"),
+                (2.5, "ghost"),
+                (3, "normal"),
+                (3.5, "ghost"),
+                (4, "normal"),
+                (4.5, "ghost"),
+            ],
+            "hh_open": [(0.5, "normal"), (2.5, "normal"), (4.5, "normal")],
+        },
+    ),
+]
+
+# ---------------------------------------------------------------------------
 # 4/4 Breakbeat (classic breaks + energy variants)
 # ---------------------------------------------------------------------------
 # Grid mapping: 16th-note positions in quarter-beat floats
@@ -2632,6 +2840,11 @@ ALL_TEMPLATES: list[DrumPattern] = [
     *TEMPLATES_3_4_EXPERIMENTAL,
     *TEMPLATES_3_4_FOLK,
     *TEMPLATES_3_4_ROCK,
+    # 5/4
+    *TEMPLATES_5_4_CLASSICAL,
+    *TEMPLATES_5_4_ELECTRONIC,
+    *TEMPLATES_5_4_FOLK,
+    *TEMPLATES_5_4_ROCK,
     # 4/4 Breakbeat
     *TEMPLATES_4_4_BREAKBEAT,
     # 4/4 Sparse / Atmospheric

--- a/packages/generation/src/white_generation/patterns/melody_patterns.py
+++ b/packages/generation/src/white_generation/patterns/melody_patterns.py
@@ -908,6 +908,79 @@ TEMPLATES_6_8_LEAD = [
     ),
 ]
 
+# ---------------------------------------------------------------------------
+# 5/4 Templates
+# ---------------------------------------------------------------------------
+# 5/4 = 5 quarter-note beats. Positions 0–4. Strong downbeat on 1; common
+# 3+2 grouping makes beat 4 (position 3) a secondary accent.
+
+TEMPLATES_5_4 = [
+    # --- Stepwise ---
+    MelodyPattern(
+        name="five_four_stepwise_sigh",
+        contour="stepwise",
+        energy="low",
+        time_sig=(5, 4),
+        description="Held note, gentle step down, long rest — elegiac 5/4 phrase",
+        intervals=[0, -2, -1, 0, 0],
+        rhythm=[0.0, 1.0, 2.0, 3.0, 4.0],
+        durations=[1.0, 1.0, 1.0, 0.5, 0.5],
+    ),
+    MelodyPattern(
+        name="five_four_stepwise_rise",
+        contour="stepwise",
+        energy="medium",
+        time_sig=(5, 4),
+        description="Ascending step across 5 beats — questioning phrase",
+        intervals=[0, 2, 1, 2, -1],
+        rhythm=[0.0, 1.0, 2.0, 3.0, 4.0],
+        durations=[1.0, 1.0, 1.0, 1.0, 1.0],
+    ),
+    # --- Arpeggiated ---
+    MelodyPattern(
+        name="five_four_arp_lift",
+        contour="arpeggiated",
+        energy="medium",
+        time_sig=(5, 4),
+        description="Triad arpeggio up and back over 5 beats",
+        intervals=[0, 4, 3, -3, -4],
+        rhythm=[0.0, 1.0, 2.0, 3.0, 4.0],
+        durations=[1.0, 1.0, 1.0, 1.0, 1.0],
+    ),
+    MelodyPattern(
+        name="five_four_arp_fall",
+        contour="arpeggiated",
+        energy="low",
+        time_sig=(5, 4),
+        description="Falling arpeggio — high note drifting down across 5 beats",
+        intervals=[0, -3, -4, -2, 0],
+        rhythm=[0.0, 1.0, 2.0, 3.0, 4.0],
+        durations=[1.0, 1.0, 1.0, 1.0, 1.0],
+    ),
+    # --- Pentatonic ---
+    MelodyPattern(
+        name="five_four_penta_run",
+        contour="pentatonic",
+        energy="high",
+        time_sig=(5, 4),
+        description="Pentatonic run across 5/4 bar with eighths",
+        intervals=[0, 2, 3, 2, -2, 3, -3, -2, 0],
+        rhythm=[0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 3.5, 4.0, 4.5],
+        durations=[0.5, 0.5, 0.5, 0.5, 1.0, 0.5, 0.5, 0.5, 0.5],
+    ),
+    # --- Repeated ---
+    MelodyPattern(
+        name="five_four_motif_rest",
+        contour="repeated",
+        energy="low",
+        time_sig=(5, 4),
+        description="Three-note motif, two beats rest — 5/4 breath",
+        intervals=[0, 2, -1, 0, 0],
+        rhythm=[0.0, 0.5, 1.0, 1.5, 3.0],
+        durations=[0.5, 0.5, 0.5, 1.5, 2.0],
+    ),
+]
+
 _EXISTING_LEAD_TEMPLATES: list[MelodyPattern] = [
     *TEMPLATES_4_4_STEPWISE,
     *TEMPLATES_4_4_ARPEGGIATED,
@@ -916,6 +989,7 @@ _EXISTING_LEAD_TEMPLATES: list[MelodyPattern] = [
     *TEMPLATES_4_4_PENTATONIC,
     *TEMPLATES_4_4_SCALAR,
     *TEMPLATES_3_4,
+    *TEMPLATES_5_4,
     *TEMPLATES_7_8,
     *TEMPLATES_6_8_LEAD,
 ]
@@ -1681,6 +1755,53 @@ VOCAL_4_4_LAMENTFUL = [
 ]
 
 
+VOCAL_5_4 = [
+    MelodyPattern(
+        name="vocal_5_4_held_sigh",
+        contour="call_and_rest",
+        use_case="vocal",
+        energy="low",
+        time_sig=(5, 4),
+        description="5/4 held sigh — long held note, rest, step down",
+        intervals=[0, -2],
+        rhythm=[0.0, 3.0],
+        durations=[2.0, 2.0],
+    ),
+    MelodyPattern(
+        name="vocal_5_4_phrase",
+        contour="declarative",
+        use_case="vocal",
+        energy="medium",
+        time_sig=(5, 4),
+        description="5/4 phrase — held opener, breath, three-note resolution",
+        intervals=[0, 2, -1, -2],
+        rhythm=[0.0, 2.0, 3.0, 4.0],
+        durations=[1.5, 0.5, 0.5, 0.5],
+    ),
+    MelodyPattern(
+        name="vocal_5_4_surge",
+        contour="declarative",
+        use_case="vocal",
+        energy="high",
+        time_sig=(5, 4),
+        description="5/4 surge — held opener, breath, three-note ascending release",
+        intervals=[0, 2, 1, -2],
+        rhythm=[0.0, 2.5, 3.0, 4.0],
+        durations=[2.0, 0.5, 1.0, 0.5],
+    ),
+    MelodyPattern(
+        name="vocal_5_4_motif",
+        contour="haiku",
+        use_case="vocal",
+        energy="low",
+        time_sig=(5, 4),
+        description="5/4 haiku — short motif, breath, long held resolution",
+        intervals=[0, 2, -1],
+        rhythm=[0.0, 0.5, 1.5],
+        durations=[0.5, 0.5, 3.5],
+    ),
+]
+
 ALL_TEMPLATES: list[MelodyPattern] = [
     # Existing templates reclassified as lead (instrument tracks)
     *_EXISTING_LEAD_TEMPLATES,
@@ -1695,6 +1816,7 @@ ALL_TEMPLATES: list[MelodyPattern] = [
     *VOCAL_4_4_DOTTED,
     # New vocal templates for other time signatures
     *VOCAL_3_4,
+    *VOCAL_5_4,
     *VOCAL_6_8,
     *VOCAL_7_8,
     # 4/4 Lamentful / Sparse

--- a/packages/generation/tests/test_bass_patterns.py
+++ b/packages/generation/tests/test_bass_patterns.py
@@ -303,7 +303,7 @@ class TestTemplateSelection:
             select_templates,
         )
 
-        result = select_templates(ALL_TEMPLATES, (5, 4), "medium")
+        result = select_templates(ALL_TEMPLATES, (11, 8), "medium")
         assert len(result) == 0
 
     def test_6_8_templates_exist(self):

--- a/packages/generation/tests/test_melody_patterns.py
+++ b/packages/generation/tests/test_melody_patterns.py
@@ -389,7 +389,7 @@ class TestTemplateSelection:
             select_templates,
         )
 
-        results = select_templates(ALL_TEMPLATES, (5, 4), "medium")
+        results = select_templates(ALL_TEMPLATES, (11, 8), "medium")
         assert len(results) == 0
 
     def test_6_8_lead_templates_exist(self):


### PR DESCRIPTION
## Summary

- **add-song-concept-display**: `scan_songs` now reads `concept` from `song_context.yml`; the `/candidates` page renders it in a collapsible 3-line block below the breadcrumb (hidden when null)
- **add-sample-browser-and-quartet** (sample browser): New `white_composition.retrieve_samples` module — `load_clap_index` joins CLAP embeddings with segment metadata; `retrieve_by_color` ranks segments by cosine similarity to the color centroid. Three new API endpoints (`GET /samples`, `GET /audio/{id}`, `POST /samples/{id}/export`) and a collapsible Samples panel in the candidate browser with inline `<audio>` player and per-row Export button
- **add-sample-browser-and-quartet** (logic handoff sweep): `handoff()` now copies any WAVs from `production/samples/` into the Logic `Samples/` folder
- **add-sample-browser-and-quartet** (quartet button fix): `canRunQuartet` now treats `quartetStatus === "pending"` as not-started so the button remains visible

The `refactor-song-index-navigation` spec was already fully implemented (all tasks `[x]`).

## Test plan

- [ ] 71 candidate server tests pass (`python -m pytest packages/api/tests/test_candidate_server.py`)
- [ ] 326 composition tests pass (`python -m pytest packages/composition/tests/`)
- [ ] Pre-existing `test_song_dashboard.py::TestBuildTable::test_table_has_correct_column_count` failure unrelated to this branch
- [ ] Concept block: create a `song_context.yml` with `concept:` key, activate song, visit `/candidates` — block appears collapsed at 3 lines with Show more toggle
- [ ] Samples panel: expand the Samples panel, confirm ranked rows with audio player and Export button; Export copies WAV to Logic Samples folder
- [ ] Quartet button: set `quartet: pending` in `song_context.yml`, confirm Generate Quartet button still renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)