### PR TITLE
Fix sample export access and stale stage after handoff

### DIFF
--- a/packages/api/src/white_api/candidate_server.py
+++ b/packages/api/src/white_api/candidate_server.py
@@ -419,6 +419,8 @@ def create_app(
 
     @app.get("/songs/active")
     def get_active_song():
+        if _active_song and _production_dir:
+            _active_song["stage"] = _compute_stage(_production_dir)
         return {"active": _active_song}
 
     def _resolve_song(song_id: str) -> tuple[dict, Path]:
@@ -745,12 +747,25 @@ def create_app(
         }
 
         def _run():
-            global _handoff_job
+            global _handoff_job, _active_song
             try:
                 from white_composition.logic_handoff import handoff
 
                 handoff(prod)
                 _handoff_job["status"] = "done"
+                # Refresh _active_song so stage flips to "composition" immediately.
+                if _shrink_wrapped_dir and _active_song:
+                    song_id = _active_song.get("id")
+                    refreshed = next(
+                        (
+                            s
+                            for s in scan_songs(_shrink_wrapped_dir)
+                            if s["id"] == song_id
+                        ),
+                        None,
+                    )
+                    if refreshed:
+                        _active_song = refreshed
             except Exception as exc:
                 _handoff_job["status"] = "error"
                 _handoff_job["error"] = str(exc)

--- a/packages/client/app/board/page.tsx
+++ b/packages/client/app/board/page.tsx
@@ -642,6 +642,9 @@ export default function BoardPage() {
         <Link href="/" className="text-zinc-500 hover:text-zinc-300 text-xs font-sans transition-colors">
           ← home
         </Link>
+        <Link href="/candidates" className="text-zinc-500 hover:text-zinc-300 text-xs font-sans transition-colors">
+          samples
+        </Link>
         <h1 className="text-lg font-bold text-white tracking-tight">Composition Board</h1>
         {activeSong && (
           <Link href="/" className="text-zinc-500 hover:text-zinc-300 text-xs font-sans ml-2 truncate transition-colors" title="Switch song">


### PR DESCRIPTION
## Summary

- Added a **"samples" link** in the board page header so songs at composition stage or higher can reach `/candidates` (and its sample export UI) without going back through the song index re-activation flow
- `/songs/active` now calls `_compute_stage` on every request rather than returning a cached value, so export buttons unlock the moment `composition.yml` exists after handoff — no server restart needed
- The handoff background thread now refreshes `_active_song` on success, ensuring stage changes propagate immediately to all API consumers

## Test plan

- [x] Activate a song at generation stage, run Handoff to Logic, confirm export buttons enable without restarting the server
- [x] From board page, click "samples" → confirm `/candidates` loads with the correct active song and export buttons enabled
- [x] Confirm existing 99 API tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)