### PR TITLE
Fix Chromatic Samples export disabled after Logic handoff

### DIFF
--- a/packages/client/app/candidates/page.tsx
+++ b/packages/client/app/candidates/page.tsx
@@ -643,8 +643,8 @@ export default function CandidatesPage() {
                       <td className="px-3 py-2">
                         <button
                           onClick={() => handleExport(s.segment_id)}
-                          disabled={exportedIds.has(s.segment_id) || exportingId === s.segment_id || activeSong?.stage !== "composition"}
-                          title={activeSong?.stage !== "composition" ? "Handoff to Logic first — exports into the Logic project folder" : undefined}
+                          disabled={exportedIds.has(s.segment_id) || exportingId === s.segment_id || !["composition", "production", "mixing", "complete"].includes(activeSong?.stage ?? "")}
+                          title={!["composition", "production", "mixing", "complete"].includes(activeSong?.stage ?? "") ? "Handoff to Logic first — exports into the Logic project folder" : undefined}
                           className="px-2 py-0.5 text-xs rounded font-medium transition-colors bg-zinc-700 hover:bg-zinc-600 text-zinc-200 disabled:opacity-50 disabled:cursor-not-allowed"
                         >
                           {exportedIds.has(s.segment_id) ? "Exported ✓" : exportingId === s.segment_id ? "…" : "Export"}


### PR DESCRIPTION
## Summary

The export button in the Chromatic Samples panel was gated on `activeSong?.stage === "composition"`. Once a song is handed off to Logic and the board's `current_stage` advances to `"recording"`, the song stage becomes `"production"` — so the gate evaluated false and the button stayed disabled even though the Logic project exists and the export is valid.

Fix: gate now allows export for any board stage (`composition | production | mixing | complete`), which matches the original intent of "has a Logic project been created."

## Root cause

Introduced by the stage-gating feature (PR #204) which extended `_compute_stage()` to map mix stages to broader song states. The Chromatic Samples gate wasn't updated to match.

## Test plan

- [x] Hand off a song to Logic (stage advances to `production`)
- [x] Open Candidates page — Chromatic Samples export button is now **enabled**
- [x] Click Export — sample lands in the Logic project folder
- [ ] Songs still in `ideation` or `generation` stage — export button still disabled with correct tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)