### PR TITLE
Sync artist catalog: bulk generation, bug fixes, chromatic scoring

### DIFF
--- a/packages/client/app/board/page.tsx
+++ b/packages/client/app/board/page.tsx
@@ -643,7 +643,7 @@ export default function BoardPage() {
           ← home
         </Link>
         <Link href="/candidates" className="text-zinc-500 hover:text-zinc-300 text-xs font-sans transition-colors">
-          samples
+          candidate view
         </Link>
         <h1 className="text-lg font-bold text-white tracking-tight">Composition Board</h1>
         {activeSong && (

--- a/packages/generation/src/white_generation/artist_catalog.py
+++ b/packages/generation/src/white_generation/artist_catalog.py
@@ -150,7 +150,12 @@ def _append_entry(
     tags_yaml = yaml.dump(style_tags, default_flow_style=True).strip()
 
     # Safely quote artist name if it contains special chars (e.g. "Songs: Ohia")
-    raw_dump = yaml.dump({artist_name: None}, default_flow_style=False)
+    raw_dump = yaml.dump(
+        {artist_name: None},
+        default_flow_style=False,
+        allow_unicode=True,
+        width=float("inf"),
+    )
     # raw_dump looks like "'Songs: Ohia': null\n" — strip trailing ": null\n"
     key = raw_dump.rstrip("\n").removesuffix(": null")
 
@@ -354,9 +359,8 @@ def score_chromatic(
             skipped += 1
             continue
 
-        results = scorer.score_batch(
-            [{"lyric_text": description}], concept_text=description
-        )
+        desc_emb = scorer.prepare_concept(description)
+        results = scorer.score_batch([{}], concept_emb=desc_emb, lyric_emb=desc_emb)
         result = results[0]
         entry["chromatic_score"] = {
             "temporal": {k: round(float(v), 4) for k, v in result["temporal"].items()},

--- a/packages/generation/src/white_generation/artist_catalog.py
+++ b/packages/generation/src/white_generation/artist_catalog.py
@@ -149,8 +149,10 @@ def _append_entry(
 
     tags_yaml = yaml.dump(style_tags, default_flow_style=True).strip()
 
-    # Safely quote artist name if it contains special chars
-    key = yaml.dump({artist_name: None}, default_flow_style=False).split(":")[0]
+    # Safely quote artist name if it contains special chars (e.g. "Songs: Ohia")
+    raw_dump = yaml.dump({artist_name: None}, default_flow_style=False)
+    # raw_dump looks like "'Songs: Ohia': null\n" — strip trailing ": null\n"
+    key = raw_dump.rstrip("\n").removesuffix(": null")
 
     discogs_str = str(discogs_id) if discogs_id is not None else "null"
 
@@ -352,7 +354,9 @@ def score_chromatic(
             skipped += 1
             continue
 
-        results = scorer.score_batch([{"lyric_text": description}])
+        results = scorer.score_batch(
+            [{"lyric_text": description}], concept_text=description
+        )
         result = results[0]
         entry["chromatic_score"] = {
             "temporal": {k: round(float(v), 4) for k, v in result["temporal"].items()},

--- a/packages/ideation/src/white_ideation/reference/music/artist_catalog.yml
+++ b/packages/ideation/src/white_ideation/reference/music/artist_catalog.yml
@@ -1,3276 +1,10454 @@
 David Bowie:
   slug: david_bowie
   status: draft
-  description: 'Bowie''s work is primarily vocal, with a chameleonic voice capable of theatrical baritone warmth, brittle
-    falsetto, and unsettling mid-range detachment. Productions shift across eras—glam rock arrangements feature layered electric
-    guitars, saxophone, and synthetic glitter; Berlin-period work embraces cold, processed ambience, sparse electronic textures,
-    and heavily treated instrumental passages. Studio approaches frequently fragment conventional song structure, layering
-    found sounds, cut-up vocal phrasing, and dense overdubbing. Lyrically, themes orbit identity dissolution, alien alienation,
-    urban isolation, transformation, mortality, and the instability of selfhood. Imagery tends toward the cinematic and surreal—dystopian
-    cityscapes, masked personas, occult and science-fiction references—rendered in oblique, non-linear language. The emotional
-    register oscillates between detached irony and raw existential vulnerability, often simultaneously. Mood ranges from euphoric
-    theatrical spectacle to claustrophobic introspection, with an underlying psychological tension suggesting identity as
-    performance rather than fixed state.
+  description: 'Bowie''s work is primarily vocal, with a chameleonic voice capable
+    of theatrical baritone warmth, brittle falsetto, and unsettling mid-range detachment.
+    Productions shift across eras—glam rock arrangements feature layered electric
+    guitars, saxophone, and synthetic glitter; Berlin-period work embraces cold, processed
+    ambience, sparse electronic textures, and heavily treated instrumental passages.
+    Studio approaches frequently fragment conventional song structure, layering found
+    sounds, cut-up vocal phrasing, and dense overdubbing. Lyrically, themes orbit
+    identity dissolution, alien alienation, urban isolation, transformation, mortality,
+    and the instability of selfhood. Imagery tends toward the cinematic and surreal—dystopian
+    cityscapes, masked personas, occult and science-fiction references—rendered in
+    oblique, non-linear language. The emotional register oscillates between detached
+    irony and raw existential vulnerability, often simultaneously. Mood ranges from
+    euphoric theatrical spectacle to claustrophobic introspection, with an underlying
+    psychological tension suggesting identity as performance rather than fixed state.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4518
+      present: 0.2479
+      future: 0.3004
+    spatial:
+      thing: 0.4527
+      place: 0.3003
+      person: 0.247
+    ontological:
+      imagined: 0.3527
+      forgotten: 0.2846
+      known: 0.3626
+    confidence: 0.0253
   discogs_id: 10263
   notes: ''
 Broadcast:
   slug: broadcast
   status: draft
-  description: 'Broadcast occupies a spectral intersection of vintage analogue warmth and cool psychedelic distance. Production
-    is dense yet airily spacious, layering mellotrons, oscillators, treated percussion, and lo-fi tape textures into a nostalgic
-    but uncanny sonic palette. Sounds feel simultaneously retro and synthetic, with a haunted library-music quality. Vocals
-    are primarily female, delivered in a detached, softly hypnotic register that functions almost as another textural instrument.
-    Lyrically, themes circle around dream states, hidden knowledge, altered perception, memory distortion, and the uncanny
-    — imagery drawn from folklore, the occult, and interior psychological landscapes. The emotional register is melancholic
-    and quietly unsettling, evoking a sense of familiar strangeness: warmth hollowed by unease, intimacy held at clinical
-    remove. Compositions balance song structures with abstract, near-instrumental passages, creating an overall mood of suspended,
+  description: 'Broadcast occupies a spectral intersection of vintage analogue warmth
+    and cool psychedelic distance. Production is dense yet airily spacious, layering
+    mellotrons, oscillators, treated percussion, and lo-fi tape textures into a nostalgic
+    but uncanny sonic palette. Sounds feel simultaneously retro and synthetic, with
+    a haunted library-music quality. Vocals are primarily female, delivered in a detached,
+    softly hypnotic register that functions almost as another textural instrument.
+    Lyrically, themes circle around dream states, hidden knowledge, altered perception,
+    memory distortion, and the uncanny — imagery drawn from folklore, the occult,
+    and interior psychological landscapes. The emotional register is melancholic and
+    quietly unsettling, evoking a sense of familiar strangeness: warmth hollowed by
+    unease, intimacy held at clinical remove. Compositions balance song structures
+    with abstract, near-instrumental passages, creating an overall mood of suspended,
     meditative dread tinged with fragile beauty.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4462
+      present: 0.246
+      future: 0.3078
+    spatial:
+      thing: 0.447
+      place: 0.3074
+      person: 0.2457
+    ontological:
+      imagined: 0.3531
+      forgotten: 0.2875
+      known: 0.3595
+    confidence: 0.0288
   discogs_id: 955
   notes: ''
 Nick Cave & The Bad Seeds:
   slug: nick_cave_the_bad_seeds
   status: draft
-  description: 'Nick Cave & The Bad Seeds are a vocal-led ensemble with Cave''s baritone voice as the central instrument.
-    Sonically, the work spans sparse, mournful arrangements featuring piano, droning strings, and minimal percussion, alongside
-    denser, distorted rock textures with churning guitar and propulsive rhythm sections. Production often emphasizes space
-    and decay, lending recordings an austere, cathedral-like quality. Lyrically, the work draws heavily on biblical imagery,
-    Southern Gothic landscapes, mortality, erotic obsession, grief, and redemption — rendered through narrative-driven songwriting
-    with a preacher-like cadence. Recurring imagery includes deserts, rivers, violence, and divine absence. The emotional
-    register is intense and brooding, oscillating between ecstatic fervor and desolate lamentation, with a strong undercurrent
-    of existential yearning. Darkness and tenderness coexist, creating a psychological atmosphere that is simultaneously confessional
-    and mythological.
+  description: 'Nick Cave & The Bad Seeds are a vocal-led ensemble with Cave''s baritone
+    voice as the central instrument. Sonically, the work spans sparse, mournful arrangements
+    featuring piano, droning strings, and minimal percussion, alongside denser, distorted
+    rock textures with churning guitar and propulsive rhythm sections. Production
+    often emphasizes space and decay, lending recordings an austere, cathedral-like
+    quality. Lyrically, the work draws heavily on biblical imagery, Southern Gothic
+    landscapes, mortality, erotic obsession, grief, and redemption — rendered through
+    narrative-driven songwriting with a preacher-like cadence. Recurring imagery includes
+    deserts, rivers, violence, and divine absence. The emotional register is intense
+    and brooding, oscillating between ecstatic fervor and desolate lamentation, with
+    a strong undercurrent of existential yearning. Darkness and tenderness coexist,
+    creating a psychological atmosphere that is simultaneously confessional and mythological.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4039
+      present: 0.2763
+      future: 0.3198
+    spatial:
+      thing: 0.4049
+      place: 0.3194
+      person: 0.2757
+    ontological:
+      imagined: 0.3481
+      forgotten: 0.3063
+      known: 0.3456
+    confidence: 0.018
   discogs_id: 36665
   notes: ''
 Blue Orchids:
   slug: blue_orchids
   status: draft
-  description: 'Blue Orchids occupy a dense, reverberant sonic space where post-punk austerity meets psychedelic drift. Their
-    production carries a raw, lo-fi warmth — guitars shimmer with tremolo and feedback while keyboards layer an organ-drenched
-    murk beneath. The overall texture feels simultaneously claustrophobic and expansive, as though recorded in a vast, decaying
-    room. Vocals are central and delivered with incantatory, slightly detached intensity, occupying a dreamlike register between
-    speech and song. Lyrically, imagery tends toward the uncanny, the domestic made strange, with undertones of spiritual
-    unease and fractured perception — everyday scenes rendered hallucinatory. Themes circle obsession, dissolution, and a
-    vaguely mystical yearning. The emotional register is melancholic yet unsettled, evoking grey urban landscapes inhabited
-    by interior visions. The approach is emphatically vocal-led, with instrumental passages serving atmospheric and textural
-    functions rather than structural prominence.
+  description: 'Blue Orchids occupy a dense, reverberant sonic space where post-punk
+    austerity meets psychedelic drift. Their production carries a raw, lo-fi warmth
+    — guitars shimmer with tremolo and feedback while keyboards layer an organ-drenched
+    murk beneath. The overall texture feels simultaneously claustrophobic and expansive,
+    as though recorded in a vast, decaying room. Vocals are central and delivered
+    with incantatory, slightly detached intensity, occupying a dreamlike register
+    between speech and song. Lyrically, imagery tends toward the uncanny, the domestic
+    made strange, with undertones of spiritual unease and fractured perception — everyday
+    scenes rendered hallucinatory. Themes circle obsession, dissolution, and a vaguely
+    mystical yearning. The emotional register is melancholic yet unsettled, evoking
+    grey urban landscapes inhabited by interior visions. The approach is emphatically
+    vocal-led, with instrumental passages serving atmospheric and textural functions
+    rather than structural prominence.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4199
+      present: 0.2655
+      future: 0.3146
+    spatial:
+      thing: 0.4208
+      place: 0.3143
+      person: 0.2649
+    ontological:
+      imagined: 0.3456
+      forgotten: 0.3014
+      known: 0.353
+    confidence: 0.03
   discogs_id: 198410
   notes: ''
 Siouxsie & The Banshees:
   slug: siouxsie_the_banshees
   status: draft
-  description: 'Siouxsie & The Banshees craft a predominantly vocal-led sound, with Siouxsie Sioux''s dramatic, keening soprano
-    anchoring dense, layered arrangements. Guitars favour sharp, trebly jangle and dissonant arpeggios over distortion, often
-    processed with heavy reverb and echo, creating cavernous spatial depth. Bass lines are melodic and prominent; percussion
-    is crisp, tribal, or mechanically precise depending on era. Production tends toward cold, atmospheric density — synthetic
+  description: 'Siouxsie & The Banshees craft a predominantly vocal-led sound, with
+    Siouxsie Sioux''s dramatic, keening soprano anchoring dense, layered arrangements.
+    Guitars favour sharp, trebly jangle and dissonant arpeggios over distortion, often
+    processed with heavy reverb and echo, creating cavernous spatial depth. Bass lines
+    are melodic and prominent; percussion is crisp, tribal, or mechanically precise
+    depending on era. Production tends toward cold, atmospheric density — synthetic
     textures and studio effects deepen a sense of unreality.
 
 
-    Lyrically, themes circle obsession, alienation, altered perception, predatory relationships, and psychological fragmentation.
-    Imagery draws on the gothic, the oneiric, and the macabre, delivered with theatrical detachment rather than confessional
+    Lyrically, themes circle obsession, alienation, altered perception, predatory
+    relationships, and psychological fragmentation. Imagery draws on the gothic, the
+    oneiric, and the macabre, delivered with theatrical detachment rather than confessional
     warmth.
 
 
-    The emotional register is one of controlled menace and icy melancholy, occasionally releasing into euphoric disorientation.
-    The affect is cinematic and unsettling — dark romanticism filtered through post-punk severity and psychedelic unease.
+    The emotional register is one of controlled menace and icy melancholy, occasionally
+    releasing into euphoric disorientation. The affect is cinematic and unsettling
+    — dark romanticism filtered through post-punk severity and psychedelic unease.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.44
+      present: 0.254
+      future: 0.306
+    spatial:
+      thing: 0.441
+      place: 0.3058
+      person: 0.2531
+    ontological:
+      imagined: 0.346
+      forgotten: 0.2933
+      known: 0.3607
+    confidence: 0.0262
   discogs_id: 80501
   notes: ''
 Bauhaus:
   slug: bauhaus
   status: draft
-  description: 'Bauhaus occupies a sonic space of skeletal, cavernous post-punk architecture. Production is deliberately sparse
-    yet dramatically textured — guitars treated with metallic scraping and reverberant decay, bass lines thick and propulsive
-    beneath hollow drum resonance, with liberal use of echo and tape manipulation creating vast negative space. The overall
-    density shifts between stark minimalism and lurching, distorted surges.
+  description: 'Bauhaus occupies a sonic space of skeletal, cavernous post-punk architecture.
+    Production is deliberately sparse yet dramatically textured — guitars treated
+    with metallic scraping and reverberant decay, bass lines thick and propulsive
+    beneath hollow drum resonance, with liberal use of echo and tape manipulation
+    creating vast negative space. The overall density shifts between stark minimalism
+    and lurching, distorted surges.
 
 
-    Lyrically, imagery draws heavily from gothic romanticism, occultism, decay, vampiric mythology, existential alienation,
-    and transgressive sexuality. Tone is theatrical and incantatory, language often elliptical and image-driven rather than
-    narrative.
+    Lyrically, imagery draws heavily from gothic romanticism, occultism, decay, vampiric
+    mythology, existential alienation, and transgressive sexuality. Tone is theatrical
+    and incantatory, language often elliptical and image-driven rather than narrative.
 
 
-    The emotional register is darkly seductive — brooding, ritualistic, carnivalesque at moments, with an underlying tension
-    between eroticism and dread. Psychological colour is shadowed and intense, carrying theatrical menace without collapsing
+    The emotional register is darkly seductive — brooding, ritualistic, carnivalesque
+    at moments, with an underlying tension between eroticism and dread. Psychological
+    colour is shadowed and intense, carrying theatrical menace without collapsing
     into self-parody.
 
 
-    Primarily a vocal-centred band, with the voice delivered in dramatic, declamatory registers ranging from whispered intimacy
-    to theatrical projection.
+    Primarily a vocal-centred band, with the voice delivered in dramatic, declamatory
+    registers ranging from whispered intimacy to theatrical projection.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4169
+      present: 0.2644
+      future: 0.3188
+    spatial:
+      thing: 0.4175
+      place: 0.3183
+      person: 0.2642
+    ontological:
+      imagined: 0.3387
+      forgotten: 0.3054
+      known: 0.3559
+    confidence: 0.0139
   discogs_id: 85897
   notes: ''
 Neu!:
   slug: neu
   status: draft
-  description: 'Neu! occupies a largely instrumental space, with vocals appearing sparingly and functioning more as textural
-    elements than narrative vehicles. Production is characterized by clean, hypnotic repetition — motorik drum patterns lock
-    into an unwavering forward pulse beneath gently evolving guitar and synthesizer layers. Density remains deliberately restrained;
-    space itself becomes a sonic material. Studio treatment is crisp and dry, avoiding reverb saturation in favor of a stark,
-    mechanical warmth. When thematic content surfaces, it gravitates toward motion, openness, and traversal — the sensation
-    of passing through landscapes or time rather than arriving anywhere. The emotional register is simultaneously detached
-    and meditative, carrying an understated optimism alongside cool, slightly mechanical serenity. There is no anxiety or
-    urgency despite the relentless rhythmic drive; instead, a trance-like acceptance pervades, as though movement itself is
-    sufficient purpose.
+  description: 'Neu! occupies a largely instrumental space, with vocals appearing
+    sparingly and functioning more as textural elements than narrative vehicles. Production
+    is characterized by clean, hypnotic repetition — motorik drum patterns lock into
+    an unwavering forward pulse beneath gently evolving guitar and synthesizer layers.
+    Density remains deliberately restrained; space itself becomes a sonic material.
+    Studio treatment is crisp and dry, avoiding reverb saturation in favor of a stark,
+    mechanical warmth. When thematic content surfaces, it gravitates toward motion,
+    openness, and traversal — the sensation of passing through landscapes or time
+    rather than arriving anywhere. The emotional register is simultaneously detached
+    and meditative, carrying an understated optimism alongside cool, slightly mechanical
+    serenity. There is no anxiety or urgency despite the relentless rhythmic drive;
+    instead, a trance-like acceptance pervades, as though movement itself is sufficient
+    purpose.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4517
+      present: 0.2461
+      future: 0.3022
+    spatial:
+      thing: 0.4527
+      place: 0.3021
+      person: 0.2452
+    ontological:
+      imagined: 0.3564
+      forgotten: 0.2866
+      known: 0.357
+    confidence: 0.0445
   discogs_id: 12636
   notes: ''
 Solid Space (2):
   slug: solid_space_2
   status: draft
-  description: Heavily influenced by BBC sci-fi, Solid Space create a minimal guitar and synth sound that has touches of pre-darkwave
-    and post-psychedelia. Their only album, "Space Museum", is a cult classic that has been cited as an influence by many
-    artists in the darkwave and post-punk scenes. The music is characterized by its sparse arrangements, eerie atmospheres,
-    and sci-fi themes. Vocals are often processed with reverb and delay, adding to the otherworldly feel of the music. Lyrically,
-    the band explores themes of space travel, alien encounters, and futuristic dystopias. The emotional register is one of
-    detached melancholy, evoking a sense of isolation and longing for connection in an uncaring universe.
+  description: Heavily influenced by BBC sci-fi, Solid Space create a minimal guitar
+    and synth sound that has touches of pre-darkwave and post-psychedelia. Their only
+    album, "Space Museum", is a cult classic that has been cited as an influence by
+    many artists in the darkwave and post-punk scenes. The music is characterized
+    by its sparse arrangements, eerie atmospheres, and sci-fi themes. Vocals are often
+    processed with reverb and delay, adding to the otherworldly feel of the music.
+    Lyrically, the band explores themes of space travel, alien encounters, and futuristic
+    dystopias. The emotional register is one of detached melancholy, evoking a sense
+    of isolation and longing for connection in an uncaring universe.
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.427
+      present: 0.2582
+      future: 0.3148
+    spatial:
+      thing: 0.4284
+      place: 0.314
+      person: 0.2576
+    ontological:
+      imagined: 0.3579
+      forgotten: 0.2959
+      known: 0.3462
+    confidence: 0.0357
   discogs_id: 448701
   notes: Unknown artist — fill description manually
 Joe Meek:
   slug: joe_meek
   status: draft
-  description: 'Joe Meek''s productions are densely layered with compressed, saturated sonic textures — reverb-drenched drums,
-    heavily processed vocals, and a distinctive lo-fi warmth born of unconventional studio techniques. Echo and electronic
-    manipulation create an otherworldly, almost claustrophobic atmosphere, where sounds feel simultaneously intimate and alien.
-    Instrumentation tends toward bright, trebly guitar tones, punchy bass lines, and mechanical rhythmic propulsion. Thematically,
-    the work gravitates toward outer space, futurism, yearning, and romantic longing — imagery of stars, distance, and emotional
-    isolation recurring frequently. Vocally, productions alternate between solo singers and group harmonies, typically male-voiced,
-    with an earnest, wide-eyed delivery. The emotional register is haunted and bittersweet, carrying undertones of melancholy
-    beneath surface-level pop brightness — a tension between excitement and unease. The overall aesthetic feels like nostalgia
-    for an imagined future, emotionally raw yet sonically stylised.
+  description: 'Joe Meek''s productions are densely layered with compressed, saturated
+    sonic textures — reverb-drenched drums, heavily processed vocals, and a distinctive
+    lo-fi warmth born of unconventional studio techniques. Echo and electronic manipulation
+    create an otherworldly, almost claustrophobic atmosphere, where sounds feel simultaneously
+    intimate and alien. Instrumentation tends toward bright, trebly guitar tones,
+    punchy bass lines, and mechanical rhythmic propulsion. Thematically, the work
+    gravitates toward outer space, futurism, yearning, and romantic longing — imagery
+    of stars, distance, and emotional isolation recurring frequently. Vocally, productions
+    alternate between solo singers and group harmonies, typically male-voiced, with
+    an earnest, wide-eyed delivery. The emotional register is haunted and bittersweet,
+    carrying undertones of melancholy beneath surface-level pop brightness — a tension
+    between excitement and unease. The overall aesthetic feels like nostalgia for
+    an imagined future, emotionally raw yet sonically stylised.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4168
+      present: 0.2682
+      future: 0.3151
+    spatial:
+      thing: 0.4177
+      place: 0.3144
+      person: 0.2678
+    ontological:
+      imagined: 0.3484
+      forgotten: 0.3001
+      known: 0.3515
+    confidence: 0.02
   discogs_id: 226551
   notes: ''
 Bruce Haack:
   slug: bruce_haack
   status: draft
-  description: 'Bruce Haack''s sonic world blends primitive analog synthesis with deliberately lo-fi production warmth — oscillators,
-    homemade electronics, and tape manipulation create textures that are simultaneously childlike and unsettling. Drum machines
-    pulse with rigid mechanical candor beneath layers of buzzing, wobbly synthesis. The production carries a handmade intimacy,
-    often sparse yet densely strange.
+  description: 'Bruce Haack''s sonic world blends primitive analog synthesis with
+    deliberately lo-fi production warmth — oscillators, homemade electronics, and
+    tape manipulation create textures that are simultaneously childlike and unsettling.
+    Drum machines pulse with rigid mechanical candor beneath layers of buzzing, wobbly
+    synthesis. The production carries a handmade intimacy, often sparse yet densely
+    strange.
 
 
-    Lyrically and thematically, his work orbits innocence, cosmic consciousness, spiritual transcendence, and the liminal
-    space between childhood wonder and adult mysticism. Imagery tends toward the otherworldly — space, light, transformation,
-    and a kind of benevolent strangeness.
+    Lyrically and thematically, his work orbits innocence, cosmic consciousness, spiritual
+    transcendence, and the liminal space between childhood wonder and adult mysticism.
+    Imagery tends toward the otherworldly — space, light, transformation, and a kind
+    of benevolent strangeness.
 
 
-    Emotionally, the register oscillates between wide-eyed warmth and an eerie, almost dissociative detachment — joyful on
-    the surface with undertones of isolation and eccentricity. There is a persistent quality of sincere naivety coexisting
-    with experimental audacity.
+    Emotionally, the register oscillates between wide-eyed warmth and an eerie, almost
+    dissociative detachment — joyful on the surface with undertones of isolation and
+    eccentricity. There is a persistent quality of sincere naivety coexisting with
+    experimental audacity.
 
 
-    His work is predominantly vocal, with voice functioning as a central compositional instrument alongside synthesized accompaniment.
+    His work is predominantly vocal, with voice functioning as a central compositional
+    instrument alongside synthesized accompaniment.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4229
+      present: 0.2629
+      future: 0.3142
+    spatial:
+      thing: 0.4236
+      place: 0.314
+      person: 0.2624
+    ontological:
+      imagined: 0.3446
+      forgotten: 0.299
+      known: 0.3564
+    confidence: 0.0191
   discogs_id: 26952
   notes: ''
 The Beatles:
   slug: the_beatles
   status: draft
-  description: 'The Beatles are a vocal-forward ensemble blending close harmonies with lead vocals of varying warmth and grit.
-    Production ranges from intimate, dry early recordings to densely layered, psychedelically treated studio constructions
-    featuring tape manipulation, orchestration, and experimental sound design. Sonic textures shift across albums from bright,
-    jangly guitar and driving rhythm sections to lush strings, brass, and electronic timbres. Lyrically, themes encompass
-    romantic longing, introspection, social observation, surreal imagery, existential questioning, and playful wordplay. Tone
-    moves fluidly between earnest sincerity and whimsical absurdism. The emotional register spans jubilant energy, tender
-    vulnerability, melancholy, and wry detachment. Arrangements often balance immediacy with structural surprise—unexpected
-    key shifts, tempo changes, and asymmetric phrasing. The overall character is melodically generous, rhythmically grounded,
-    and sonically curious, with studio space treated as a compositional instrument alongside traditional rock instrumentation.
+  description: 'The Beatles are a vocal-forward ensemble blending close harmonies
+    with lead vocals of varying warmth and grit. Production ranges from intimate,
+    dry early recordings to densely layered, psychedelically treated studio constructions
+    featuring tape manipulation, orchestration, and experimental sound design. Sonic
+    textures shift across albums from bright, jangly guitar and driving rhythm sections
+    to lush strings, brass, and electronic timbres. Lyrically, themes encompass romantic
+    longing, introspection, social observation, surreal imagery, existential questioning,
+    and playful wordplay. Tone moves fluidly between earnest sincerity and whimsical
+    absurdism. The emotional register spans jubilant energy, tender vulnerability,
+    melancholy, and wry detachment. Arrangements often balance immediacy with structural
+    surprise—unexpected key shifts, tempo changes, and asymmetric phrasing. The overall
+    character is melodically generous, rhythmically grounded, and sonically curious,
+    with studio space treated as a compositional instrument alongside traditional
+    rock instrumentation.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.434
+      present: 0.2574
+      future: 0.3086
+    spatial:
+      thing: 0.4348
+      place: 0.3085
+      person: 0.2567
+    ontological:
+      imagined: 0.3459
+      forgotten: 0.2939
+      known: 0.3602
+    confidence: 0.0164
   discogs_id: 82730
   notes: ''
 The Momes:
   slug: the_momes
   status: draft
-  description: The Momes were an unique power trio with an abrasive sound channelling post-punk, psych-prog and avant-rock.
-    Their music oscillated between frenetic outbursts and hypnotic, droning passages, with a raw, lo-fi production aesthetic
-    that emphasized the visceral energy of their performances. Vocals were often shouted or chanted, adding to the primal
-    intensity of their sound. Lyrically, The Momes explored themes of urban decay, existential dread, and surrealism, with
-    a penchant for cryptic and abstract imagery. The emotional register was one of cathartic release, oscillating between
-    aggression and melancholy, creating a sense of controlled chaos that was both unsettling and compelling.
+  description: The Momes were an unique power trio with an abrasive sound channelling
+    post-punk, psych-prog and avant-rock. Their music oscillated between frenetic
+    outbursts and hypnotic, droning passages, with a raw, lo-fi production aesthetic
+    that emphasized the visceral energy of their performances. Vocals were often shouted
+    or chanted, adding to the primal intensity of their sound. Lyrically, The Momes
+    explored themes of urban decay, existential dread, and surrealism, with a penchant
+    for cryptic and abstract imagery. The emotional register was one of cathartic
+    release, oscillating between aggression and melancholy, creating a sense of controlled
+    chaos that was both unsettling and compelling.
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4309
+      present: 0.2621
+      future: 0.307
+    spatial:
+      thing: 0.4326
+      place: 0.3063
+      person: 0.2611
+    ontological:
+      imagined: 0.3722
+      forgotten: 0.2888
+      known: 0.339
+    confidence: 0.0524
   discogs_id: 1416914
   notes: Unknown artist — fill description manually
 Ariel Pink's Haunted Graffiti:
   slug: ariel_pink_s_haunted_graffiti
   status: draft
-  description: 'Ariel Pink''s Haunted Graffiti operates in a vocal-forward lo-fi pop idiom saturated with deliberate tape
-    degradation, hiss, flutter, and warbly analog warmth. Production feels simultaneously dense and dissolving — layers of
-    keyboard, guitar, and drum machine compressed into a murky, bedroom-studio haze where timbres bleed and decay unnaturally.
-    Melodic hooks emerge clearly despite the surface noise, creating tension between accessibility and corrosion.
+  description: 'Ariel Pink''s Haunted Graffiti operates in a vocal-forward lo-fi pop
+    idiom saturated with deliberate tape degradation, hiss, flutter, and warbly analog
+    warmth. Production feels simultaneously dense and dissolving — layers of keyboard,
+    guitar, and drum machine compressed into a murky, bedroom-studio haze where timbres
+    bleed and decay unnaturally. Melodic hooks emerge clearly despite the surface
+    noise, creating tension between accessibility and corrosion.
 
 
-    Lyrically, themes circle suburban unease, nostalgia rendered uncanny, romantic alienation, and fragmented everyday imagery
-    treated with an ironic or detached tone. Surreal non-sequiturs sit alongside earnest sentiment, producing tonal ambiguity
+    Lyrically, themes circle suburban unease, nostalgia rendered uncanny, romantic
+    alienation, and fragmented everyday imagery treated with an ironic or detached
+    tone. Surreal non-sequiturs sit alongside earnest sentiment, producing tonal ambiguity
     — sincerity and parody coexist unresolved.
 
 
-    Emotionally, the register is melancholic yet playful, psychologically murky — evoking half-remembered daydreams, mild
-    dread, and wistful disorientation. The overall affect is deliberately destabilized, hovering between comfort and strangeness,
+    Emotionally, the register is melancholic yet playful, psychologically murky —
+    evoking half-remembered daydreams, mild dread, and wistful disorientation. The
+    overall affect is deliberately destabilized, hovering between comfort and strangeness,
     warmth and unease.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4395
+      present: 0.2538
+      future: 0.3067
+    spatial:
+      thing: 0.4404
+      place: 0.3066
+      person: 0.253
+    ontological:
+      imagined: 0.3492
+      forgotten: 0.2914
+      known: 0.3594
+    confidence: 0.0284
   discogs_id: 284349
   notes: ''
 Lily Vakili:
   slug: lily_vakili
   status: draft
-  description: Lily Vakili works in a vocal-driven rock idiom rooted in the tradition of punk's literary fringe. Production
-    is raw and direct, favouring guitar arrangements that move between jangling clarity and overdriven intensity — a sonic
-    environment that reflects the volatility of the lyrical content rather than smoothing it. Vocals are central and unguarded,
-    delivered with physical urgency and a street-level expressiveness that prioritises emotional truth over technical refinement.
-    The voice moves between controlled melodic phrasing and near-spoken declamation, treating the gap between singing and
-    speech as expressive territory. Lyrically, the work operates in a confessional-poetic register — dense with imagery, drawing
-    on urban experience, desire, loss, and the interior life rendered in immediate, concrete language. Themes circle female
-    agency, creative survival, and the navigation of public and private identity. The emotional register is fierce and exposed,
-    evoking a kind of defiant vulnerability — confrontational in its refusal of distance, demanding attention through the
-    sheer force of its presence.
+  description: Lily Vakili works in a vocal-driven rock idiom rooted in the tradition
+    of punk's literary fringe. Production is raw and direct, favouring guitar arrangements
+    that move between jangling clarity and overdriven intensity — a sonic environment
+    that reflects the volatility of the lyrical content rather than smoothing it.
+    Vocals are central and unguarded, delivered with physical urgency and a street-level
+    expressiveness that prioritises emotional truth over technical refinement. The
+    voice moves between controlled melodic phrasing and near-spoken declamation, treating
+    the gap between singing and speech as expressive territory. Lyrically, the work
+    operates in a confessional-poetic register — dense with imagery, drawing on urban
+    experience, desire, loss, and the interior life rendered in immediate, concrete
+    language. Themes circle female agency, creative survival, and the navigation of
+    public and private identity. The emotional register is fierce and exposed, evoking
+    a kind of defiant vulnerability — confrontational in its refusal of distance,
+    demanding attention through the sheer force of its presence.
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4359
+      present: 0.2493
+      future: 0.3148
+    spatial:
+      thing: 0.4366
+      place: 0.3142
+      person: 0.2491
+    ontological:
+      imagined: 0.3443
+      forgotten: 0.2968
+      known: 0.3589
+    confidence: 0.0268
   discogs_id: 12841037
   notes: Unknown artist — fill description manually
 Dirty Beaches:
   slug: dirty_beaches
   status: draft
-  description: 'Dirty Beaches produces music of dense, lo-fi texture — saturated reverb, crackling tape hiss, and distorted
-    production that evokes decayed urban spaces and late-night isolation. The sonic palette blends rockabilly guitar figures,
-    droning synthesizers, and primitive drum machine patterns into a claustrophobic, hypnotic density. Vocals, when present,
-    are heavily processed and buried within the mix, functioning more as textural elements than melodic focal points; many
-    pieces are largely instrumental or ambient in character. Thematically, the work circles around dislocation, transience,
-    liminal spaces, and a romanticized violence drawn from noir and pulp imagery. The emotional register is persistently melancholic,
-    tense, and nocturnal — evoking alienation, restlessness, and a kind of romantic fatalism. Imagery tends toward highways,
-    motels, anonymous cities, and solitary figures in motion. The overall psychological colour is brooding, cinematic, and
+  description: 'Dirty Beaches produces music of dense, lo-fi texture — saturated reverb,
+    crackling tape hiss, and distorted production that evokes decayed urban spaces
+    and late-night isolation. The sonic palette blends rockabilly guitar figures,
+    droning synthesizers, and primitive drum machine patterns into a claustrophobic,
+    hypnotic density. Vocals, when present, are heavily processed and buried within
+    the mix, functioning more as textural elements than melodic focal points; many
+    pieces are largely instrumental or ambient in character. Thematically, the work
+    circles around dislocation, transience, liminal spaces, and a romanticized violence
+    drawn from noir and pulp imagery. The emotional register is persistently melancholic,
+    tense, and nocturnal — evoking alienation, restlessness, and a kind of romantic
+    fatalism. Imagery tends toward highways, motels, anonymous cities, and solitary
+    figures in motion. The overall psychological colour is brooding, cinematic, and
     emotionally compressed.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4127
+      present: 0.2675
+      future: 0.3199
+    spatial:
+      thing: 0.4137
+      place: 0.3192
+      person: 0.2671
+    ontological:
+      imagined: 0.344
+      forgotten: 0.3061
+      known: 0.3499
+    confidence: 0.0224
   discogs_id: 1352332
   notes: ''
 Dungen:
   slug: dungen
   status: draft
-  description: 'Dungen crafts a dense, psychedelic sonic world rooted in vintage analogue warmth — layered electric guitars,
-    organ, mellotron, and live drums blend into richly textured, slightly hazy productions with a hand-crafted, non-clinical
-    studio character. The arrangements shift fluidly between intricate melodic passages and expansive, reverb-soaked improvisation,
-    giving recordings an organic, almost live-room intimacy despite their complexity. Vocals are present but often treated
-    as another timbral layer rather than a primary narrative vehicle, frequently sung in Swedish, lending an incantatory,
-    phonetic quality to English-speaking listeners. Thematically, the music evokes interior landscape, natural imagery, and
-    contemplative introspection without didactic messaging. The emotional register is predominantly meditative and wistful,
-    occasionally building toward euphoric release through instrumental crescendo. Overall density oscillates between sparse
-    folk-influenced passages and thick, multi-layered psychedelic saturation, maintaining a warmly melancholic psychological
-    colour throughout.
+  description: 'Dungen crafts a dense, psychedelic sonic world rooted in vintage analogue
+    warmth — layered electric guitars, organ, mellotron, and live drums blend into
+    richly textured, slightly hazy productions with a hand-crafted, non-clinical studio
+    character. The arrangements shift fluidly between intricate melodic passages and
+    expansive, reverb-soaked improvisation, giving recordings an organic, almost live-room
+    intimacy despite their complexity. Vocals are present but often treated as another
+    timbral layer rather than a primary narrative vehicle, frequently sung in Swedish,
+    lending an incantatory, phonetic quality to English-speaking listeners. Thematically,
+    the music evokes interior landscape, natural imagery, and contemplative introspection
+    without didactic messaging. The emotional register is predominantly meditative
+    and wistful, occasionally building toward euphoric release through instrumental
+    crescendo. Overall density oscillates between sparse folk-influenced passages
+    and thick, multi-layered psychedelic saturation, maintaining a warmly melancholic
+    psychological colour throughout.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4387
+      present: 0.2533
+      future: 0.308
+    spatial:
+      thing: 0.4396
+      place: 0.3079
+      person: 0.2525
+    ontological:
+      imagined: 0.3457
+      forgotten: 0.2947
+      known: 0.3595
+    confidence: 0.0217
   discogs_id: 352175
   notes: ''
 Momus:
   slug: momus
   status: draft
-  description: 'Momus (Nick Currie) works primarily as a vocal artist, his voice intimate and slightly theatrical, often dry
-    and conversational in delivery. Productions tend toward sparse, meticulous arrangements — chamber pop instrumentation,
-    electronic sequencing, and sampled textures layered with deliberate artificiality. Studio work favors a cool, slightly
-    clinical sonic surface beneath which emotional complexity resides. Lyrically, the work is dense and literary, drawing
-    on European intellectual traditions, erotic surrealism, cultural theory, mythology, and ironic self-mythologizing. Imagery
-    tends toward the cerebral and the perverse, blending the philosophical with the domestic and the transgressive. The emotional
-    register is characteristically detached yet arch — wit functioning as both shield and scalpel — with melancholy and desire
-    filtered through ironic distance. Themes frequently interrogate identity, desire, exoticism, and the performance of selfhood,
-    maintaining a tone that is simultaneously playful and unsettling.
+  description: 'Momus (Nick Currie) works primarily as a vocal artist, his voice intimate
+    and slightly theatrical, often dry and conversational in delivery. Productions
+    tend toward sparse, meticulous arrangements — chamber pop instrumentation, electronic
+    sequencing, and sampled textures layered with deliberate artificiality. Studio
+    work favors a cool, slightly clinical sonic surface beneath which emotional complexity
+    resides. Lyrically, the work is dense and literary, drawing on European intellectual
+    traditions, erotic surrealism, cultural theory, mythology, and ironic self-mythologizing.
+    Imagery tends toward the cerebral and the perverse, blending the philosophical
+    with the domestic and the transgressive. The emotional register is characteristically
+    detached yet arch — wit functioning as both shield and scalpel — with melancholy
+    and desire filtered through ironic distance. Themes frequently interrogate identity,
+    desire, exoticism, and the performance of selfhood, maintaining a tone that is
+    simultaneously playful and unsettling.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4049
+      present: 0.2718
+      future: 0.3233
+    spatial:
+      thing: 0.4056
+      place: 0.323
+      person: 0.2713
+    ontological:
+      imagined: 0.3394
+      forgotten: 0.3105
+      known: 0.3502
+    confidence: 0.0131
   discogs_id: 17592
   notes: ''
 The Charlatans:
   slug: the_charlatans
   status: draft
-  description: 'The Charlatans craft a vocal-led sound built on dense, warm organ tones layered beneath jangly, reverb-soaked
-    guitars and propulsive rhythmic grooves rooted in Mancunian baggy aesthetics fused with psychedelic rock. Production carries
-    an analogue warmth, favouring thick low-midrange textures, punchy drumming, and a slight haze across the mix that evokes
-    sunlit yet melancholic spaces. Lyrically, themes circle romantic ambiguity, dislocation, introspection, and hedonistic
-    escapism, rendered in elliptical, impressionistic imagery that avoids overt narrative clarity. The emotional register
-    balances euphoria against underlying melancholy — communal yet introspective, celebratory yet wistful. Vocals sit prominently
-    in the mix, delivered with a languid, slightly drawling confidence that adds emotional intimacy. The overall palette feels
-    simultaneously expansive and intimate, blending hypnotic repetition with emotional directness, making the music feel both
-    danceable and contemplative.
+  description: 'The Charlatans craft a vocal-led sound built on dense, warm organ
+    tones layered beneath jangly, reverb-soaked guitars and propulsive rhythmic grooves
+    rooted in Mancunian baggy aesthetics fused with psychedelic rock. Production carries
+    an analogue warmth, favouring thick low-midrange textures, punchy drumming, and
+    a slight haze across the mix that evokes sunlit yet melancholic spaces. Lyrically,
+    themes circle romantic ambiguity, dislocation, introspection, and hedonistic escapism,
+    rendered in elliptical, impressionistic imagery that avoids overt narrative clarity.
+    The emotional register balances euphoria against underlying melancholy — communal
+    yet introspective, celebratory yet wistful. Vocals sit prominently in the mix,
+    delivered with a languid, slightly drawling confidence that adds emotional intimacy.
+    The overall palette feels simultaneously expansive and intimate, blending hypnotic
+    repetition with emotional directness, making the music feel both danceable and
+    contemplative.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4181
+      present: 0.2695
+      future: 0.3124
+    spatial:
+      thing: 0.4191
+      place: 0.3123
+      person: 0.2687
+    ontological:
+      imagined: 0.3572
+      forgotten: 0.2988
+      known: 0.344
+    confidence: 0.019
   discogs_id: 49023
   notes: ''
 My Bloody Valentine:
   slug: my_bloody_valentine
   status: draft
-  description: 'My Bloody Valentine operates primarily in the vocal-led space, though vocals are treated as textural instruments
-    rather than melodic focal points, buried beneath dense, layered guitar cascades. Production is characterised by extreme
-    dynamic compression, oscillating pitch through heavy tremolo and whammy-bar manipulation, and a deliberately diffuse,
-    submerged quality — sounds appear smeared across the stereo field, creating an enveloping, almost tactile wall of noise.
-    Timbres blend distortion with softness simultaneously, generating contradiction between abrasion and warmth. Lyrically,
-    themes orbit intimacy, dissolution of self, desire, and psychological ambiguity, rendered through fragmented, impressionistic
-    imagery that resists narrative clarity. Tonal register is emotionally ambivalent — simultaneously yearning and detached,
-    tender and overwhelming, dreamlike yet unsettling. The emotional colour suggests suspension, dissociation, and muted ecstasy,
-    occupying a space between pleasure and disorientation. Rhythmic elements often feel submerged beneath textural layers,
-    contributing to a floating, temporally untethered atmosphere.
+  description: 'My Bloody Valentine operates primarily in the vocal-led space, though
+    vocals are treated as textural instruments rather than melodic focal points, buried
+    beneath dense, layered guitar cascades. Production is characterised by extreme
+    dynamic compression, oscillating pitch through heavy tremolo and whammy-bar manipulation,
+    and a deliberately diffuse, submerged quality — sounds appear smeared across the
+    stereo field, creating an enveloping, almost tactile wall of noise. Timbres blend
+    distortion with softness simultaneously, generating contradiction between abrasion
+    and warmth. Lyrically, themes orbit intimacy, dissolution of self, desire, and
+    psychological ambiguity, rendered through fragmented, impressionistic imagery
+    that resists narrative clarity. Tonal register is emotionally ambivalent — simultaneously
+    yearning and detached, tender and overwhelming, dreamlike yet unsettling. The
+    emotional colour suggests suspension, dissociation, and muted ecstasy, occupying
+    a space between pleasure and disorientation. Rhythmic elements often feel submerged
+    beneath textural layers, contributing to a floating, temporally untethered atmosphere.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.406
+      present: 0.2728
+      future: 0.3212
+    spatial:
+      thing: 0.4066
+      place: 0.321
+      person: 0.2723
+    ontological:
+      imagined: 0.3306
+      forgotten: 0.3125
+      known: 0.3569
+    confidence: 0.0117
   discogs_id: 6516
   notes: ''
 Julian Cope:
   slug: julian_cope
   status: draft
-  description: 'Julian Cope''s sonic world blends psychedelic rock density with post-punk austerity and krautrock motorik
-    pulse. Productions oscillate between cavernous, reverb-drenched atmospheres and brittle, angular arrangements, often layering
-    drones, distorted guitars, and unconventional instrumentation to create an unsettling yet hypnotic texture. The studio
-    approach favours rawness and spatial depth simultaneously, sometimes incorporating ritualistic, repetitive structures.
+  description: 'Julian Cope''s sonic world blends psychedelic rock density with post-punk
+    austerity and krautrock motorik pulse. Productions oscillate between cavernous,
+    reverb-drenched atmospheres and brittle, angular arrangements, often layering
+    drones, distorted guitars, and unconventional instrumentation to create an unsettling
+    yet hypnotic texture. The studio approach favours rawness and spatial depth simultaneously,
+    sometimes incorporating ritualistic, repetitive structures.
 
 
-    Lyrically, Cope operates as a vocal-led artist whose themes traverse pagan mythology, cosmic spirituality, prehistoric
-    landscape, altered consciousness, and political dissent. Imagery draws heavily from ancient British culture, standing
-    stones, shamanic ritual, and an apocalyptic pastoral sensibility. Tone shifts between visionary earnestness and sardonic
-    absurdism.
+    Lyrically, Cope operates as a vocal-led artist whose themes traverse pagan mythology,
+    cosmic spirituality, prehistoric landscape, altered consciousness, and political
+    dissent. Imagery draws heavily from ancient British culture, standing stones,
+    shamanic ritual, and an apocalyptic pastoral sensibility. Tone shifts between
+    visionary earnestness and sardonic absurdism.
 
 
-    The emotional register is psychologically intense — feverish, ecstatic, occasionally paranoid, and deeply interior. There
-    is a restless, searching quality throughout, balancing mystical yearning with earthbound urgency and dark wit.
+    The emotional register is psychologically intense — feverish, ecstatic, occasionally
+    paranoid, and deeply interior. There is a restless, searching quality throughout,
+    balancing mystical yearning with earthbound urgency and dark wit.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4132
+      present: 0.2719
+      future: 0.315
+    spatial:
+      thing: 0.4141
+      place: 0.3148
+      person: 0.2711
+    ontological:
+      imagined: 0.3424
+      forgotten: 0.303
+      known: 0.3546
+    confidence: 0.0152
   discogs_id: 114566
   notes: ''
 Gary Walker & The Rain:
   slug: gary_walker_the_rain
   status: draft
-  description: 'Gary Walker & The Rain''s sound is rooted in 1960s pop-rock, blending jangly guitars, melodic basslines, and
-    straightforward drumming with a vocal style that is earnest and slightly nasal. Production is relatively clean and direct,
-    with a focus on capturing the energy of live performance rather than studio polish. The overall texture is bright and
-    upbeat, with a youthful exuberance that contrasts with occasional lyrical themes of romantic longing and teenage angst.
-    Vocals are central to the sound, often delivered in a call-and-response style between lead and backing singers. Lyrically,
-    the work explores themes of love, heartbreak, and youthful rebellion, rendered in simple, relatable language. The emotional
-    register is predominantly optimistic and energetic, evoking the spirit of 1960s pop culture while maintaining a sense
-    of immediacy and emotional sincerity.
+  description: 'Gary Walker & The Rain''s sound is rooted in 1960s pop-rock, blending
+    jangly guitars, melodic basslines, and straightforward drumming with a vocal style
+    that is earnest and slightly nasal. Production is relatively clean and direct,
+    with a focus on capturing the energy of live performance rather than studio polish.
+    The overall texture is bright and upbeat, with a youthful exuberance that contrasts
+    with occasional lyrical themes of romantic longing and teenage angst. Vocals are
+    central to the sound, often delivered in a call-and-response style between lead
+    and backing singers. Lyrically, the work explores themes of love, heartbreak,
+    and youthful rebellion, rendered in simple, relatable language. The emotional
+    register is predominantly optimistic and energetic, evoking the spirit of 1960s
+    pop culture while maintaining a sense of immediacy and emotional sincerity.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4304
+      present: 0.2573
+      future: 0.3123
+    spatial:
+      thing: 0.4315
+      place: 0.3116
+      person: 0.2569
+    ontological:
+      imagined: 0.3631
+      forgotten: 0.292
+      known: 0.3449
+    confidence: 0.0246
   discogs_id: 369452
   notes: Unknown artist — fill description manually
 The Brian Jonestown Massacre:
   slug: the_brian_jonestown_massacre
   status: draft
-  description: 'The Brian Jonestown Massacre operates primarily as a vocal-led ensemble layered over dense, reverb-saturated
-    instrumentation. Production favours a lo-fi, occasionally murky aesthetic — guitars shimmer with tremolo and fuzz, sitars
-    and tambourines add ritualistic texture, and drums carry a sluggish, hypnotic weight. The overall sonic density ranges
-    from droning psychedelic walls to sparse, brittle folk arrangements. Lyrics tend toward introspective dissolution, spiritual
-    seeking, interpersonal alienation, and altered states of consciousness, often filtered through imagery evoking decay,
-    longing, and transcendence. Tone is frequently detached and incantatory rather than emotionally confessional. The emotional
-    register is predominantly melancholic, dissociative, and hazy — a psychological palette of sedated yearning and restless
-    nihilism. Studio approaches embrace tape warmth, slight distortion, and deliberate imperfection, creating a time-blurred
-    atmosphere that references late-1960s psychedelia while maintaining a rawer, more confrontational undercurrent.
+  description: 'The Brian Jonestown Massacre operates primarily as a vocal-led ensemble
+    layered over dense, reverb-saturated instrumentation. Production favours a lo-fi,
+    occasionally murky aesthetic — guitars shimmer with tremolo and fuzz, sitars and
+    tambourines add ritualistic texture, and drums carry a sluggish, hypnotic weight.
+    The overall sonic density ranges from droning psychedelic walls to sparse, brittle
+    folk arrangements. Lyrics tend toward introspective dissolution, spiritual seeking,
+    interpersonal alienation, and altered states of consciousness, often filtered
+    through imagery evoking decay, longing, and transcendence. Tone is frequently
+    detached and incantatory rather than emotionally confessional. The emotional register
+    is predominantly melancholic, dissociative, and hazy — a psychological palette
+    of sedated yearning and restless nihilism. Studio approaches embrace tape warmth,
+    slight distortion, and deliberate imperfection, creating a time-blurred atmosphere
+    that references late-1960s psychedelia while maintaining a rawer, more confrontational
+    undercurrent.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4331
+      present: 0.2562
+      future: 0.3107
+    spatial:
+      thing: 0.434
+      place: 0.3105
+      person: 0.2555
+    ontological:
+      imagined: 0.3425
+      forgotten: 0.2977
+      known: 0.3599
+    confidence: 0.0299
   discogs_id: 371334
   notes: ''
 Nine Inch Nails:
   slug: nine_inch_nails
   status: draft
-  description: 'Nine Inch Nails is a primarily vocal project, though instrumental passages carry substantial weight. Production
-    is dense and confrontational, layering abrasive industrial noise, distorted synthesizers, and heavily processed drums
-    against moments of sparse, fragile quiet. Textures shift dramatically between crushing sonic walls and near-silence, creating
-    visceral tension. Studio work treats the recording itself as a compositional element, with degraded audio, glitch artifacts,
-    and mechanical rhythms embedded throughout. Lyrically, themes center on psychological fragmentation, self-destruction,
-    power and submission, alienation, spiritual collapse, and the body as a site of pain or shame. Imagery tends toward the
-    visceral and internal — dissolution of self, contamination, obsessive thought loops. Emotionally, the register oscillates
-    between rage, despair, dissociation, and a kind of hollow yearning. The overall psychological colour is claustrophobic
+  description: 'Nine Inch Nails is a primarily vocal project, though instrumental
+    passages carry substantial weight. Production is dense and confrontational, layering
+    abrasive industrial noise, distorted synthesizers, and heavily processed drums
+    against moments of sparse, fragile quiet. Textures shift dramatically between
+    crushing sonic walls and near-silence, creating visceral tension. Studio work
+    treats the recording itself as a compositional element, with degraded audio, glitch
+    artifacts, and mechanical rhythms embedded throughout. Lyrically, themes center
+    on psychological fragmentation, self-destruction, power and submission, alienation,
+    spiritual collapse, and the body as a site of pain or shame. Imagery tends toward
+    the visceral and internal — dissolution of self, contamination, obsessive thought
+    loops. Emotionally, the register oscillates between rage, despair, dissociation,
+    and a kind of hollow yearning. The overall psychological colour is claustrophobic
     and confessional, with an undercurrent of desperation seeking release or transcendence.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4326
+      present: 0.2558
+      future: 0.3117
+    spatial:
+      thing: 0.4333
+      place: 0.3113
+      person: 0.2553
+    ontological:
+      imagined: 0.3449
+      forgotten: 0.2957
+      known: 0.3594
+    confidence: 0.0207
   discogs_id: 3857
   notes: ''
 Pram:
   slug: pram
   status: draft
-  description: 'Pram crafts music that is primarily instrumental with occasional wordless or abstracted vocals, blending post-rock,
-    avant-garde electronics, and vintage exotica into dense, layered sonic tapestries. Production favours a warm but unsettling
-    analogue quality, incorporating toy instruments, melodica, found-sound fragments, vibraphone, and analogue synthesizers
-    that create a dusty, antiquarian texture. Thematically, the work draws on surrealist imagery, dreamlike narratives, scientific
-    curiosity, and imaginary geography, evoking a sense of exploration into strange, unmapped interior spaces. Lyrically sparse
-    where vocals appear, the tone suggests cryptic storytelling rather than direct expression. The emotional register is persistently
-    melancholic yet curious — hovering between childhood wonder and quiet dread, projecting a psychological colour that feels
-    simultaneously intimate and detached. Rhythmic structures tend toward hypnotic repetition, and dynamic contrasts shift
-    between hushed minimalism and denser, murky orchestration.
+  description: 'Pram crafts music that is primarily instrumental with occasional wordless
+    or abstracted vocals, blending post-rock, avant-garde electronics, and vintage
+    exotica into dense, layered sonic tapestries. Production favours a warm but unsettling
+    analogue quality, incorporating toy instruments, melodica, found-sound fragments,
+    vibraphone, and analogue synthesizers that create a dusty, antiquarian texture.
+    Thematically, the work draws on surrealist imagery, dreamlike narratives, scientific
+    curiosity, and imaginary geography, evoking a sense of exploration into strange,
+    unmapped interior spaces. Lyrically sparse where vocals appear, the tone suggests
+    cryptic storytelling rather than direct expression. The emotional register is
+    persistently melancholic yet curious — hovering between childhood wonder and quiet
+    dread, projecting a psychological colour that feels simultaneously intimate and
+    detached. Rhythmic structures tend toward hypnotic repetition, and dynamic contrasts
+    shift between hushed minimalism and denser, murky orchestration.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4263
+      present: 0.2641
+      future: 0.3096
+    spatial:
+      thing: 0.4271
+      place: 0.3096
+      person: 0.2633
+    ontological:
+      imagined: 0.3427
+      forgotten: 0.2968
+      known: 0.3605
+    confidence: 0.0185
   discogs_id: 3542
   notes: ''
 Panda Bear:
   slug: panda_bear
   status: draft
-  description: 'Panda Bear''s music is primarily vocal-driven, layering his own voice into dense, harmonically rich tapestries
-    through heavy use of loops and tape-influenced processing. Production favors warm, saturated textures — lo-fi grain softened
-    by reverb halos that blur instrumental and vocal sources into an ambient wash. Rhythmically, the work often anchors dreamy,
-    oceanic soundscapes with propulsive, sample-heavy beats, creating a tension between grounded pulse and floating atmosphere.
-    Thematically, imagery orbits domesticity, familial bonds, mortality, spiritual cyclicality, and the passage of time, rendered
-    in impressionistic rather than narrative terms. Vocally, melodies are elongated and mantra-like, suggesting devotional
-    or meditative intent. The emotional register oscillates between melancholy and euphoria, holding both simultaneously —
-    nostalgic yet luminous, introspective yet communal. Studio space itself functions as an instrument, with silence, reverb
+  description: 'Panda Bear''s music is primarily vocal-driven, layering his own voice
+    into dense, harmonically rich tapestries through heavy use of loops and tape-influenced
+    processing. Production favors warm, saturated textures — lo-fi grain softened
+    by reverb halos that blur instrumental and vocal sources into an ambient wash.
+    Rhythmically, the work often anchors dreamy, oceanic soundscapes with propulsive,
+    sample-heavy beats, creating a tension between grounded pulse and floating atmosphere.
+    Thematically, imagery orbits domesticity, familial bonds, mortality, spiritual
+    cyclicality, and the passage of time, rendered in impressionistic rather than
+    narrative terms. Vocally, melodies are elongated and mantra-like, suggesting devotional
+    or meditative intent. The emotional register oscillates between melancholy and
+    euphoria, holding both simultaneously — nostalgic yet luminous, introspective
+    yet communal. Studio space itself functions as an instrument, with silence, reverb
     decay, and texture carrying as much expressive weight as melody.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4399
+      present: 0.2498
+      future: 0.3103
+    spatial:
+      thing: 0.4408
+      place: 0.3098
+      person: 0.2494
+    ontological:
+      imagined: 0.3501
+      forgotten: 0.2931
+      known: 0.3568
+    confidence: 0.0308
   discogs_id: 218809
   notes: ''
 Washed Out:
   slug: washed_out
   status: draft
-  description: 'Washed Out operates primarily as a vocal-driven project layered beneath dense electronic production. The sonic
-    texture is hazy and saturated — heavily processed vocals float through reverb-drenched synthesizers, lush tape-saturated
-    warmth, and softly compressed rhythms that blur melodic edges into an ambient fog. Production tends toward lo-fi intimacy
-    even at high density, favoring washed-out (diffuse) timbres over sharp transients. Lyrical themes orbit nostalgia, longing,
-    romantic dissolution, and the emotional residue of memory — imagery frequently evokes summer heat, fading moments, and
-    dreamlike temporal dislocation. Tone remains introspective rather than confessional, suggesting feeling through atmosphere
-    more than direct statement. The emotional register is bittersweet and sedated — melancholic without despair, euphoric
-    without urgency — occupying a psychological space between contentment and wistfulness. Rhythmic structures are present
-    but languid, supporting mood rather than driving momentum.
+  description: 'Washed Out operates primarily as a vocal-driven project layered beneath
+    dense electronic production. The sonic texture is hazy and saturated — heavily
+    processed vocals float through reverb-drenched synthesizers, lush tape-saturated
+    warmth, and softly compressed rhythms that blur melodic edges into an ambient
+    fog. Production tends toward lo-fi intimacy even at high density, favoring washed-out
+    (diffuse) timbres over sharp transients. Lyrical themes orbit nostalgia, longing,
+    romantic dissolution, and the emotional residue of memory — imagery frequently
+    evokes summer heat, fading moments, and dreamlike temporal dislocation. Tone remains
+    introspective rather than confessional, suggesting feeling through atmosphere
+    more than direct statement. The emotional register is bittersweet and sedated
+    — melancholic without despair, euphoric without urgency — occupying a psychological
+    space between contentment and wistfulness. Rhythmic structures are present but
+    languid, supporting mood rather than driving momentum.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4327
+      present: 0.2544
+      future: 0.313
+    spatial:
+      thing: 0.4332
+      place: 0.3127
+      person: 0.254
+    ontological:
+      imagined: 0.3416
+      forgotten: 0.2977
+      known: 0.3607
+    confidence: 0.0208
   discogs_id: 1575877
   notes: ''
 Gary Numan:
   slug: gary_numan
   status: draft
-  description: 'Gary Numan''s sound is built on cold, layered synthesiser textures — dense analogue pads, rigid sequenced
-    basslines, and brittle electronic percussion that create a machine-like sonic architecture. Production tends toward controlled
-    sterility, with heavy processing and stark dynamic contrasts. Later work incorporates distorted industrial guitars beneath
-    synthetic atmospheres, adding weight and abrasion. He is primarily a vocal artist, delivering lines in a detached, affectless
-    baritone that reinforces emotional distance. Lyrically, recurring imagery centres on urban alienation, mechanical existence,
-    psychological fragmentation, and the dissolution of human identity against technological landscapes. Themes of paranoia,
-    isolation, and existential dread surface consistently, often framed through desolate cityscapes or dystopian interior
-    states. The emotional register is uniformly cold and dissociative — anxious yet numbly resigned, projecting psychological
-    unease through clinical sonic restraint rather than expressive warmth.
+  description: 'Gary Numan''s sound is built on cold, layered synthesiser textures
+    — dense analogue pads, rigid sequenced basslines, and brittle electronic percussion
+    that create a machine-like sonic architecture. Production tends toward controlled
+    sterility, with heavy processing and stark dynamic contrasts. Later work incorporates
+    distorted industrial guitars beneath synthetic atmospheres, adding weight and
+    abrasion. He is primarily a vocal artist, delivering lines in a detached, affectless
+    baritone that reinforces emotional distance. Lyrically, recurring imagery centres
+    on urban alienation, mechanical existence, psychological fragmentation, and the
+    dissolution of human identity against technological landscapes. Themes of paranoia,
+    isolation, and existential dread surface consistently, often framed through desolate
+    cityscapes or dystopian interior states. The emotional register is uniformly cold
+    and dissociative — anxious yet numbly resigned, projecting psychological unease
+    through clinical sonic restraint rather than expressive warmth.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4177
+      present: 0.2674
+      future: 0.3149
+    spatial:
+      thing: 0.4184
+      place: 0.3148
+      person: 0.2668
+    ontological:
+      imagined: 0.348
+      forgotten: 0.3012
+      known: 0.3508
+    confidence: 0.0137
   discogs_id: 12588
   notes: ''
 Steely Dan:
   slug: steely_dan
   status: draft
-  description: 'Steely Dan operates as a vocal-led project with sophisticated jazz-rock fusion at its core. Production is
-    immaculate and dense — heavily layered studio arrangements featuring clean electric guitar tones, rhodes electric piano,
-    tight rhythm sections, and prominent session-horn stabs. Sonically, surfaces are polished to near-clinical precision,
-    with meticulous attention to timbral balance and spatial separation. Lyrics traffic in irony, moral ambiguity, and urban
-    disillusionment, populated by morally compromised characters, failed hedonism, and veiled cynicism delivered through oblique,
-    elliptical imagery. Themes often circle addiction, obsession, class anxiety, and detached desire. The emotional register
-    is cool and sardonic — emotionally distanced yet psychologically penetrating, creating a sense of elegant unease beneath
-    sophisticated surfaces. Harmonic language borrows heavily from jazz — extended chords, chromatic passing tones, unexpected
-    modal shifts — generating tension between surface smoothness and underlying harmonic restlessness.
+  description: 'Steely Dan operates as a vocal-led project with sophisticated jazz-rock
+    fusion at its core. Production is immaculate and dense — heavily layered studio
+    arrangements featuring clean electric guitar tones, rhodes electric piano, tight
+    rhythm sections, and prominent session-horn stabs. Sonically, surfaces are polished
+    to near-clinical precision, with meticulous attention to timbral balance and spatial
+    separation. Lyrics traffic in irony, moral ambiguity, and urban disillusionment,
+    populated by morally compromised characters, failed hedonism, and veiled cynicism
+    delivered through oblique, elliptical imagery. Themes often circle addiction,
+    obsession, class anxiety, and detached desire. The emotional register is cool
+    and sardonic — emotionally distanced yet psychologically penetrating, creating
+    a sense of elegant unease beneath sophisticated surfaces. Harmonic language borrows
+    heavily from jazz — extended chords, chromatic passing tones, unexpected modal
+    shifts — generating tension between surface smoothness and underlying harmonic
+    restlessness.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.414
+      present: 0.2698
+      future: 0.3163
+    spatial:
+      thing: 0.4146
+      place: 0.3161
+      person: 0.2693
+    ontological:
+      imagined: 0.3366
+      forgotten: 0.3071
+      known: 0.3564
+    confidence: 0.0101
   discogs_id: 160906
   notes: ''
 Foo Fighters:
   slug: foo_fighters
   status: draft
-  description: 'Foo Fighters are a vocal-led rock ensemble with a signature sonic duality: muscular, distortion-heavy guitar
-    riffs alternating with restrained, clean-toned passages, creating dramatic dynamic shifts. Production is dense yet polished,
-    favouring thick low-mid frequencies, punchy compressed drums, and layered guitar textures that build toward anthemic climaxes.
-    The studio approach prioritises a live, powerful feel alongside arena-scale clarity.
+  description: 'Foo Fighters are a vocal-led rock ensemble with a signature sonic
+    duality: muscular, distortion-heavy guitar riffs alternating with restrained,
+    clean-toned passages, creating dramatic dynamic shifts. Production is dense yet
+    polished, favouring thick low-mid frequencies, punchy compressed drums, and layered
+    guitar textures that build toward anthemic climaxes. The studio approach prioritises
+    a live, powerful feel alongside arena-scale clarity.
 
 
-    Lyrically, themes centre on perseverance, inner conflict, survival, self-doubt, and the struggle toward resilience. Imagery
-    tends toward the visceral and internal — confronting darkness, weathering collapse, re-emerging with renewed resolve.
+    Lyrically, themes centre on perseverance, inner conflict, survival, self-doubt,
+    and the struggle toward resilience. Imagery tends toward the visceral and internal
+    — confronting darkness, weathering collapse, re-emerging with renewed resolve.
     Tone oscillates between anguish and defiance.
 
 
-    Emotionally, the register spans raw vulnerability to cathartic release, with a psychological colour rooted in tension
-    and ultimate determination. The affect is earnest, intense, and often urgently hopeful, leaning heavily into emotional
+    Emotionally, the register spans raw vulnerability to cathartic release, with a
+    psychological colour rooted in tension and ultimate determination. The affect
+    is earnest, intense, and often urgently hopeful, leaning heavily into emotional
     extremity rather than irony or detachment.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4489
+      present: 0.2497
+      future: 0.3015
+    spatial:
+      thing: 0.4498
+      place: 0.3014
+      person: 0.2488
+    ontological:
+      imagined: 0.3464
+      forgotten: 0.2874
+      known: 0.3663
+    confidence: 0.0325
   discogs_id: 198282
   notes: ''
 Swervedriver:
   slug: swervedriver
   status: draft
-  description: 'Swervedriver occupies a dense, guitar-saturated sonic space where heavily layered, distortion-soaked riffs
-    merge with shimmering, reverb-drenched textures. The production leans into thickness and momentum, blending shoegaze-adjacent
-    walls of sound with driving rock energy, creating a sensation of controlled forward propulsion. Low-end weight anchors
-    swirling upper-register guitar tones, producing a rich, almost cinematic density.
+  description: 'Swervedriver occupies a dense, guitar-saturated sonic space where
+    heavily layered, distortion-soaked riffs merge with shimmering, reverb-drenched
+    textures. The production leans into thickness and momentum, blending shoegaze-adjacent
+    walls of sound with driving rock energy, creating a sensation of controlled forward
+    propulsion. Low-end weight anchors swirling upper-register guitar tones, producing
+    a rich, almost cinematic density.
 
 
-    Lyrically, imagery tends toward motion, speed, dislocation, and urban or road-worn landscapes, carrying a detached yet
-    restless tone. Themes of yearning, drift, and disconnected modernity surface consistently, treated with understated coolness
+    Lyrically, imagery tends toward motion, speed, dislocation, and urban or road-worn
+    landscapes, carrying a detached yet restless tone. Themes of yearning, drift,
+    and disconnected modernity surface consistently, treated with understated coolness
     rather than overt emotionality.
 
 
-    The emotional register is simultaneously melancholic and energized — a paradox of numbness and intensity, evoking wide
-    open spaces pressed against claustrophobic psychic states. The band is primarily vocal, though guitar arrangements often
+    The emotional register is simultaneously melancholic and energized — a paradox
+    of numbness and intensity, evoking wide open spaces pressed against claustrophobic
+    psychic states. The band is primarily vocal, though guitar arrangements often
     function as melodic and textural counterweights to the sung lines.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4495
+      present: 0.2463
+      future: 0.3042
+    spatial:
+      thing: 0.4503
+      place: 0.3042
+      person: 0.2456
+    ontological:
+      imagined: 0.3541
+      forgotten: 0.2875
+      known: 0.3585
+    confidence: 0.024
   discogs_id: 159997
   notes: ''
 Brian Eno:
   slug: brian_eno
   status: draft
-  description: 'Brian Eno works predominantly in instrumental ambient music, though vocal works appear throughout his output.
-    Sonically, his productions favour vast, slowly evolving timbral fields — soft synthesizer pads, processed piano, treated
-    guitar, and environmental sound woven into minimal, low-density textures. Studio technology functions as a compositional
-    instrument; tape manipulation, generative systems, and extended reverb create music that breathes and shifts almost imperceptibly.
-    Dynamics are restrained, transitions gradual, silence treated as active space. When vocals appear, they are often detached,
-    treated as texture rather than narrative delivery. Thematic territory gravitates toward liminal states, vast scale, timelessness,
-    and the dissolution of self into environment. Imagery suggests open landscape, oceanic depth, or suspended duration. The
-    emotional register is contemplative, spacious, and cool — occasionally tender, occasionally unsettling — evoking a psychological
-    state of calm alertness or waking suspension between consciousness and dream.
+  description: 'Brian Eno works predominantly in instrumental ambient music, though
+    vocal works appear throughout his output. Sonically, his productions favour vast,
+    slowly evolving timbral fields — soft synthesizer pads, processed piano, treated
+    guitar, and environmental sound woven into minimal, low-density textures. Studio
+    technology functions as a compositional instrument; tape manipulation, generative
+    systems, and extended reverb create music that breathes and shifts almost imperceptibly.
+    Dynamics are restrained, transitions gradual, silence treated as active space.
+    When vocals appear, they are often detached, treated as texture rather than narrative
+    delivery. Thematic territory gravitates toward liminal states, vast scale, timelessness,
+    and the dissolution of self into environment. Imagery suggests open landscape,
+    oceanic depth, or suspended duration. The emotional register is contemplative,
+    spacious, and cool — occasionally tender, occasionally unsettling — evoking a
+    psychological state of calm alertness or waking suspension between consciousness
+    and dream.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4356
+      present: 0.2518
+      future: 0.3126
+    spatial:
+      thing: 0.4363
+      place: 0.3123
+      person: 0.2514
+    ontological:
+      imagined: 0.3467
+      forgotten: 0.2953
+      known: 0.358
+    confidence: 0.0259
   discogs_id: 634
   notes: ''
 Devo:
   slug: devo
   status: draft
-  description: 'Devo''s sound is built from rigid, mechanistic rhythms and synthetic textures — angular synth stabs, processed
-    guitar reduced to percussive bursts, and drum machines or tightly quantized live drumming that enforce a relentless, inhuman
-    pulse. Production is deliberately flat and clinical, favoring brightness and density over warmth, with abrupt transitions
-    and jerky, repetitive motifs. Vocals are present and central, often delivered in a strained, nasal, or sardonic register
-    — declarative rather than melodic. Thematically, lyrics engage with devolution, conformity, consumerism, and the dehumanizing
-    effects of modern civilization, employing absurdist imagery, mock-corporate language, and dystopian scenarios. The emotional
-    register is ironic, alienated, and unsettling beneath a surface of rigid cheerfulness — affect that mimics enthusiasm
-    while undermining it. The overall psychological colour is paranoid, satirical, and deliberately hollow, suggesting compliance
-    as a form of dysfunction.
+  description: 'Devo''s sound is built from rigid, mechanistic rhythms and synthetic
+    textures — angular synth stabs, processed guitar reduced to percussive bursts,
+    and drum machines or tightly quantized live drumming that enforce a relentless,
+    inhuman pulse. Production is deliberately flat and clinical, favoring brightness
+    and density over warmth, with abrupt transitions and jerky, repetitive motifs.
+    Vocals are present and central, often delivered in a strained, nasal, or sardonic
+    register — declarative rather than melodic. Thematically, lyrics engage with devolution,
+    conformity, consumerism, and the dehumanizing effects of modern civilization,
+    employing absurdist imagery, mock-corporate language, and dystopian scenarios.
+    The emotional register is ironic, alienated, and unsettling beneath a surface
+    of rigid cheerfulness — affect that mimics enthusiasm while undermining it. The
+    overall psychological colour is paranoid, satirical, and deliberately hollow,
+    suggesting compliance as a form of dysfunction.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4193
+      present: 0.2628
+      future: 0.3179
+    spatial:
+      thing: 0.42
+      place: 0.3175
+      person: 0.2625
+    ontological:
+      imagined: 0.3484
+      forgotten: 0.3008
+      known: 0.3508
+    confidence: 0.0161
   discogs_id: 12834
   notes: ''
 The Afghan Whigs:
   slug: the_afghan_whigs
   status: draft
-  description: 'The Afghan Whigs operate primarily as a vocal-driven ensemble, with Greg Dulli''s raw, impassioned baritone
-    anchoring dense, layered arrangements. Production leans into thick guitar textures, gospel-inflected backing vocals, and
-    a murky, saturated studio aesthetic that blurs rock aggression with soul warmth. Rhythmically, the music pulses with a
-    heavy, deliberate groove, often punctuated by dynamic swells that shift from brooding restraint to cathartic release.
-    Lyrically, themes orbit obsession, desire, guilt, and self-destruction, rendered through intimate second-person address
-    and charged, psychologically ambiguous imagery. The emotional register is consistently heightened — volatile, confessional,
-    and claustrophobic — conveying interior states of craving, shame, and fractured intimacy. Darkness is never purely nihilistic;
-    tension between seduction and consequence gives the work a fevered, melodramatic quality. Arrangements favor density over
-    minimalism, with orchestral and horn elements occasionally reinforcing the emotionally saturated atmosphere.
+  description: 'The Afghan Whigs operate primarily as a vocal-driven ensemble, with
+    Greg Dulli''s raw, impassioned baritone anchoring dense, layered arrangements.
+    Production leans into thick guitar textures, gospel-inflected backing vocals,
+    and a murky, saturated studio aesthetic that blurs rock aggression with soul warmth.
+    Rhythmically, the music pulses with a heavy, deliberate groove, often punctuated
+    by dynamic swells that shift from brooding restraint to cathartic release. Lyrically,
+    themes orbit obsession, desire, guilt, and self-destruction, rendered through
+    intimate second-person address and charged, psychologically ambiguous imagery.
+    The emotional register is consistently heightened — volatile, confessional, and
+    claustrophobic — conveying interior states of craving, shame, and fractured intimacy.
+    Darkness is never purely nihilistic; tension between seduction and consequence
+    gives the work a fevered, melodramatic quality. Arrangements favor density over
+    minimalism, with orchestral and horn elements occasionally reinforcing the emotionally
+    saturated atmosphere.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4203
+      present: 0.2622
+      future: 0.3174
+    spatial:
+      thing: 0.421
+      place: 0.317
+      person: 0.262
+    ontological:
+      imagined: 0.3435
+      forgotten: 0.3025
+      known: 0.354
+    confidence: 0.0192
   discogs_id: 89572
   notes: ''
 The Smithereens:
   slug: the_smithereens
   status: draft
-  description: 'The Smithereens blend bright, chiming guitar tones with dense, punchy production, favoring a raw yet polished
-    studio character that emphasizes crunch and presence. Rhythm guitars carry considerable weight, underpinned by driving,
-    muscular drumming and melodic basslines. The overall sonic texture is thick but transparent, balancing aggression with
-    melodicism. Vocally driven, the band centers gruff, earnest lead singing within tight harmonic arrangements. Lyrically,
-    themes orbit romantic longing, obsession, alienation, and bittersweet nostalgia, rendered through direct, confessional
-    language with occasional cinematic and nocturnal imagery. The emotional register is persistently melancholic yet energized
-    — yearning and urgency coexist, creating a brooding tension beneath accessible surfaces. There is a quality of emotional
-    sincerity bordering on ache, reinforced by dynamic contrasts between verse restraint and chorus release. The mood consistently
-    evokes late-night introspection fused with visceral, guitar-forward propulsion.
+  description: 'The Smithereens blend bright, chiming guitar tones with dense, punchy
+    production, favoring a raw yet polished studio character that emphasizes crunch
+    and presence. Rhythm guitars carry considerable weight, underpinned by driving,
+    muscular drumming and melodic basslines. The overall sonic texture is thick but
+    transparent, balancing aggression with melodicism. Vocally driven, the band centers
+    gruff, earnest lead singing within tight harmonic arrangements. Lyrically, themes
+    orbit romantic longing, obsession, alienation, and bittersweet nostalgia, rendered
+    through direct, confessional language with occasional cinematic and nocturnal
+    imagery. The emotional register is persistently melancholic yet energized — yearning
+    and urgency coexist, creating a brooding tension beneath accessible surfaces.
+    There is a quality of emotional sincerity bordering on ache, reinforced by dynamic
+    contrasts between verse restraint and chorus release. The mood consistently evokes
+    late-night introspection fused with visceral, guitar-forward propulsion.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.432
+      present: 0.2616
+      future: 0.3064
+    spatial:
+      thing: 0.433
+      place: 0.3064
+      person: 0.2606
+    ontological:
+      imagined: 0.3484
+      forgotten: 0.2938
+      known: 0.3578
+    confidence: 0.0243
   discogs_id: 377441
   notes: ''
 The Church:
   slug: the_church
   status: draft
-  description: 'The Church crafts guitar-driven rock with a distinctly atmospheric, reverb-soaked sonic palette. Layers of
-    chiming, arpeggiated guitars create dense, shimmering textures, while bass lines move melodically beneath a wash of studio-enhanced
-    depth. Production favours spaciousness and echo, giving tracks an immersive, almost cavernous quality. Vocals are prominent
-    but blend into the instrumental texture rather than dominating it, delivered in a cool, detached baritone.
+  description: 'The Church crafts guitar-driven rock with a distinctly atmospheric,
+    reverb-soaked sonic palette. Layers of chiming, arpeggiated guitars create dense,
+    shimmering textures, while bass lines move melodically beneath a wash of studio-enhanced
+    depth. Production favours spaciousness and echo, giving tracks an immersive, almost
+    cavernous quality. Vocals are prominent but blend into the instrumental texture
+    rather than dominating it, delivered in a cool, detached baritone.
 
 
-    Lyrically, imagery draws on mystery, ancient mythology, altered perception, desert and oceanic landscapes, and existential
-    searching. Themes circle around transcendence, illusion, temporal displacement, and spiritual longing, rendered in dense,
-    elliptical language.
+    Lyrically, imagery draws on mystery, ancient mythology, altered perception, desert
+    and oceanic landscapes, and existential searching. Themes circle around transcendence,
+    illusion, temporal displacement, and spiritual longing, rendered in dense, elliptical
+    language.
 
 
-    The emotional register is introspective and melancholic, with undercurrents of unease and wonder. Moods tend toward twilight
-    and the liminal — neither purely dark nor bright — evoking a sustained psychological suspension between clarity and dreamlike
-    disorientation.
+    The emotional register is introspective and melancholic, with undercurrents of
+    unease and wonder. Moods tend toward twilight and the liminal — neither purely
+    dark nor bright — evoking a sustained psychological suspension between clarity
+    and dreamlike disorientation.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4276
+      present: 0.2622
+      future: 0.3102
+    spatial:
+      thing: 0.4286
+      place: 0.3099
+      person: 0.2615
+    ontological:
+      imagined: 0.3446
+      forgotten: 0.2973
+      known: 0.358
+    confidence: 0.0275
   discogs_id: 258153
   notes: ''
 The Jesus And Mary Chain:
   slug: the_jesus_and_mary_chain
   status: draft
-  description: 'The Jesus and Mary Chain layer dense, distorted guitar noise over deceptively simple pop structures, creating
-    a wall of feedback and hiss that functions as texture rather than chaos. Production is deliberately lo-fi and saturated,
-    with trebly, buzzing guitars burying melodic hooks beneath sheets of white noise. Rhythm sections are sparse and mechanical,
-    often driven by drum machines. The sound is simultaneously abrasive and dreamy, balancing harshness with underlying sweetness.
+  description: 'The Jesus and Mary Chain layer dense, distorted guitar noise over
+    deceptively simple pop structures, creating a wall of feedback and hiss that functions
+    as texture rather than chaos. Production is deliberately lo-fi and saturated,
+    with trebly, buzzing guitars burying melodic hooks beneath sheets of white noise.
+    Rhythm sections are sparse and mechanical, often driven by drum machines. The
+    sound is simultaneously abrasive and dreamy, balancing harshness with underlying
+    sweetness.
 
 
-    Vocals are central, delivered in a detached, near-monotone baritone that conveys emotional numbness rather than expressiveness.
-    Lyrical themes circle obsession, desire, alienation, self-destruction, and a romanticised darkness — imagery tends toward
-    the nocturnal, the transgressive, and the melancholic.
+    Vocals are central, delivered in a detached, near-monotone baritone that conveys
+    emotional numbness rather than expressiveness. Lyrical themes circle obsession,
+    desire, alienation, self-destruction, and a romanticised darkness — imagery tends
+    toward the nocturnal, the transgressive, and the melancholic.
 
 
-    The emotional register is psychologically cool yet internally intense — numbness masking yearning. The overall affect
-    suggests detachment as a defence mechanism against overwhelming feeling, blending nihilism with suppressed romanticism.
+    The emotional register is psychologically cool yet internally intense — numbness
+    masking yearning. The overall affect suggests detachment as a defence mechanism
+    against overwhelming feeling, blending nihilism with suppressed romanticism.
 
     '
   style_tags: &id001 []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4321
+      present: 0.2604
+      future: 0.3074
+    spatial:
+      thing: 0.4333
+      place: 0.3071
+      person: 0.2596
+    ontological:
+      imagined: 0.3534
+      forgotten: 0.2929
+      known: 0.3537
+    confidence: 0.0298
   discogs_id: 243280
   notes: ''
 Happy Mondays:
   slug: happy_mondays
   status: draft
-  description: 'Happy Mondays occupy a dense, hypnotic sonic space where rock instrumentation dissolves into loose, funk-inflected
-    grooves layered with synthesiser washes, sequenced electronic pulses, and heavily treated guitar textures. Production
-    carries an intentionally murky, narcotic weight — beats sit low and rolling, bass lines anchor sprawling arrangements,
-    and percussion feels simultaneously mechanical and organic. Maracas and percussion accents inject rhythmic irregularity
-    throughout. Vocals are delivered in a drawling, conversational Mancunian register, half-spoken and melodically ambiguous,
-    riding rhythms rather than commanding them. Lyrically, imagery circles around street-level hedonism, altered states, desire,
-    and working-class urban experience, rendered with a detached, sardonic tone rather than earnest emotion. The emotional
-    register is simultaneously euphoric and bleary — celebratory yet laced with an underlying disconnection and chemical haziness.
-    The project is fundamentally vocal-led, though groove and texture carry equal compositional weight.
+  description: 'Happy Mondays occupy a dense, hypnotic sonic space where rock instrumentation
+    dissolves into loose, funk-inflected grooves layered with synthesiser washes,
+    sequenced electronic pulses, and heavily treated guitar textures. Production carries
+    an intentionally murky, narcotic weight — beats sit low and rolling, bass lines
+    anchor sprawling arrangements, and percussion feels simultaneously mechanical
+    and organic. Maracas and percussion accents inject rhythmic irregularity throughout.
+    Vocals are delivered in a drawling, conversational Mancunian register, half-spoken
+    and melodically ambiguous, riding rhythms rather than commanding them. Lyrically,
+    imagery circles around street-level hedonism, altered states, desire, and working-class
+    urban experience, rendered with a detached, sardonic tone rather than earnest
+    emotion. The emotional register is simultaneously euphoric and bleary — celebratory
+    yet laced with an underlying disconnection and chemical haziness. The project
+    is fundamentally vocal-led, though groove and texture carry equal compositional
+    weight.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4317
+      present: 0.2572
+      future: 0.3111
+    spatial:
+      thing: 0.4326
+      place: 0.3106
+      person: 0.2567
+    ontological:
+      imagined: 0.3643
+      forgotten: 0.293
+      known: 0.3426
+    confidence: 0.0188
   discogs_id: 12097
   notes: ''
 Medicine (2):
   slug: medicine_2
   status: draft
-  description: Medicine occupy a sonic territory where shoegaze infrastructure collides with industrial compulsion. Guitar
-    production is extreme — heavily distorted, layered into dense walls of processed noise where individual strings dissolve
-    into a unified, abrasive mass. Tremolo and feedback manipulation generate a perpetually unstable tonal surface that shifts
-    between grinding aggression and smeared warmth. Female vocals are submerged almost entirely beneath the textural overload,
-    functioning as another frequency layer rather than melodic presence — their buried quality contributing to a sense of
-    the human voice overwhelmed by mechanical force. Rhythmic elements drive hard beneath the noise, machine-precise rather
-    than loose, providing industrial propulsion. Production resists clarity deliberately, favoring density and compression
-    over separation. Lyrically, content is impressionistic and largely obscured — emotional intensity encoded through volume
-    and texture rather than narrative. The emotional register is cathartic and overwhelming — pleasure and punishment made
-    indistinguishable — evoking submersion, dissociation, and the perverse euphoria of sonic saturation.
+  description: Medicine occupy a sonic territory where shoegaze infrastructure collides
+    with industrial compulsion. Guitar production is extreme — heavily distorted,
+    layered into dense walls of processed noise where individual strings dissolve
+    into a unified, abrasive mass. Tremolo and feedback manipulation generate a perpetually
+    unstable tonal surface that shifts between grinding aggression and smeared warmth.
+    Female vocals are submerged almost entirely beneath the textural overload, functioning
+    as another frequency layer rather than melodic presence — their buried quality
+    contributing to a sense of the human voice overwhelmed by mechanical force. Rhythmic
+    elements drive hard beneath the noise, machine-precise rather than loose, providing
+    industrial propulsion. Production resists clarity deliberately, favoring density
+    and compression over separation. Lyrically, content is impressionistic and largely
+    obscured — emotional intensity encoded through volume and texture rather than
+    narrative. The emotional register is cathartic and overwhelming — pleasure and
+    punishment made indistinguishable — evoking submersion, dissociation, and the
+    perverse euphoria of sonic saturation.
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4416
+      present: 0.2468
+      future: 0.3117
+    spatial:
+      thing: 0.4422
+      place: 0.3113
+      person: 0.2465
+    ontological:
+      imagined: 0.3538
+      forgotten: 0.2924
+      known: 0.3538
+    confidence: 0.0261
   discogs_id: 71224
   notes: Unknown artist — fill description manually
 Popol Vuh:
   slug: popol_vuh
   status: draft
-  description: 'Popol Vuh occupies a liminal space between sacred minimalism and cosmic drift. Their sonic palette layers
-    delicate piano, devotional organ, orchestral strings, and processed synthesizers into slowly evolving, breath-like textures
-    — dense yet transparent, warm and overtly organic. Production feels intimate and spacious simultaneously, favoring gradual
-    transformation over rhythmic momentum. Vocals, when present, carry a ceremonial, chant-like quality — wordless or near-wordless,
-    functioning as another tonal layer rather than a narrative vehicle; the music is predominantly instrumental. Thematically,
-    imagery orbits spiritual transcendence, primordial landscape, and the threshold between earthly and divine — drawing loosely
-    from mystical and non-Western spiritual traditions without explicit doctrine. The emotional register is contemplative,
-    reverent, and vast — carrying an atmosphere of solemn wonder, inner stillness, and timeless suspended meditation, suitable
+  description: 'Popol Vuh occupies a liminal space between sacred minimalism and cosmic
+    drift. Their sonic palette layers delicate piano, devotional organ, orchestral
+    strings, and processed synthesizers into slowly evolving, breath-like textures
+    — dense yet transparent, warm and overtly organic. Production feels intimate and
+    spacious simultaneously, favoring gradual transformation over rhythmic momentum.
+    Vocals, when present, carry a ceremonial, chant-like quality — wordless or near-wordless,
+    functioning as another tonal layer rather than a narrative vehicle; the music
+    is predominantly instrumental. Thematically, imagery orbits spiritual transcendence,
+    primordial landscape, and the threshold between earthly and divine — drawing loosely
+    from mystical and non-Western spiritual traditions without explicit doctrine.
+    The emotional register is contemplative, reverent, and vast — carrying an atmosphere
+    of solemn wonder, inner stillness, and timeless suspended meditation, suitable
     for underscore requiring profound psychological depth without sentimentality.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4159
+      present: 0.2673
+      future: 0.3168
+    spatial:
+      thing: 0.4168
+      place: 0.3164
+      person: 0.2668
+    ontological:
+      imagined: 0.3412
+      forgotten: 0.3044
+      known: 0.3545
+    confidence: 0.0219
   discogs_id: 81882
   notes: ''
 Tangerine Dream:
   slug: tangerine_dream
   status: draft
-  description: 'Tangerine Dream works almost entirely in the instrumental domain, with vocals appearing rarely and peripherally.
-    Their sonic texture is dense, layered, and immersive — built from analog synthesizers, sequencers, and electronic organ,
-    producing long, slowly evolving pads, pulsing rhythmic patterns, and shimmering tonal sweeps. The production character
-    emphasizes spatial depth, with sounds distributed across a wide stereo field and allowed to breathe over extended durations.
-    Thematic tendencies lean toward the cosmic, the architectural, and the liminal — evoking vast space, machinery in motion,
-    oceanic depth, and twilight landscapes. Imagery is abstract rather than narrative, suggesting states of consciousness
-    or environmental immersion rather than storytelling. The emotional register is meditative, cool, and expansive — psychologically
-    oriented toward awe, stillness, and mild tension, occasionally shading into urgency through accelerating sequencer patterns.
-    The overall mood is cerebral and contemplative, favoring suspension over resolution.
+  description: 'Tangerine Dream works almost entirely in the instrumental domain,
+    with vocals appearing rarely and peripherally. Their sonic texture is dense, layered,
+    and immersive — built from analog synthesizers, sequencers, and electronic organ,
+    producing long, slowly evolving pads, pulsing rhythmic patterns, and shimmering
+    tonal sweeps. The production character emphasizes spatial depth, with sounds distributed
+    across a wide stereo field and allowed to breathe over extended durations. Thematic
+    tendencies lean toward the cosmic, the architectural, and the liminal — evoking
+    vast space, machinery in motion, oceanic depth, and twilight landscapes. Imagery
+    is abstract rather than narrative, suggesting states of consciousness or environmental
+    immersion rather than storytelling. The emotional register is meditative, cool,
+    and expansive — psychologically oriented toward awe, stillness, and mild tension,
+    occasionally shading into urgency through accelerating sequencer patterns. The
+    overall mood is cerebral and contemplative, favoring suspension over resolution.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4305
+      present: 0.2553
+      future: 0.3142
+    spatial:
+      thing: 0.4313
+      place: 0.3138
+      person: 0.2549
+    ontological:
+      imagined: 0.346
+      forgotten: 0.2973
+      known: 0.3566
+    confidence: 0.0239
   discogs_id: 10343
   notes: ''
 John Carpenter:
   slug: john_carpenter
   status: draft
-  description: 'John Carpenter''s sonic palette is rooted in analogue synthesizers, minimalist repetition, and cold electronic
-    textures. His production favours sparse, pulsing ostinatos layered beneath foreboding pads, creating a sense of suspended
-    dread. Tempos are deliberate; rhythmic elements are mechanical and hypnotic rather than propulsive. The timbral character
-    leans heavily on vintage hardware — monophonic leads, detuned strings, and sub-bass drones that occupy physical space
-    rather than melodic foreground.
+  description: 'John Carpenter''s sonic palette is rooted in analogue synthesizers,
+    minimalist repetition, and cold electronic textures. His production favours sparse,
+    pulsing ostinatos layered beneath foreboding pads, creating a sense of suspended
+    dread. Tempos are deliberate; rhythmic elements are mechanical and hypnotic rather
+    than propulsive. The timbral character leans heavily on vintage hardware — monophonic
+    leads, detuned strings, and sub-bass drones that occupy physical space rather
+    than melodic foreground.
 
 
-    His work is almost entirely instrumental, with thematic content drawn from horror, science fiction, and psychological
-    unease. Imagery implied through composition tends toward isolation, pursuit, and the uncanny. There is little harmonic
-    resolution; modal ambiguity and unresolved tension are structural rather than incidental.
+    His work is almost entirely instrumental, with thematic content drawn from horror,
+    science fiction, and psychological unease. Imagery implied through composition
+    tends toward isolation, pursuit, and the uncanny. There is little harmonic resolution;
+    modal ambiguity and unresolved tension are structural rather than incidental.
 
 
-    The emotional register is sustained anxiety with occasional passages of bleak grandeur — cold, cinematic, and psychologically
-    immersive rather than emotionally cathartic.
+    The emotional register is sustained anxiety with occasional passages of bleak
+    grandeur — cold, cinematic, and psychologically immersive rather than emotionally
+    cathartic.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4057
+      present: 0.275
+      future: 0.3194
+    spatial:
+      thing: 0.4063
+      place: 0.3192
+      person: 0.2745
+    ontological:
+      imagined: 0.3403
+      forgotten: 0.3077
+      known: 0.352
+    confidence: 0.0098
   discogs_id: 32433
   notes: ''
 Hood:
   slug: hood
   status: draft
-  description: 'Hood operates primarily as a vocal project, though instrumental texture is foregrounded to near-equal prominence.
-    Sonically, their productions layer delicate acoustic elements — fingerpicked guitar, sparse percussion, gentle piano —
-    beneath softly degraded electronic treatments: crackle, granular static, tape hiss, and subdued glitch artifacts. The
-    density remains consistently low, favouring negative space and restraint over saturation. Studio approach emphasises intimate,
-    almost fragile recording quality, where imperfection feels deliberate and expressive.
+  description: 'Hood operates primarily as a vocal project, though instrumental texture
+    is foregrounded to near-equal prominence. Sonically, their productions layer delicate
+    acoustic elements — fingerpicked guitar, sparse percussion, gentle piano — beneath
+    softly degraded electronic treatments: crackle, granular static, tape hiss, and
+    subdued glitch artifacts. The density remains consistently low, favouring negative
+    space and restraint over saturation. Studio approach emphasises intimate, almost
+    fragile recording quality, where imperfection feels deliberate and expressive.
 
 
-    Lyrically, the work gravitates toward introspection and quiet anguish — themes of estrangement, memory, longing, failed
-    communication, and the passage of time. Imagery tends toward the domestic, the seasonal, and the quietly desolate. Tone
+    Lyrically, the work gravitates toward introspection and quiet anguish — themes
+    of estrangement, memory, longing, failed communication, and the passage of time.
+    Imagery tends toward the domestic, the seasonal, and the quietly desolate. Tone
     is understated and inward rather than dramatic.
 
 
-    The emotional register is muted and melancholic, carrying a persistent undercurrent of wistfulness and emotional exhaustion
-    — psychologically coloured by ambiguity, fragility, and subdued yearning without resolution.
+    The emotional register is muted and melancholic, carrying a persistent undercurrent
+    of wistfulness and emotional exhaustion — psychologically coloured by ambiguity,
+    fragility, and subdued yearning without resolution.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4171
+      present: 0.2666
+      future: 0.3163
+    spatial:
+      thing: 0.4181
+      place: 0.3158
+      person: 0.2662
+    ontological:
+      imagined: 0.3375
+      forgotten: 0.3047
+      known: 0.3578
+    confidence: 0.0193
   discogs_id: 5047
   notes: ''
 Oneohtrix Point Never:
   slug: oneohtrix_point_never
   status: draft
-  description: 'Oneohtrix Point Never occupies a space between ambient, electronic, and avant-garde composition, blending
-    synthetic and organic timbres into densely layered, often disorienting sound worlds. Production is meticulous yet deliberately
-    abrasive — pristine digital textures fracture into glitch artifacts, pitch-shifted vocal samples dissolve into noise,
-    and tonal passages collapse without resolution. The work spans both instrumental and vocal territory, with heavily processed
-    voices functioning more as textural elements than conventional melodic carriers. Thematically, the work circles around
-    technological alienation, digital consciousness, nostalgia rendered uncanny, and the fragmentation of identity within
-    media-saturated environments. Imagery tends toward the clinical, the synthetic, and the surreal — familiar surfaces made
-    strange. Emotionally, the register oscillates between melancholic longing and cold dissociation, with moments of overwhelming
-    intensity giving way to eerie stillness, producing a psychological atmosphere that feels simultaneously intimate and deeply
-    unsettling.
+  description: 'Oneohtrix Point Never occupies a space between ambient, electronic,
+    and avant-garde composition, blending synthetic and organic timbres into densely
+    layered, often disorienting sound worlds. Production is meticulous yet deliberately
+    abrasive — pristine digital textures fracture into glitch artifacts, pitch-shifted
+    vocal samples dissolve into noise, and tonal passages collapse without resolution.
+    The work spans both instrumental and vocal territory, with heavily processed voices
+    functioning more as textural elements than conventional melodic carriers. Thematically,
+    the work circles around technological alienation, digital consciousness, nostalgia
+    rendered uncanny, and the fragmentation of identity within media-saturated environments.
+    Imagery tends toward the clinical, the synthetic, and the surreal — familiar surfaces
+    made strange. Emotionally, the register oscillates between melancholic longing
+    and cold dissociation, with moments of overwhelming intensity giving way to eerie
+    stillness, producing a psychological atmosphere that feels simultaneously intimate
+    and deeply unsettling.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4472
+      present: 0.2489
+      future: 0.3039
+    spatial:
+      thing: 0.4481
+      place: 0.3036
+      person: 0.2483
+    ontological:
+      imagined: 0.3458
+      forgotten: 0.2888
+      known: 0.3654
+    confidence: 0.0376
   discogs_id: 1191704
   notes: ''
 Throbbing Gristle:
   slug: throbbing_gristle
   status: draft
-  description: 'Throbbing Gristle fuses abrasive industrial noise with cold, clinical electronic textures — harsh feedback,
-    tape manipulation, distorted synthesizers, and primitive drum machines create a dense, confrontational sonic mass. Production
-    is deliberately lo-fi and degraded, treating the studio as a site of deconstruction rather than refinement. Vocals are
-    present but often treated as another textural element — deadpan, detached, or processed into near-abstraction. Thematically,
-    the work circles transgression, control systems, psychological extremity, mass violence, surveillance, and societal taboo,
-    rendered through flat, reportorial imagery that refuses conventional moral framing. The emotional register is cold and
-    dissociative — evoking dread, numbness, voyeuristic unease, and a clinical fascination with darkness. Dynamics shift between
-    oppressive noise walls and eerily sparse passages, creating psychological tension through contrast rather than melodic
-    development. The overall affect is alienating, confrontational, and deliberately destabilizing.
+  description: 'Throbbing Gristle fuses abrasive industrial noise with cold, clinical
+    electronic textures — harsh feedback, tape manipulation, distorted synthesizers,
+    and primitive drum machines create a dense, confrontational sonic mass. Production
+    is deliberately lo-fi and degraded, treating the studio as a site of deconstruction
+    rather than refinement. Vocals are present but often treated as another textural
+    element — deadpan, detached, or processed into near-abstraction. Thematically,
+    the work circles transgression, control systems, psychological extremity, mass
+    violence, surveillance, and societal taboo, rendered through flat, reportorial
+    imagery that refuses conventional moral framing. The emotional register is cold
+    and dissociative — evoking dread, numbness, voyeuristic unease, and a clinical
+    fascination with darkness. Dynamics shift between oppressive noise walls and eerily
+    sparse passages, creating psychological tension through contrast rather than melodic
+    development. The overall affect is alienating, confrontational, and deliberately
+    destabilizing.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4171
+      present: 0.2606
+      future: 0.3223
+    spatial:
+      thing: 0.4178
+      place: 0.3215
+      person: 0.2606
+    ontological:
+      imagined: 0.3476
+      forgotten: 0.3048
+      known: 0.3476
+    confidence: 0.0181
   discogs_id: 12589
   notes: ''
 Your Team Ring:
   slug: your_team_ring
   status: draft
-  description: Your Team Ring is a vocal-led project with a sonic palette that blends indie rock, dream pop, and lo-fi aesthetics.
-    Production is characterized by a warm, intimate quality — guitars shimmer with reverb, drums are softly compressed, and
-    vocals are layered to create a lush yet personal atmosphere. The overall texture is dense but not overwhelming, allowing
-    space for melodic hooks and emotional nuance. Lyrically, themes orbit around friendship, emotional vulnerability, nostalgia,
-    and the complexities of interpersonal relationships. Imagery tends toward the domestic and the emotional landscape of
-    youth — late-night conversations, shared secrets, and the bittersweet nature of growing up. The tone is earnest and heartfelt
-    rather than ironic, with an emotional register that balances melancholy with warmth and hope.
+  description: Your Team Ring is a vocal-led project with a sonic palette that blends
+    indie rock, dream pop, and lo-fi aesthetics. Production is characterized by a
+    warm, intimate quality — guitars shimmer with reverb, drums are softly compressed,
+    and vocals are layered to create a lush yet personal atmosphere. The overall texture
+    is dense but not overwhelming, allowing space for melodic hooks and emotional
+    nuance. Lyrically, themes orbit around friendship, emotional vulnerability, nostalgia,
+    and the complexities of interpersonal relationships. Imagery tends toward the
+    domestic and the emotional landscape of youth — late-night conversations, shared
+    secrets, and the bittersweet nature of growing up. The tone is earnest and heartfelt
+    rather than ironic, with an emotional register that balances melancholy with warmth
+    and hope.
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4211
+      present: 0.2653
+      future: 0.3137
+    spatial:
+      thing: 0.4221
+      place: 0.3131
+      person: 0.2648
+    ontological:
+      imagined: 0.3424
+      forgotten: 0.3
+      known: 0.3576
+    confidence: 0.0272
   discogs_id: 317585
   notes: Gabriel Walsh is Your Team Ring
 Purple Mountains:
   slug: purple_mountains
   status: draft
-  description: 'Purple Mountains is primarily a vocal project, centred on a dry, unadorned baritone voice delivered with minimal
-    affectation. Production is spare and intimate — acoustic and electric guitars, brushed percussion, occasional pedal steel
-    — creating a low-density, close-mic''d atmosphere that feels like a small, quiet room. Arrangements resist ornamentation,
-    favouring space and restraint. Lyrically, the work circles themes of loneliness, romantic dissolution, existential drift,
-    and the negotiation between self-awareness and despair; imagery tends toward the mundane and domestic, rendered with sardonic
-    precision and dark wit. The tone occupies an uncomfortable territory between deadpan comedy and genuine anguish, often
-    holding both simultaneously. The emotional register is predominantly melancholic, tinged with wry resignation rather than
-    sentimentality — a bleakness that remains oddly conversational in its address, as though confiding rather than performing
+  description: 'Purple Mountains is primarily a vocal project, centred on a dry, unadorned
+    baritone voice delivered with minimal affectation. Production is spare and intimate
+    — acoustic and electric guitars, brushed percussion, occasional pedal steel —
+    creating a low-density, close-mic''d atmosphere that feels like a small, quiet
+    room. Arrangements resist ornamentation, favouring space and restraint. Lyrically,
+    the work circles themes of loneliness, romantic dissolution, existential drift,
+    and the negotiation between self-awareness and despair; imagery tends toward the
+    mundane and domestic, rendered with sardonic precision and dark wit. The tone
+    occupies an uncomfortable territory between deadpan comedy and genuine anguish,
+    often holding both simultaneously. The emotional register is predominantly melancholic,
+    tinged with wry resignation rather than sentimentality — a bleakness that remains
+    oddly conversational in its address, as though confiding rather than performing
     grief.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4341
+      present: 0.2595
+      future: 0.3064
+    spatial:
+      thing: 0.4352
+      place: 0.3062
+      person: 0.2586
+    ontological:
+      imagined: 0.3489
+      forgotten: 0.2927
+      known: 0.3584
+    confidence: 0.0432
   discogs_id: 7149935
   notes: ''
 The Olivia Tremor Control:
   slug: the_olivia_tremor_control
   status: draft
-  description: 'The Olivia Tremor Control blend dense, layered vocal harmonies with lo-fi psychedelic production, creating
-    a saturated, dreamlike sonic texture. Studio techniques include tape manipulation, reversed loops, found sounds, and deliberate
-    noise artifacts that blur the boundary between composition and collage. The palette shifts between warm acoustic folk-pop
-    and distorted, disorienting experimental passages, sometimes within a single track. Lyrically, imagery tends toward abstract,
-    surrealist landscapes — fragmented consciousness, dreamstates, cosmic or natural motifs, and a sense of suspended or dissolving
-    identity. The tone is simultaneously intimate and dissociative. Emotionally, the music occupies a hazy, bittersweet register:
-    nostalgic yet unsettled, euphoric yet melancholic, with an underlying psychological tension beneath surface warmth. The
-    work is primarily vocal, with melodic songwriting at its core, though extended instrumental and noise sections frequently
-    interrupt or envelop the songs, treating texture itself as compositional material.
+  description: 'The Olivia Tremor Control blend dense, layered vocal harmonies with
+    lo-fi psychedelic production, creating a saturated, dreamlike sonic texture. Studio
+    techniques include tape manipulation, reversed loops, found sounds, and deliberate
+    noise artifacts that blur the boundary between composition and collage. The palette
+    shifts between warm acoustic folk-pop and distorted, disorienting experimental
+    passages, sometimes within a single track. Lyrically, imagery tends toward abstract,
+    surrealist landscapes — fragmented consciousness, dreamstates, cosmic or natural
+    motifs, and a sense of suspended or dissolving identity. The tone is simultaneously
+    intimate and dissociative. Emotionally, the music occupies a hazy, bittersweet
+    register: nostalgic yet unsettled, euphoric yet melancholic, with an underlying
+    psychological tension beneath surface warmth. The work is primarily vocal, with
+    melodic songwriting at its core, though extended instrumental and noise sections
+    frequently interrupt or envelop the songs, treating texture itself as compositional
+    material.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4257
+      present: 0.2612
+      future: 0.3131
+    spatial:
+      thing: 0.4265
+      place: 0.3127
+      person: 0.2608
+    ontological:
+      imagined: 0.3453
+      forgotten: 0.2978
+      known: 0.3568
+    confidence: 0.0223
   discogs_id: 252619
   notes: ''
 Television Personalities:
   slug: television_personalities
   status: draft
-  description: 'Television Personalities are a vocal-led project with a distinctly lo-fi, ramshackle production character.
-    Recordings carry deliberate roughness — thin, trebly guitar tones, rudimentary drumming, tape hiss, and a homemade quality
-    that resists polish. The sonic density is sparse to moderate, leaving space feeling accidental rather than designed. Lyrically,
-    themes orbit suburban alienation, disillusionment with pop culture, romantic melancholy, childhood nostalgia, and a sardonic
-    awareness of cultural pretension. Imagery tends toward the mundane rendered strange — ordinary English life viewed through
-    a slightly cracked lens. The tone oscillates between dry irony and genuine emotional vulnerability, sometimes simultaneously.
-    The emotional register carries weariness, detached bemusement, and an undercurrent of quiet sadness, occasionally tipping
-    into bleakness. Vocals are delivered in a flat, conversational style — unadorned and deliberately unpolished — reinforcing
-    the sense of intimate, unmediated confession.
+  description: 'Television Personalities are a vocal-led project with a distinctly
+    lo-fi, ramshackle production character. Recordings carry deliberate roughness
+    — thin, trebly guitar tones, rudimentary drumming, tape hiss, and a homemade quality
+    that resists polish. The sonic density is sparse to moderate, leaving space feeling
+    accidental rather than designed. Lyrically, themes orbit suburban alienation,
+    disillusionment with pop culture, romantic melancholy, childhood nostalgia, and
+    a sardonic awareness of cultural pretension. Imagery tends toward the mundane
+    rendered strange — ordinary English life viewed through a slightly cracked lens.
+    The tone oscillates between dry irony and genuine emotional vulnerability, sometimes
+    simultaneously. The emotional register carries weariness, detached bemusement,
+    and an undercurrent of quiet sadness, occasionally tipping into bleakness. Vocals
+    are delivered in a flat, conversational style — unadorned and deliberately unpolished
+    — reinforcing the sense of intimate, unmediated confession.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4389
+      present: 0.253
+      future: 0.3081
+    spatial:
+      thing: 0.44
+      place: 0.3078
+      person: 0.2522
+    ontological:
+      imagined: 0.3531
+      forgotten: 0.2921
+      known: 0.3549
+    confidence: 0.0283
   discogs_id: 83074
   notes: ''
 UILab:
   slug: uilab
   status: draft
-  description: UILab construct minimal electronic music at the intersection of motorik structure and ambient dissolution.
-    Compositions are built from repeating synthetic figures — simple melodic cells or rhythmic patterns that cycle with subtle,
-    incremental variation — establishing a hypnotic regularity that resists both stasis and conventional development. Production
-    is cool and precise, favouring clean timbres, modest reverb, and restrained dynamic range. Low-end frequencies are present
-    but controlled; mid-range synthesis carries most of the melodic weight. Arrangements are spare by design — space between
-    sounds is treated as compositional material rather than absence. The motorik element provides forward motion without urgency;
-    the ambient element prevents the rhythm from dominating, keeping the overall affect suspended between movement and stillness.
-    There is no lyrical content — the work is entirely instrumental, communicating through structural repetition, timbral
-    nuance, and the psychological effect of sustained, unhurried sonic environments. The emotional register is calm and analytical
-    — pleasurable but cool, cerebral without being cold.
+  description: UILab construct minimal electronic music at the intersection of motorik
+    structure and ambient dissolution. Compositions are built from repeating synthetic
+    figures — simple melodic cells or rhythmic patterns that cycle with subtle, incremental
+    variation — establishing a hypnotic regularity that resists both stasis and conventional
+    development. Production is cool and precise, favouring clean timbres, modest reverb,
+    and restrained dynamic range. Low-end frequencies are present but controlled;
+    mid-range synthesis carries most of the melodic weight. Arrangements are spare
+    by design — space between sounds is treated as compositional material rather than
+    absence. The motorik element provides forward motion without urgency; the ambient
+    element prevents the rhythm from dominating, keeping the overall affect suspended
+    between movement and stillness. There is no lyrical content — the work is entirely
+    instrumental, communicating through structural repetition, timbral nuance, and
+    the psychological effect of sustained, unhurried sonic environments. The emotional
+    register is calm and analytical — pleasurable but cool, cerebral without being
+    cold.
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4515
+      present: 0.2389
+      future: 0.3096
+    spatial:
+      thing: 0.4522
+      place: 0.3092
+      person: 0.2386
+    ontological:
+      imagined: 0.3509
+      forgotten: 0.2899
+      known: 0.3592
+    confidence: 0.0294
   discogs_id: 93183
   notes: Unknown artist — fill description manually
 Manfred Mann's Earth Band:
   slug: manfred_mann_s_earth_band
   status: draft
-  description: 'Manfred Mann''s Earth Band occupies a dense, richly layered sonic space where synthesizers and organ form
-    thick harmonic beds beneath heavily processed electric guitar and driving rhythm sections. Production tends toward full-spectrum
-    saturation, with keyboards given prominent textural weight and vocals sitting assertively within the mix. The band is
-    primarily vocal, with extended instrumental passages woven throughout. Lyrically and thematically, the material gravitates
-    toward existential searching, cosmic or mythological imagery, romantic yearning, and reflections on human struggle against
-    larger forces — sometimes drawing from literary or poetic sources. The emotional register is intense and elevated, carrying
-    a sense of grandiosity tempered by earnest vulnerability. There is a dramatic, almost cinematic quality to the arrangements,
-    blending progressive rock complexity with accessible melodic hooks, producing an affect that feels simultaneously expansive
+  description: 'Manfred Mann''s Earth Band occupies a dense, richly layered sonic
+    space where synthesizers and organ form thick harmonic beds beneath heavily processed
+    electric guitar and driving rhythm sections. Production tends toward full-spectrum
+    saturation, with keyboards given prominent textural weight and vocals sitting
+    assertively within the mix. The band is primarily vocal, with extended instrumental
+    passages woven throughout. Lyrically and thematically, the material gravitates
+    toward existential searching, cosmic or mythological imagery, romantic yearning,
+    and reflections on human struggle against larger forces — sometimes drawing from
+    literary or poetic sources. The emotional register is intense and elevated, carrying
+    a sense of grandiosity tempered by earnest vulnerability. There is a dramatic,
+    almost cinematic quality to the arrangements, blending progressive rock complexity
+    with accessible melodic hooks, producing an affect that feels simultaneously expansive
     and emotionally direct, straddling introspection and arena-scaled declaration.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4312
+      present: 0.26
+      future: 0.3088
+    spatial:
+      thing: 0.4322
+      place: 0.3086
+      person: 0.2592
+    ontological:
+      imagined: 0.3585
+      forgotten: 0.2935
+      known: 0.348
+    confidence: 0.0207
   discogs_id: 170358
   notes: ''
 Niton:
   slug: niton
   status: draft
-  description: Niton operates in a sparse, electronic sonic space built from minimal synthesis, careful use of silence, and
-    restrained rhythmic structures. Textures are cool and precise — oscillators sustain at low density, processed tones drift
-    at the margins of perception, and occasional percussive elements arrive with careful placement rather than pulse-driven
-    urgency. The overall sound is clean without being sterile, favouring spatial openness over layered density. Compositions
-    evolve through gradual timbral modulation, small harmonic shifts, and the subtle interaction between sound and the silence
-    surrounding it. There is little or no conventional melodic content — attention is directed toward texture, duration, and
-    the relationship between sounds in a shared space. Thematically, the work resists explicit imagery, presenting instead
-    a kind of ambient phenomenology — the careful observation of sound as physical event. The emotional register is neutral
-    and reflective, evoking neither urgency nor sentimentality but a quiet attentiveness that rewards sustained listening.
+  description: Niton operates in a sparse, electronic sonic space built from minimal
+    synthesis, careful use of silence, and restrained rhythmic structures. Textures
+    are cool and precise — oscillators sustain at low density, processed tones drift
+    at the margins of perception, and occasional percussive elements arrive with careful
+    placement rather than pulse-driven urgency. The overall sound is clean without
+    being sterile, favouring spatial openness over layered density. Compositions evolve
+    through gradual timbral modulation, small harmonic shifts, and the subtle interaction
+    between sound and the silence surrounding it. There is little or no conventional
+    melodic content — attention is directed toward texture, duration, and the relationship
+    between sounds in a shared space. Thematically, the work resists explicit imagery,
+    presenting instead a kind of ambient phenomenology — the careful observation of
+    sound as physical event. The emotional register is neutral and reflective, evoking
+    neither urgency nor sentimentality but a quiet attentiveness that rewards sustained
+    listening.
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4399
+      present: 0.2492
+      future: 0.3109
+    spatial:
+      thing: 0.4406
+      place: 0.3105
+      person: 0.2489
+    ontological:
+      imagined: 0.354
+      forgotten: 0.2911
+      known: 0.3549
+    confidence: 0.031
   discogs_id: 3548044
   notes: Unknown artist — fill description manually
 Visible Cloaks:
   slug: visible_cloaks
   status: draft
-  description: 'Visible Cloaks work primarily instrumentally, constructing music of exceptional timbral precision and spatial
-    delicacy. Their production approach merges digital synthesis with acoustic and traditional East Asian instrumentation,
-    creating textures that feel simultaneously ancient and computational — crystalline, cool, and meticulously arranged. Density
-    is restrained; space functions as a compositional element, with silences and subtle resonances carrying as much weight
-    as sound. Timbres lean toward translucent metallics, soft percussive decays, and pure sine-adjacent tones layered with
-    field-recording-like intimacy. Thematic tendencies orbit concepts of mediation, transmission, and cultural translation
-    — the boundary between organic and synthetic, between geographical and sonic distance. The emotional register is contemplative
-    and suspended, evoking a calm alertness rather than overt sentiment. Psychological colour tends toward the liminal — neither
-    melancholic nor euphoric, but occupying a luminous, attentive middle space suggesting careful observation of transient
-    phenomena.
+  description: 'Visible Cloaks work primarily instrumentally, constructing music of
+    exceptional timbral precision and spatial delicacy. Their production approach
+    merges digital synthesis with acoustic and traditional East Asian instrumentation,
+    creating textures that feel simultaneously ancient and computational — crystalline,
+    cool, and meticulously arranged. Density is restrained; space functions as a compositional
+    element, with silences and subtle resonances carrying as much weight as sound.
+    Timbres lean toward translucent metallics, soft percussive decays, and pure sine-adjacent
+    tones layered with field-recording-like intimacy. Thematic tendencies orbit concepts
+    of mediation, transmission, and cultural translation — the boundary between organic
+    and synthetic, between geographical and sonic distance. The emotional register
+    is contemplative and suspended, evoking a calm alertness rather than overt sentiment.
+    Psychological colour tends toward the liminal — neither melancholic nor euphoric,
+    but occupying a luminous, attentive middle space suggesting careful observation
+    of transient phenomena.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4455
+      present: 0.2499
+      future: 0.3046
+    spatial:
+      thing: 0.4463
+      place: 0.3047
+      person: 0.249
+    ontological:
+      imagined: 0.3438
+      forgotten: 0.2911
+      known: 0.3651
+    confidence: 0.027
   discogs_id: 4398429
   notes: ''
 Pink Floyd:
   slug: pink_floyd
   status: draft
-  description: 'Pink Floyd occupies a sonic space of vast, immersive density, built through layered synthesizers, heavily
-    processed guitars, and deliberately paced rhythmic structures. Production favors wide stereo fields, cavernous reverb,
-    and meticulous studio craft, creating a sense of physical space within recordings. Timbres lean toward the warm, the metallic,
-    and the otherworldly, often blurring boundaries between acoustic and electronic sources.
+  description: 'Pink Floyd occupies a sonic space of vast, immersive density, built
+    through layered synthesizers, heavily processed guitars, and deliberately paced
+    rhythmic structures. Production favors wide stereo fields, cavernous reverb, and
+    meticulous studio craft, creating a sense of physical space within recordings.
+    Timbres lean toward the warm, the metallic, and the otherworldly, often blurring
+    boundaries between acoustic and electronic sources.
 
 
-    Lyrically, themes circle alienation, psychological fragmentation, war''s dehumanizing machinery, consumer society''s numbness,
-    and the thin membrane between sanity and collapse. Imagery is surreal yet grounded in mundane detail — clinical, sometimes
+    Lyrically, themes circle alienation, psychological fragmentation, war''s dehumanizing
+    machinery, consumer society''s numbness, and the thin membrane between sanity
+    and collapse. Imagery is surreal yet grounded in mundane detail — clinical, sometimes
     coldly observational in tone.
 
 
-    The emotional register is predominantly introspective, melancholic, and psychologically uneasy, occasionally erupting
-    into cathartic intensity or dark irony. A persistent sense of existential dread underlies even quieter passages.
+    The emotional register is predominantly introspective, melancholic, and psychologically
+    uneasy, occasionally erupting into cathartic intensity or dark irony. A persistent
+    sense of existential dread underlies even quieter passages.
 
 
-    The band is primarily vocal-driven, though extended instrumental passages are central to the compositional architecture.
+    The band is primarily vocal-driven, though extended instrumental passages are
+    central to the compositional architecture.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4238
+      present: 0.2633
+      future: 0.3129
+    spatial:
+      thing: 0.4247
+      place: 0.3125
+      person: 0.2627
+    ontological:
+      imagined: 0.3463
+      forgotten: 0.2991
+      known: 0.3545
+    confidence: 0.0194
   discogs_id: 45467
   notes: ''
 Radiohead:
   slug: radiohead
   status: draft
-  description: 'Radiohead occupies a space between organic and electronic sound, layering guitars, synthesizers, processed
-    strings, and fractured digital textures into densely atmospheric productions. Studio work emphasizes space, distortion
-    control, and unconventional signal processing, often dissolving conventional song architecture into ambient drift or polyrhythmic
-    tension. Timbres range from warm acoustic intimacy to cold, clinical electronics, sometimes within a single piece.
+  description: 'Radiohead occupies a space between organic and electronic sound, layering
+    guitars, synthesizers, processed strings, and fractured digital textures into
+    densely atmospheric productions. Studio work emphasizes space, distortion control,
+    and unconventional signal processing, often dissolving conventional song architecture
+    into ambient drift or polyrhythmic tension. Timbres range from warm acoustic intimacy
+    to cold, clinical electronics, sometimes within a single piece.
 
 
-    Lyrically, the work circles themes of alienation, technological anxiety, psychological dissociation, political dread,
-    and existential fragility. Imagery tends toward the abstract and elliptical, resisting narrative closure. Tone is rarely
-    consoling, favouring unresolved tension over catharsis.
+    Lyrically, the work circles themes of alienation, technological anxiety, psychological
+    dissociation, political dread, and existential fragility. Imagery tends toward
+    the abstract and elliptical, resisting narrative closure. Tone is rarely consoling,
+    favouring unresolved tension over catharsis.
 
 
-    The emotional register is predominantly introspective, melancholic, and unsettled — occasionally breaking into euphoric
-    release or quiet resignation. Paranoia and vulnerability coexist throughout.
+    The emotional register is predominantly introspective, melancholic, and unsettled
+    — occasionally breaking into euphoric release or quiet resignation. Paranoia and
+    vulnerability coexist throughout.
 
 
-    The band is primarily vocal-led, with Thom Yorke''s falsetto-dominant voice functioning as an additional textural instrument
-    rather than a conventional melodic anchor.
+    The band is primarily vocal-led, with Thom Yorke''s falsetto-dominant voice functioning
+    as an additional textural instrument rather than a conventional melodic anchor.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4207
+      present: 0.2645
+      future: 0.3148
+    spatial:
+      thing: 0.4215
+      place: 0.3144
+      person: 0.2641
+    ontological:
+      imagined: 0.3528
+      forgotten: 0.2969
+      known: 0.3503
+    confidence: 0.0199
   discogs_id: 3840
   notes: ''
 Kraftwerk:
   slug: kraftwerk
   status: draft
-  description: 'Kraftwerk''s sonic palette is built from clean, modular synthesizer tones, motorik rhythmic grids, and metronomic
-    drum machines layered with precise, minimal density. Production is deliberately clinical — dry, symmetrical, and sterile,
-    favouring repetition over development. Textures sit in mid-to-upper registers, often thin and glassy, punctuated by mechanical
-    sound effects and processed vocal fragments.
+  description: 'Kraftwerk''s sonic palette is built from clean, modular synthesizer
+    tones, motorik rhythmic grids, and metronomic drum machines layered with precise,
+    minimal density. Production is deliberately clinical — dry, symmetrical, and sterile,
+    favouring repetition over development. Textures sit in mid-to-upper registers,
+    often thin and glassy, punctuated by mechanical sound effects and processed vocal
+    fragments.
 
 
-    Lyrically, themes orbit technology, infrastructure, transit, robotics, and human-machine symbiosis. Imagery tends toward
-    the urban, the systematic, and the futuristic-mundane — highways, data transmission, automated bodies. Tone is declarative
-    and affectless.
+    Lyrically, themes orbit technology, infrastructure, transit, robotics, and human-machine
+    symbiosis. Imagery tends toward the urban, the systematic, and the futuristic-mundane
+    — highways, data transmission, automated bodies. Tone is declarative and affectless.
 
 
-    Vocals are present but treated instrumentally — monotone, heavily processed, sometimes vocoded into near-synthetic uniformity,
-    functioning less as expressive delivery and more as timbral element.
+    Vocals are present but treated instrumentally — monotone, heavily processed, sometimes
+    vocoded into near-synthetic uniformity, functioning less as expressive delivery
+    and more as timbral element.
 
 
-    The emotional register is detached, cool, and hypnotic — projecting a smooth, frictionless affect with an undercurrent
-    of estrangement and utopian ambiguity.
+    The emotional register is detached, cool, and hypnotic — projecting a smooth,
+    frictionless affect with an undercurrent of estrangement and utopian ambiguity.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4095
+      present: 0.2682
+      future: 0.3223
+    spatial:
+      thing: 0.4102
+      place: 0.3218
+      person: 0.2679
+    ontological:
+      imagined: 0.3489
+      forgotten: 0.3064
+      known: 0.3447
+    confidence: 0.0125
   discogs_id: 4654
   notes: ''
 Terry Riley:
   slug: terry_riley
   status: draft
-  description: 'Terry Riley''s work is primarily instrumental, rooted in minimalist repetition and extended, hypnotic cycles.
-    Sonically, his textures are dense yet meditative, layering tape loops, electric organ, saxophone, and synthesizer into
-    shimmering, slowly evolving drones. The production character favors warmth and analog depth, with gradual phase-shifting
-    creating subtle rhythmic interference patterns. Timbres are often circular and suspended, resisting conventional resolution.
-    Thematically, his instrumental work evokes cyclical time, ritual consciousness, and trance-like spiritual states, drawing
-    loosely on Eastern meditative traditions and psychedelic awareness without explicit narrative. The emotional register
-    is contemplative, expansive, and internally focused — sustaining a psychological state of open alertness or deep stillness
-    rather than dramatic arc. Dynamics shift incrementally rather than abruptly, cultivating patience and immersion. The overall
-    affect is one of timeless suspension, blurring boundaries between structure and improvisation, foreground and atmosphere.
+  description: 'Terry Riley''s work is primarily instrumental, rooted in minimalist
+    repetition and extended, hypnotic cycles. Sonically, his textures are dense yet
+    meditative, layering tape loops, electric organ, saxophone, and synthesizer into
+    shimmering, slowly evolving drones. The production character favors warmth and
+    analog depth, with gradual phase-shifting creating subtle rhythmic interference
+    patterns. Timbres are often circular and suspended, resisting conventional resolution.
+    Thematically, his instrumental work evokes cyclical time, ritual consciousness,
+    and trance-like spiritual states, drawing loosely on Eastern meditative traditions
+    and psychedelic awareness without explicit narrative. The emotional register is
+    contemplative, expansive, and internally focused — sustaining a psychological
+    state of open alertness or deep stillness rather than dramatic arc. Dynamics shift
+    incrementally rather than abruptly, cultivating patience and immersion. The overall
+    affect is one of timeless suspension, blurring boundaries between structure and
+    improvisation, foreground and atmosphere.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4232
+      present: 0.2619
+      future: 0.3149
+    spatial:
+      thing: 0.4238
+      place: 0.3149
+      person: 0.2614
+    ontological:
+      imagined: 0.3403
+      forgotten: 0.3013
+      known: 0.3584
+    confidence: 0.0166
   discogs_id: 32198
   notes: ''
 Amp:
   slug: amp
   status: draft
-  description: Amp builds atmospheric sound from interlocking layers of treated electric guitar, synthesiser, and subtle electronic
-    processing. Guitars shimmer rather than drive — tremolo-drenched, reverb-saturated, their edges blurred until they function
-    as tonal atmosphere rather than melodic instrument. Production favours warmth over precision, with a gently analogue imprecision
-    that softens the electronics into something that breathes. Female vocals float above or within the instrumental texture
-    — softly delivered and lightly processed — never forcing a foreground position, instead merging with the surrounding harmonic
-    environment. Arrangements move slowly and spaciously, with changes arriving through gradual drift rather than structural
-    break. Thematic territory orbits inwardness, private introspection, and the emotional texture of experience held interior
-    rather than expressed — imagery is impressionistic, gesturing toward feeling states rather than events. The emotional
-    register is contemplative and tender, occupying a psychological space between reverie and quiet melancholy — not despairing
-    but gently sorrowful, suffused with a bittersweet quality that feels personal without being confessional.
+  description: Amp builds atmospheric sound from interlocking layers of treated electric
+    guitar, synthesiser, and subtle electronic processing. Guitars shimmer rather
+    than drive — tremolo-drenched, reverb-saturated, their edges blurred until they
+    function as tonal atmosphere rather than melodic instrument. Production favours
+    warmth over precision, with a gently analogue imprecision that softens the electronics
+    into something that breathes. Female vocals float above or within the instrumental
+    texture — softly delivered and lightly processed — never forcing a foreground
+    position, instead merging with the surrounding harmonic environment. Arrangements
+    move slowly and spaciously, with changes arriving through gradual drift rather
+    than structural break. Thematic territory orbits inwardness, private introspection,
+    and the emotional texture of experience held interior rather than expressed —
+    imagery is impressionistic, gesturing toward feeling states rather than events.
+    The emotional register is contemplative and tender, occupying a psychological
+    space between reverie and quiet melancholy — not despairing but gently sorrowful,
+    suffused with a bittersweet quality that feels personal without being confessional.
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4345
+      present: 0.2579
+      future: 0.3076
+    spatial:
+      thing: 0.4352
+      place: 0.3076
+      person: 0.2572
+    ontological:
+      imagined: 0.3442
+      forgotten: 0.2934
+      known: 0.3624
+    confidence: 0.0214
   discogs_id: 4090
   notes: Unknown artist — fill description manually
 The Space Spectrum:
   slug: the_space_spectrum
   status: draft
-  description: The Space Spectrum construct slow-moving, immersive instrumental environments from layered synthesiser drones,
-    processed guitar, and textural electronics. Sound sources are blended until individual timbres dissolve into continuous,
-    evolving fields — the distinction between melody, harmony, and texture deliberately collapsed. Production favours depth
-    and spatial extension, with reverb and delay used not as effects but as structural components that expand the apparent
-    dimensions of the sound. Rhythmic elements are minimal or absent, replaced by the organic ebb and flow of sustained tones
-    shifting against one another. Thematic territory, suggested by instrumentation and affect rather than lyrical content,
-    gravitates toward vastness, isolation, and the contemplation of scale — imagery of deep space, oceanic depth, and the
-    experience of duration. The emotional register is expansive and introspective simultaneously, evoking a particular form
-    of solitude that is not loneliness but chosen removal — a sense of floating within something enormous and indifferent,
-    finding it beautiful rather than threatening.
+  description: The Space Spectrum construct slow-moving, immersive instrumental environments
+    from layered synthesiser drones, processed guitar, and textural electronics. Sound
+    sources are blended until individual timbres dissolve into continuous, evolving
+    fields — the distinction between melody, harmony, and texture deliberately collapsed.
+    Production favours depth and spatial extension, with reverb and delay used not
+    as effects but as structural components that expand the apparent dimensions of
+    the sound. Rhythmic elements are minimal or absent, replaced by the organic ebb
+    and flow of sustained tones shifting against one another. Thematic territory,
+    suggested by instrumentation and affect rather than lyrical content, gravitates
+    toward vastness, isolation, and the contemplation of scale — imagery of deep space,
+    oceanic depth, and the experience of duration. The emotional register is expansive
+    and introspective simultaneously, evoking a particular form of solitude that is
+    not loneliness but chosen removal — a sense of floating within something enormous
+    and indifferent, finding it beautiful rather than threatening.
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.472
+      present: 0.2287
+      future: 0.2993
+    spatial:
+      thing: 0.4726
+      place: 0.299
+      person: 0.2284
+    ontological:
+      imagined: 0.3465
+      forgotten: 0.2801
+      known: 0.3734
+    confidence: 0.0461
   discogs_id: 3623833
   notes: Unknown artist — fill description manually
 Animal Collective:
   slug: animal_collective
   status: draft
-  description: 'Animal Collective blends densely layered vocal harmonies with fractured, loop-based electronic and acoustic
-    textures, creating productions that feel simultaneously tribal and psychedelic. Studio work emphasizes saturated reverb,
-    pitch-shifted samples, and collaged sound design, where timbres blur between organic and synthetic. The result is a high-density
-    sonic environment where individual elements dissolve into shimmering, rhythmically complex webs.
+  description: 'Animal Collective blends densely layered vocal harmonies with fractured,
+    loop-based electronic and acoustic textures, creating productions that feel simultaneously
+    tribal and psychedelic. Studio work emphasizes saturated reverb, pitch-shifted
+    samples, and collaged sound design, where timbres blur between organic and synthetic.
+    The result is a high-density sonic environment where individual elements dissolve
+    into shimmering, rhythmically complex webs.
 
 
-    Lyrically, themes orbit childhood memory, domestic intimacy, seasonal cycles, and a sense of wonder toward the natural
-    and supernatural. Imagery tends toward the pastoral, the dreamlike, and the anxiously tender. Vocals are central and prominent,
-    often multi-tracked into choral masses, functioning both melodically and as textural instruments.
+    Lyrically, themes orbit childhood memory, domestic intimacy, seasonal cycles,
+    and a sense of wonder toward the natural and supernatural. Imagery tends toward
+    the pastoral, the dreamlike, and the anxiously tender. Vocals are central and
+    prominent, often multi-tracked into choral masses, functioning both melodically
+    and as textural instruments.
 
 
-    The emotional register spans ecstatic euphoria, nostalgic melancholy, and uneasy awe — frequently within a single piece.
-    The psychological colour is warmly hallucinatory, evoking liminal states between waking and dreaming, comfort and disorientation.
+    The emotional register spans ecstatic euphoria, nostalgic melancholy, and uneasy
+    awe — frequently within a single piece. The psychological colour is warmly hallucinatory,
+    evoking liminal states between waking and dreaming, comfort and disorientation.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4169
+      present: 0.2639
+      future: 0.3192
+    spatial:
+      thing: 0.4177
+      place: 0.3186
+      person: 0.2637
+    ontological:
+      imagined: 0.3374
+      forgotten: 0.3057
+      known: 0.3569
+    confidence: 0.0185
   discogs_id: 207958
   notes: ''
 The Dead Boys:
   slug: the_dead_boys
   status: draft
-  description: 'The Dead Boys deliver a raw, abrasive sonic texture rooted in first-wave American punk — guitars are trebly,
-    distorted, and deliberately ragged, with minimal studio polish creating a live, confrontational density. Production skews
-    lo-fi and aggressive, emphasizing speed, noise, and urgency over precision. The band is primarily vocal-driven, with lead
-    vocals delivered in a sneering, snarling, antagonistic register that bleeds into physical provocation and theatrical menace.
-    Lyrically, themes orbit nihilism, urban decay, transgression, bodily violence, and deliberate offensiveness — imagery
-    is visceral and confrontational, drawing on street-level desperation and shock aesthetics. Emotionally, the register is
-    hostile, reckless, and deliberately destabilizing — projecting a psychological colour of controlled chaos and self-destructive
-    energy. There is little sentimentality; affect is blunt, combative, and intentionally uncomfortable, sitting at the intersection
+  description: 'The Dead Boys deliver a raw, abrasive sonic texture rooted in first-wave
+    American punk — guitars are trebly, distorted, and deliberately ragged, with minimal
+    studio polish creating a live, confrontational density. Production skews lo-fi
+    and aggressive, emphasizing speed, noise, and urgency over precision. The band
+    is primarily vocal-driven, with lead vocals delivered in a sneering, snarling,
+    antagonistic register that bleeds into physical provocation and theatrical menace.
+    Lyrically, themes orbit nihilism, urban decay, transgression, bodily violence,
+    and deliberate offensiveness — imagery is visceral and confrontational, drawing
+    on street-level desperation and shock aesthetics. Emotionally, the register is
+    hostile, reckless, and deliberately destabilizing — projecting a psychological
+    colour of controlled chaos and self-destructive energy. There is little sentimentality;
+    affect is blunt, combative, and intentionally uncomfortable, sitting at the intersection
     of rage and dark absurdist provocation.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4004
+      present: 0.272
+      future: 0.3276
+    spatial:
+      thing: 0.4012
+      place: 0.3271
+      person: 0.2716
+    ontological:
+      imagined: 0.3301
+      forgotten: 0.3173
+      known: 0.3526
+    confidence: 0.0142
   discogs_id: 266431
   notes: ''
 The Rolling Stones:
   slug: the_rolling_stones
   status: draft
-  description: 'The Rolling Stones are a vocal-led rock ensemble with a sound built on raw, slightly abrasive electric guitar
-    tones, prominent blues-inflected riffs, and a loose, lived-in rhythmic feel. Production tends toward gritty immediacy
-    rather than pristine clarity, with layered guitars, understated bass, and dry or moderately reverberant drums creating
-    a dense yet organic texture. Lyrically, themes circle around desire, transgression, street-level cynicism, hedonism, and
-    power dynamics, often employing blues imagery, urban grit, and sardonic wit. The tone moves between swagger and menace,
-    occasionally softening into melancholy or longing. Emotionally, the register is restless and visceral — charged with tension,
-    defiance, and a persistent undercurrent of world-weary sensuality. Vocally, the lead style is rough-edged and conversational,
-    favoring attitude over technical precision, with harmonica and piano frequently reinforcing the ensemble''s earthy, blues-rooted
-    character.
+  description: 'The Rolling Stones are a vocal-led rock ensemble with a sound built
+    on raw, slightly abrasive electric guitar tones, prominent blues-inflected riffs,
+    and a loose, lived-in rhythmic feel. Production tends toward gritty immediacy
+    rather than pristine clarity, with layered guitars, understated bass, and dry
+    or moderately reverberant drums creating a dense yet organic texture. Lyrically,
+    themes circle around desire, transgression, street-level cynicism, hedonism, and
+    power dynamics, often employing blues imagery, urban grit, and sardonic wit. The
+    tone moves between swagger and menace, occasionally softening into melancholy
+    or longing. Emotionally, the register is restless and visceral — charged with
+    tension, defiance, and a persistent undercurrent of world-weary sensuality. Vocally,
+    the lead style is rough-edged and conversational, favoring attitude over technical
+    precision, with harmonica and piano frequently reinforcing the ensemble''s earthy,
+    blues-rooted character.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.428
+      present: 0.2588
+      future: 0.3132
+    spatial:
+      thing: 0.4288
+      place: 0.3128
+      person: 0.2583
+    ontological:
+      imagined: 0.3439
+      forgotten: 0.2979
+      known: 0.3582
+    confidence: 0.0185
   discogs_id: 20991
   notes: ''
 Boards of Canada:
   slug: boards_of_canada
   status: draft
-  description: 'Boards of Canada craft dense, warm electronic textures built from degraded analog synthesis, tape saturation,
-    and lo-fi sampling. Production favors muffled low-pass filtering, dusty drum machine grooves, and carefully detuned oscillators
-    that evoke decaying magnetic media. The sonic palette is thick and layered, with bass frequencies cushioned beneath hazy
-    mid-range beds and fractured, half-buried vocal samples processed into near-abstraction.
+  description: 'Boards of Canada craft dense, warm electronic textures built from
+    degraded analog synthesis, tape saturation, and lo-fi sampling. Production favors
+    muffled low-pass filtering, dusty drum machine grooves, and carefully detuned
+    oscillators that evoke decaying magnetic media. The sonic palette is thick and
+    layered, with bass frequencies cushioned beneath hazy mid-range beds and fractured,
+    half-buried vocal samples processed into near-abstraction.
 
 
-    The work is primarily instrumental, though fragmented voices and children''s speech surface as textural elements rather
-    than narrative devices. Thematically, imagery clusters around childhood memory, nature, esoteric geometry, and temporal
-    dislocation — a sense of documentary footage recalled imperfectly.
+    The work is primarily instrumental, though fragmented voices and children''s speech
+    surface as textural elements rather than narrative devices. Thematically, imagery
+    clusters around childhood memory, nature, esoteric geometry, and temporal dislocation
+    — a sense of documentary footage recalled imperfectly.
 
 
-    Emotionally, the music occupies a liminal psychological space: nostalgic yet unsettling, pastoral yet subtly threatening.
-    The affect is dreamlike and introspective, evoking summer afternoons filmed on degraded stock, simultaneously comforting
-    and quietly anxious.
+    Emotionally, the music occupies a liminal psychological space: nostalgic yet unsettling,
+    pastoral yet subtly threatening. The affect is dreamlike and introspective, evoking
+    summer afternoons filmed on degraded stock, simultaneously comforting and quietly
+    anxious.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4314
+      present: 0.2552
+      future: 0.3134
+    spatial:
+      thing: 0.4319
+      place: 0.3131
+      person: 0.255
+    ontological:
+      imagined: 0.3368
+      forgotten: 0.2991
+      known: 0.364
+    confidence: 0.0171
   discogs_id: 307
   notes: ''
 Joy Division:
   slug: joy_division
   status: draft
-  description: 'Joy Division is a vocal-led rock group whose sonic signature blends cavernous, echo-drenched production with
-    a stark, minimal density. Bass frequencies dominate the low end, thick and melodic, anchored beneath sparse, angular guitar
-    textures and metronomic, powerful drumming. Production favours cavernous reverb, creating a cold, industrial spaciousness
-    where sounds feel simultaneously intimate and vast. Synthesiser lines surface as ghostly, atmospheric layers. Lyrically,
-    themes circle alienation, psychological fragmentation, disintegration of self, and existential dread, rendered through
-    bleak urban imagery, fractured perception, and an atmosphere of inescapable entropy. The tone is oblique rather than confessional,
-    with imagery drawn from clinical detachment and inner collapse. The emotional register is relentlessly sombre, evoking
-    grief, anxiety, numbness, and a particular post-industrial bleakness — tense yet strangely meditative, with moments of
-    desperate urgency punctuating sustained, hollow desolation.
+  description: 'Joy Division is a vocal-led rock group whose sonic signature blends
+    cavernous, echo-drenched production with a stark, minimal density. Bass frequencies
+    dominate the low end, thick and melodic, anchored beneath sparse, angular guitar
+    textures and metronomic, powerful drumming. Production favours cavernous reverb,
+    creating a cold, industrial spaciousness where sounds feel simultaneously intimate
+    and vast. Synthesiser lines surface as ghostly, atmospheric layers. Lyrically,
+    themes circle alienation, psychological fragmentation, disintegration of self,
+    and existential dread, rendered through bleak urban imagery, fractured perception,
+    and an atmosphere of inescapable entropy. The tone is oblique rather than confessional,
+    with imagery drawn from clinical detachment and inner collapse. The emotional
+    register is relentlessly sombre, evoking grief, anxiety, numbness, and a particular
+    post-industrial bleakness — tense yet strangely meditative, with moments of desperate
+    urgency punctuating sustained, hollow desolation.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4193
+      present: 0.2648
+      future: 0.3159
+    spatial:
+      thing: 0.4202
+      place: 0.3156
+      person: 0.2643
+    ontological:
+      imagined: 0.3519
+      forgotten: 0.3001
+      known: 0.348
+    confidence: 0.0174
   discogs_id: 3898
   notes: ''
 Mad Professor:
   slug: mad_professor
   status: draft
-  description: 'Mad Professor operates in deep dub reggae territory, crafting productions dense with cavernous reverb, echo-drenched
-    basslines, and precisely delayed percussion that creates vast spatial depth. The sonic texture is thick yet deliberately
-    hollow — instruments appear and dissolve into reverberant space, creating a sense of geological layering. Studio manipulation
-    is central: tracks are constructed through conscious engineering, with effects becoming compositional elements rather
-    than ornamentation. The emotional register is hypnotic and meditative, carrying an undertow of cosmic mystery and spiritual
-    weight. Thematically, works tend toward Afrocentric consciousness, spiritual resistance, and metaphysical contemplation,
-    rendered through imagery of shadows, forces, and elemental power. The tone is solemn yet transportive. Productions are
-    primarily instrumental or near-instrumental, with vocal elements — when present — treated as textural components submerged
+  description: 'Mad Professor operates in deep dub reggae territory, crafting productions
+    dense with cavernous reverb, echo-drenched basslines, and precisely delayed percussion
+    that creates vast spatial depth. The sonic texture is thick yet deliberately hollow
+    — instruments appear and dissolve into reverberant space, creating a sense of
+    geological layering. Studio manipulation is central: tracks are constructed through
+    conscious engineering, with effects becoming compositional elements rather than
+    ornamentation. The emotional register is hypnotic and meditative, carrying an
+    undertow of cosmic mystery and spiritual weight. Thematically, works tend toward
+    Afrocentric consciousness, spiritual resistance, and metaphysical contemplation,
+    rendered through imagery of shadows, forces, and elemental power. The tone is
+    solemn yet transportive. Productions are primarily instrumental or near-instrumental,
+    with vocal elements — when present — treated as textural components submerged
     within the dub architecture rather than foregrounded as lyrical delivery.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4216
+      present: 0.2642
+      future: 0.3143
+    spatial:
+      thing: 0.4226
+      place: 0.3138
+      person: 0.2636
+    ontological:
+      imagined: 0.3486
+      forgotten: 0.301
+      known: 0.3504
+    confidence: 0.0258
   discogs_id: 7870
   notes: ''
 Pale Saints:
   slug: pale_saints
   status: draft
-  description: 'Pale Saints craft a sound built on layered, reverb-saturated guitars that blur into dense, luminous walls
-    of texture, underpinned by driving rhythms and bass lines that anchor the ethereal surface. Production leans into haze
-    and depth, with instruments dissolving into one another through deliberate use of delay and spatial processing. Vocals
-    — both male and female — are treated as melodic instruments, often hushed and submerged within the mix, contributing to
-    a diffuse, introverted quality. Lyrically, imagery tends toward the abstract and interior: fragmented emotional states,
-    longing, dissolution of self, and an atmosphere of quiet unease or wistful distance. Themes circle transience, isolation,
-    and subdued desire. The emotional register is melancholic yet gently euphoric, suggesting yearning held at arm''s length.
-    The work is primarily vocal but foregrounds texture so heavily that instrumentation carries equivalent expressive weight.
+  description: 'Pale Saints craft a sound built on layered, reverb-saturated guitars
+    that blur into dense, luminous walls of texture, underpinned by driving rhythms
+    and bass lines that anchor the ethereal surface. Production leans into haze and
+    depth, with instruments dissolving into one another through deliberate use of
+    delay and spatial processing. Vocals — both male and female — are treated as melodic
+    instruments, often hushed and submerged within the mix, contributing to a diffuse,
+    introverted quality. Lyrically, imagery tends toward the abstract and interior:
+    fragmented emotional states, longing, dissolution of self, and an atmosphere of
+    quiet unease or wistful distance. Themes circle transience, isolation, and subdued
+    desire. The emotional register is melancholic yet gently euphoric, suggesting
+    yearning held at arm''s length. The work is primarily vocal but foregrounds texture
+    so heavily that instrumentation carries equivalent expressive weight.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4479
+      present: 0.2467
+      future: 0.3054
+    spatial:
+      thing: 0.4488
+      place: 0.3052
+      person: 0.2461
+    ontological:
+      imagined: 0.3511
+      forgotten: 0.2881
+      known: 0.3607
+    confidence: 0.0389
   discogs_id: 88711
   notes: ''
 Ruhr:
   slug: ruhr
   status: draft
-  description: RUHR is a project born between Verona and Berlin, mixing rough analog synth sounds inspired by the beginning
-    of the minimal electronic music with the more contemporary sound of the Berlin scene. The result is a sound that is both
-    raw and polished, with a strong emphasis on rhythm and texture. The production style is characterized by a blend of vintage
-    and modern techniques, creating a unique sonic landscape that is both nostalgic and forward-thinking. Thematically, RUHR
-    explores themes of urban life, technology, and human connection, often using abstract and poetic imagery to convey complex
-    ideas. The emotional register is dynamic and multifaceted, evoking feelings of excitement, introspection, and a sense
-    of belonging within the electronic music community.
+  description: RUHR is a project born between Verona and Berlin, mixing rough analog
+    synth sounds inspired by the beginning of the minimal electronic music with the
+    more contemporary sound of the Berlin scene. The result is a sound that is both
+    raw and polished, with a strong emphasis on rhythm and texture. The production
+    style is characterized by a blend of vintage and modern techniques, creating a
+    unique sonic landscape that is both nostalgic and forward-thinking. Thematically,
+    RUHR explores themes of urban life, technology, and human connection, often using
+    abstract and poetic imagery to convey complex ideas. The emotional register is
+    dynamic and multifaceted, evoking feelings of excitement, introspection, and a
+    sense of belonging within the electronic music community.
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4396
+      present: 0.2516
+      future: 0.3088
+    spatial:
+      thing: 0.4412
+      place: 0.3081
+      person: 0.2508
+    ontological:
+      imagined: 0.355
+      forgotten: 0.2894
+      known: 0.3555
+    confidence: 0.084
   discogs_id: 93854
   notes: Unknown artist — fill description manually
 Ride:
   slug: ride
   status: draft
-  description: 'Ride occupies a dense, shimmering sonic space where heavily layered electric guitars generate walls of reverb-saturated
-    noise, softened by melodic sweetness. Production leans into lush, almost painterly guitar textures — tremolo, feedback,
-    and cascading chord voicings blurring instrumental and vocal elements into unified washes of sound. Vocals are present
-    but often submerged within the instrumental mass, functioning more as textural colour than lyrical foreground. Thematically,
-    imagery gravitates toward introspection, dreamlike states, emotional distance, longing, and the ambiguity between inner
-    and outer landscapes. Tonal references evoke sky, light, movement, and psychological drift. The emotional register is
-    simultaneously euphoric and melancholic — warmth shot through with unease, ecstasy tinged with detachment. Rhythmically,
-    the music tends toward driving momentum beneath the textural density, grounding the atmospheric qualities with persistent
-    forward motion.
+  description: 'Ride occupies a dense, shimmering sonic space where heavily layered
+    electric guitars generate walls of reverb-saturated noise, softened by melodic
+    sweetness. Production leans into lush, almost painterly guitar textures — tremolo,
+    feedback, and cascading chord voicings blurring instrumental and vocal elements
+    into unified washes of sound. Vocals are present but often submerged within the
+    instrumental mass, functioning more as textural colour than lyrical foreground.
+    Thematically, imagery gravitates toward introspection, dreamlike states, emotional
+    distance, longing, and the ambiguity between inner and outer landscapes. Tonal
+    references evoke sky, light, movement, and psychological drift. The emotional
+    register is simultaneously euphoric and melancholic — warmth shot through with
+    unease, ecstasy tinged with detachment. Rhythmically, the music tends toward driving
+    momentum beneath the textural density, grounding the atmospheric qualities with
+    persistent forward motion.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4259
+      present: 0.2583
+      future: 0.3158
+    spatial:
+      thing: 0.4266
+      place: 0.3155
+      person: 0.2579
+    ontological:
+      imagined: 0.3449
+      forgotten: 0.3001
+      known: 0.355
+    confidence: 0.0193
   discogs_id: 10138
   notes: ''
 The Lewers:
   slug: the_lewers
   status: draft
-  description: 'The Lewers mine completely different territory and are best described as a pop minded, avant leaning group
-    that revolves around counter points and a pure approach.
+  description: 'The Lewers mine completely different territory and are best described
+    as a pop minded, avant leaning group that revolves around counter points and a
+    pure approach.
 
 
-    Both positive and negative space are utilised. Instruments move where they want or need to be. Control and chaos have
-    equal consideration. A wide range of emotions are explored. There is a focus on the relationship between harmony and dissonance.
-    The emphasis on atmosphere is heavy. Motifs are loose. The guitars hit like a wave. Delays refract and ricochet off the
-    wall.
+    Both positive and negative space are utilised. Instruments move where they want
+    or need to be. Control and chaos have equal consideration. A wide range of emotions
+    are explored. There is a focus on the relationship between harmony and dissonance.
+    The emphasis on atmosphere is heavy. Motifs are loose. The guitars hit like a
+    wave. Delays refract and ricochet off the wall.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.3826
+      present: 0.2895
+      future: 0.3279
+    spatial:
+      thing: 0.3833
+      place: 0.3278
+      person: 0.2889
+    ontological:
+      imagined: 0.3341
+      forgotten: 0.3198
+      known: 0.3461
+    confidence: 0.0085
   discogs_id: 13801555
   notes: Unknown artist — fill description manually
 The Boo Radleys:
   slug: the_boo_radleys
   status: draft
-  description: 'The Boo Radleys blend shoegaze density with Merseybeat melodicism, layering distorted guitars, brass arrangements,
-    and noise textures beneath bright, hooky vocal lines. Production swings between lo-fi abrasion and lush, maximalist studio
-    construction, often placing delicate melodies against walls of feedback and overdubbed instrumentation. Lyrically, they
-    explore suburban ennui, fleeting joy, dissociation, and the tension between mundane existence and transcendence, frequently
-    using pastoral and urban imagery to evoke emotional ambivalence. The emotional register is characteristically bittersweet
-    — euphoric surfaces concealing underlying unease or melancholy, creating a psychological tension between optimism and
-    resignation. Vocals are central but often treated as another textural layer within dense sonic arrangements, with instrumentation
-    carrying equal expressive weight. The overall character moves fluidly between noise-rock aggression, chamber-pop warmth,
-    and psychedelic sprawl.
+  description: 'The Boo Radleys blend shoegaze density with Merseybeat melodicism,
+    layering distorted guitars, brass arrangements, and noise textures beneath bright,
+    hooky vocal lines. Production swings between lo-fi abrasion and lush, maximalist
+    studio construction, often placing delicate melodies against walls of feedback
+    and overdubbed instrumentation. Lyrically, they explore suburban ennui, fleeting
+    joy, dissociation, and the tension between mundane existence and transcendence,
+    frequently using pastoral and urban imagery to evoke emotional ambivalence. The
+    emotional register is characteristically bittersweet — euphoric surfaces concealing
+    underlying unease or melancholy, creating a psychological tension between optimism
+    and resignation. Vocals are central but often treated as another textural layer
+    within dense sonic arrangements, with instrumentation carrying equal expressive
+    weight. The overall character moves fluidly between noise-rock aggression, chamber-pop
+    warmth, and psychedelic sprawl.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4471
+      present: 0.2492
+      future: 0.3037
+    spatial:
+      thing: 0.4481
+      place: 0.3034
+      person: 0.2486
+    ontological:
+      imagined: 0.3619
+      forgotten: 0.2848
+      known: 0.3534
+    confidence: 0.0306
   discogs_id: 7579
   notes: ''
 Willie Hutch:
   slug: willie_hutch
   status: draft
-  description: 'Willie Hutch occupies a warm, deeply sensual corner of 1970s soul-funk. His production favors lush string
-    arrangements layered over slow-burning rhythm sections, with wah-wah guitar, electric piano, and bass lines that pulse
-    with unhurried confidence. Studio textures lean dense yet intimate, balancing orchestral richness against tight, rhythmically
-    precise funk grooves. His vocal delivery is smooth and mid-range, projecting tenderness and assured masculinity simultaneously
-    — primarily a vocal artist, though instrumental passages carry equal atmospheric weight. Lyrically, his themes orbit romantic
-    devotion, physical desire, street-level resilience, and emotional vulnerability, often framed through vivid sensory imagery
-    evoking nighttime cityscapes and close human connection. The emotional register remains consistently warm and introspective,
-    occasionally shadowed by melancholy or quiet urgency, but rarely aggressive. An underlying cinematic quality pervades
+  description: 'Willie Hutch occupies a warm, deeply sensual corner of 1970s soul-funk.
+    His production favors lush string arrangements layered over slow-burning rhythm
+    sections, with wah-wah guitar, electric piano, and bass lines that pulse with
+    unhurried confidence. Studio textures lean dense yet intimate, balancing orchestral
+    richness against tight, rhythmically precise funk grooves. His vocal delivery
+    is smooth and mid-range, projecting tenderness and assured masculinity simultaneously
+    — primarily a vocal artist, though instrumental passages carry equal atmospheric
+    weight. Lyrically, his themes orbit romantic devotion, physical desire, street-level
+    resilience, and emotional vulnerability, often framed through vivid sensory imagery
+    evoking nighttime cityscapes and close human connection. The emotional register
+    remains consistently warm and introspective, occasionally shadowed by melancholy
+    or quiet urgency, but rarely aggressive. An underlying cinematic quality pervades
     his work, suggesting narrative momentum even within contained song structures.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4267
+      present: 0.2669
+      future: 0.3064
+    spatial:
+      thing: 0.4276
+      place: 0.3065
+      person: 0.2659
+    ontological:
+      imagined: 0.3531
+      forgotten: 0.2951
+      known: 0.3518
+    confidence: 0.0155
   discogs_id: 7153
   notes: ''
 Public Image Limited:
   slug: public_image_limited
   status: draft
-  description: 'Public Image Limited constructs a sonic world of deliberate abrasion and hollow, cavernous space. Production
-    favours stark separation between instruments — bass rendered as a deep, seismic pulse; guitars fragmented into metallic,
-    angular shards; drums cold and mechanical. Density fluctuates between suffocating thickness and unsettling emptiness.
-    The studio approach emphasises texture over convention, often dissolving traditional song architecture into repetitive,
-    hypnotic structures.
+  description: 'Public Image Limited constructs a sonic world of deliberate abrasion
+    and hollow, cavernous space. Production favours stark separation between instruments
+    — bass rendered as a deep, seismic pulse; guitars fragmented into metallic, angular
+    shards; drums cold and mechanical. Density fluctuates between suffocating thickness
+    and unsettling emptiness. The studio approach emphasises texture over convention,
+    often dissolving traditional song architecture into repetitive, hypnotic structures.
 
 
-    Lyrically, the work orbits themes of alienation, institutional distrust, identity dissolution, and confrontation with
-    media and authority. Imagery tends toward the clinical and corrosive, delivered with irony and controlled aggression.
-    Tone resists sentimentality entirely.
+    Lyrically, the work orbits themes of alienation, institutional distrust, identity
+    dissolution, and confrontation with media and authority. Imagery tends toward
+    the clinical and corrosive, delivered with irony and controlled aggression. Tone
+    resists sentimentality entirely.
 
 
-    The emotional register is primarily disaffected and confrontational — psychologically unsettling, existing in the cold
-    territory between rage and numbness. Anxiety and dissociation permeate the atmosphere.
+    The emotional register is primarily disaffected and confrontational — psychologically
+    unsettling, existing in the cold territory between rage and numbness. Anxiety
+    and dissociation permeate the atmosphere.
 
 
-    The project is fundamentally vocal-centred, with the voice used as an expressive, often declamatory instrument against
-    the textural backdrop.
+    The project is fundamentally vocal-centred, with the voice used as an expressive,
+    often declamatory instrument against the textural backdrop.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4039
+      present: 0.2764
+      future: 0.3196
+    spatial:
+      thing: 0.4048
+      place: 0.3194
+      person: 0.2759
+    ontological:
+      imagined: 0.3428
+      forgotten: 0.308
+      known: 0.3492
+    confidence: 0.0147
   discogs_id: 66302
   notes: ''
 Tears for Fears:
   slug: tears_for_fears
   status: draft
-  description: 'Tears for Fears blend lush, layered synthesizer textures with driving rhythm programming and organic instrumentation,
-    creating a dense yet polished sonic environment. Production favors wide stereo fields, prominent low-end pulse, and atmospheric
-    depth achieved through reverb-heavy drums and harmonic keyboard stacking. The approach balances clinical precision with
-    warmth.
+  description: 'Tears for Fears blend lush, layered synthesizer textures with driving
+    rhythm programming and organic instrumentation, creating a dense yet polished
+    sonic environment. Production favors wide stereo fields, prominent low-end pulse,
+    and atmospheric depth achieved through reverb-heavy drums and harmonic keyboard
+    stacking. The approach balances clinical precision with warmth.
 
 
-    Lyrically, themes center on psychological introspection, trauma, power dynamics, and emotional liberation. Imagery draws
-    from inner conflict, childhood wounds, and societal alienation, rendered in language that oscillates between personal
+    Lyrically, themes center on psychological introspection, trauma, power dynamics,
+    and emotional liberation. Imagery draws from inner conflict, childhood wounds,
+    and societal alienation, rendered in language that oscillates between personal
     confession and universal statement.
 
 
-    The emotional register is intense and searching — melancholic yet cathartic, with underlying tension that periodically
-    resolves into anthemic release. A sense of contained anguish pervades quieter passages, while crescendos carry expansive,
+    The emotional register is intense and searching — melancholic yet cathartic, with
+    underlying tension that periodically resolves into anthemic release. A sense of
+    contained anguish pervades quieter passages, while crescendos carry expansive,
     almost euphoric energy.
 
 
-    The project is fundamentally vocal-led, with dual voices often harmonizing or alternating to create dialogic emotional
-    contrast within arrangements.
+    The project is fundamentally vocal-led, with dual voices often harmonizing or
+    alternating to create dialogic emotional contrast within arrangements.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4308
+      present: 0.2586
+      future: 0.3106
+    spatial:
+      thing: 0.4315
+      place: 0.3106
+      person: 0.258
+    ontological:
+      imagined: 0.345
+      forgotten: 0.2961
+      known: 0.3589
+    confidence: 0.0205
   discogs_id: 19814
   notes: ''
 Phil Collins:
   slug: phil_collins
   status: draft
-  description: 'Phil Collins works primarily as a vocalist, though drumming defines his sonic identity. His production style
-    is dense yet polished, characterized by gated reverb on snare drums, layered synthesizers, and a warm, compressed sheen
-    across the mix. Studio textures blend live percussion with electronic programming, creating a hybrid feel that is simultaneously
-    organic and mechanical. Thematically, his lyrics orbit domestic collapse, betrayal, isolation, and unresolved emotional
-    conflict, often addressing a specific, unnamed second person in an accusatory or pleading register. Imagery tends toward
-    the personal and interior rather than the abstract or metaphorical. Emotionally, his work occupies a tense middle ground
-    between restraint and eruption — controlled grief sitting beneath polished surfaces, occasionally breaking into raw confrontation.
-    The emotional colour is predominantly melancholic, with undercurrents of resentment and longing. Arrangements build dynamically,
-    moving from sparse, intimate openings toward anthemic, percussion-driven climaxes.
+  description: 'Phil Collins works primarily as a vocalist, though drumming defines
+    his sonic identity. His production style is dense yet polished, characterized
+    by gated reverb on snare drums, layered synthesizers, and a warm, compressed sheen
+    across the mix. Studio textures blend live percussion with electronic programming,
+    creating a hybrid feel that is simultaneously organic and mechanical. Thematically,
+    his lyrics orbit domestic collapse, betrayal, isolation, and unresolved emotional
+    conflict, often addressing a specific, unnamed second person in an accusatory
+    or pleading register. Imagery tends toward the personal and interior rather than
+    the abstract or metaphorical. Emotionally, his work occupies a tense middle ground
+    between restraint and eruption — controlled grief sitting beneath polished surfaces,
+    occasionally breaking into raw confrontation. The emotional colour is predominantly
+    melancholic, with undercurrents of resentment and longing. Arrangements build
+    dynamically, moving from sparse, intimate openings toward anthemic, percussion-driven
+    climaxes.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4272
+      present: 0.2612
+      future: 0.3116
+    spatial:
+      thing: 0.4282
+      place: 0.3113
+      person: 0.2605
+    ontological:
+      imagined: 0.3548
+      forgotten: 0.2943
+      known: 0.3509
+    confidence: 0.0245
   discogs_id: 101028
   notes: ''
 Peter Gabriel:
   slug: peter_gabriel
   status: draft
-  description: 'Peter Gabriel is a vocal-led artist whose work blends organic percussion, layered synthesizers, and world-music
-    instrumentation into dense, textured soundscapes. Production is deliberate and atmospheric, favouring gated reverb, tribal
-    rhythmic patterns, and stark dynamic contrasts between intimate passages and expansive sonic architecture. Vocals carry
-    emotional weight through restrained intensity, often building toward cathartic release. Thematically, his writing explores
-    alienation, transformation, psychological fragmentation, political injustice, and the sacred dimensions of everyday experience,
-    frequently employing surreal or mythological imagery alongside raw human vulnerability. The emotional register oscillates
-    between brooding introspection and urgent, primal release, with a persistent undercurrent of existential searching. Studio
-    work tends toward meticulous layering, with found sounds and unconventional timbres woven into rhythmically complex arrangements.
-    The overall character is cinematic and deeply psychological, balancing cerebral conceptualism with visceral emotional
-    directness.
+  description: 'Peter Gabriel is a vocal-led artist whose work blends organic percussion,
+    layered synthesizers, and world-music instrumentation into dense, textured soundscapes.
+    Production is deliberate and atmospheric, favouring gated reverb, tribal rhythmic
+    patterns, and stark dynamic contrasts between intimate passages and expansive
+    sonic architecture. Vocals carry emotional weight through restrained intensity,
+    often building toward cathartic release. Thematically, his writing explores alienation,
+    transformation, psychological fragmentation, political injustice, and the sacred
+    dimensions of everyday experience, frequently employing surreal or mythological
+    imagery alongside raw human vulnerability. The emotional register oscillates between
+    brooding introspection and urgent, primal release, with a persistent undercurrent
+    of existential searching. Studio work tends toward meticulous layering, with found
+    sounds and unconventional timbres woven into rhythmically complex arrangements.
+    The overall character is cinematic and deeply psychological, balancing cerebral
+    conceptualism with visceral emotional directness.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4341
+      present: 0.256
+      future: 0.3099
+    spatial:
+      thing: 0.435
+      place: 0.3096
+      person: 0.2555
+    ontological:
+      imagined: 0.3589
+      forgotten: 0.2908
+      known: 0.3503
+    confidence: 0.0216
   discogs_id: 11136
   notes: ''
 Carpenters:
   slug: carpenters
   status: draft
-  description: 'The Carpenters present a primarily vocal style built around close-harmony singing, with Karen Carpenter''s
-    warm, chest-forward contralto anchoring a lustrous, mid-range sonic palette. Production is meticulous and spacious — lush
-    orchestral strings, soft woodwinds, and clean acoustic piano surround vocals placed prominently forward in the mix. Density
-    is carefully controlled; arrangements breathe, favoring clarity over saturation. Studio processing is polished and pristine,
-    with minimal grit or rhythmic urgency.
+  description: 'The Carpenters present a primarily vocal style built around close-harmony
+    singing, with Karen Carpenter''s warm, chest-forward contralto anchoring a lustrous,
+    mid-range sonic palette. Production is meticulous and spacious — lush orchestral
+    strings, soft woodwinds, and clean acoustic piano surround vocals placed prominently
+    forward in the mix. Density is carefully controlled; arrangements breathe, favoring
+    clarity over saturation. Studio processing is polished and pristine, with minimal
+    grit or rhythmic urgency.
 
 
-    Lyrically, themes center on longing, romantic vulnerability, temporal loss, and the ache of absence. Imagery tends toward
-    the everyday and intimate — seasons, mornings, quiet domestic moments — rendered with gentle, unadorned language.
+    Lyrically, themes center on longing, romantic vulnerability, temporal loss, and
+    the ache of absence. Imagery tends toward the everyday and intimate — seasons,
+    mornings, quiet domestic moments — rendered with gentle, unadorned language.
 
 
-    Emotionally, the register is bittersweet and introspective, carrying a quality of restrained melancholy beneath surface
-    warmth. The psychological colour is tender and nostalgic, with an underlying undercurrent of emotional solitude even within
+    Emotionally, the register is bittersweet and introspective, carrying a quality
+    of restrained melancholy beneath surface warmth. The psychological colour is tender
+    and nostalgic, with an underlying undercurrent of emotional solitude even within
     optimistic melodic frameworks.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4131
+      present: 0.2701
+      future: 0.3167
+    spatial:
+      thing: 0.4141
+      place: 0.3163
+      person: 0.2696
+    ontological:
+      imagined: 0.3222
+      forgotten: 0.3129
+      known: 0.3649
+    confidence: 0.0204
   discogs_id: 170357
   notes: ''
 Cocteau Twins:
   slug: cocteau_twins
   status: draft
-  description: 'Cocteau Twins craft densely layered soundscapes built from heavily processed guitars producing cascading,
-    reverb-saturated arpeggios, shimmering tremolo textures, and lush, warm bass foundations. Production favours deep spatial
-    depth, with instruments suspended in vast reverb fields that blur individual timbres into cohesive sonic atmosphere. Drum
-    machines provide rhythmic structure while remaining submerged beneath melodic layers. Vocals are central and highly distinctive
-    — treated as timbral instruments themselves, blurred through effects until phonemes dissolve into abstract, vowel-rich
-    vocalise. Lyrical content, when decipherable, gestures toward mythic femininity, elemental imagery, dreamlike interiority,
-    and emotional abstraction rather than narrative clarity. Themes carry a sense of longing, surrender, and hushed ecstasy.
-    The emotional register is consistently otherworldly — simultaneously melancholic and euphoric, introspective and expansive,
-    occupying a psychological space between waking reverie and half-remembered dream. The overall affect is immersive, devotional,
-    and deliberately suspended in ambiguity.
+  description: 'Cocteau Twins craft densely layered soundscapes built from heavily
+    processed guitars producing cascading, reverb-saturated arpeggios, shimmering
+    tremolo textures, and lush, warm bass foundations. Production favours deep spatial
+    depth, with instruments suspended in vast reverb fields that blur individual timbres
+    into cohesive sonic atmosphere. Drum machines provide rhythmic structure while
+    remaining submerged beneath melodic layers. Vocals are central and highly distinctive
+    — treated as timbral instruments themselves, blurred through effects until phonemes
+    dissolve into abstract, vowel-rich vocalise. Lyrical content, when decipherable,
+    gestures toward mythic femininity, elemental imagery, dreamlike interiority, and
+    emotional abstraction rather than narrative clarity. Themes carry a sense of longing,
+    surrender, and hushed ecstasy. The emotional register is consistently otherworldly
+    — simultaneously melancholic and euphoric, introspective and expansive, occupying
+    a psychological space between waking reverie and half-remembered dream. The overall
+    affect is immersive, devotional, and deliberately suspended in ambiguity.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4408
+      present: 0.2509
+      future: 0.3082
+    spatial:
+      thing: 0.4416
+      place: 0.3079
+      person: 0.2505
+    ontological:
+      imagined: 0.3449
+      forgotten: 0.2943
+      known: 0.3608
+    confidence: 0.0274
   discogs_id: 12373
   notes: ''
 Killing Joke:
   slug: killing_joke
   status: draft
-  description: 'Killing Joke operate as a vocal-led ensemble anchored by dense, ritualistic sonic architecture. Production
-    favours thick, distorted guitar walls layered over mechanistic, tribal drumming — a percussive engine that drives relentless
-    forward momentum. Bass sits prominently high in the mix, functioning almost melodically. Synthesisers add cold, industrial
-    texture, creating claustrophobic density. The overall sound is deliberately abrasive yet hypnotic.
+  description: 'Killing Joke operate as a vocal-led ensemble anchored by dense, ritualistic
+    sonic architecture. Production favours thick, distorted guitar walls layered over
+    mechanistic, tribal drumming — a percussive engine that drives relentless forward
+    momentum. Bass sits prominently high in the mix, functioning almost melodically.
+    Synthesisers add cold, industrial texture, creating claustrophobic density. The
+    overall sound is deliberately abrasive yet hypnotic.
 
 
-    Lyrically, themes orbit societal collapse, occult systems, apocalyptic prophecy, urban alienation, and primal psychological
-    states. Imagery draws on warfare, mass psychology, entropy, and ritual. Tone is confrontational and incantatory, oscillating
+    Lyrically, themes orbit societal collapse, occult systems, apocalyptic prophecy,
+    urban alienation, and primal psychological states. Imagery draws on warfare, mass
+    psychology, entropy, and ritual. Tone is confrontational and incantatory, oscillating
     between paranoia and dark ecstasy.
 
 
-    The emotional register is intense and unsettling — aggressive urgency fused with a trance-like, almost ceremonial gravity.
-    The psychological colour is persistently dark, conveying existential threat and barely contained fury, occasionally resolving
+    The emotional register is intense and unsettling — aggressive urgency fused with
+    a trance-like, almost ceremonial gravity. The psychological colour is persistently
+    dark, conveying existential threat and barely contained fury, occasionally resolving
     into euphoric menace rather than despair.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.407
+      present: 0.2702
+      future: 0.3228
+    spatial:
+      thing: 0.4077
+      place: 0.3224
+      person: 0.2699
+    ontological:
+      imagined: 0.3391
+      forgotten: 0.3104
+      known: 0.3505
+    confidence: 0.012
   discogs_id: 13408
   notes: ''
 Christian Death:
   slug: christian_death
   status: draft
-  description: 'Christian Death operates in a dense, abrasive sonic landscape blending post-punk guitar dissonance with gothic
-    atmospherics — trebly, reverb-drenched strings, cavernous percussion, and layered distortion creating a claustrophobic
-    texture. Production tends toward raw, lo-fi murkiness, prioritizing atmosphere over clarity. The music is primarily vocal-driven,
-    with declamatory, theatrically expressive delivery sitting prominently above the instrumentation. Lyrically, the work
-    dwells in sacred and profane imagery — crucifixes, mortality, flesh, transgression, spiritual decay, and blasphemy — rendered
-    through a tone of theatrical anguish and erotic morbidity. Religious iconography is consistently subverted or corrupted.
-    The emotional register is one of existential dread interlaced with perverse ecstasy — psychologically intense, confrontational,
-    and deliberately unsettling. The overall affect leans toward ritualistic darkness, occupying a space between horror, grief,
-    and nihilistic provocation.
+  description: 'Christian Death operates in a dense, abrasive sonic landscape blending
+    post-punk guitar dissonance with gothic atmospherics — trebly, reverb-drenched
+    strings, cavernous percussion, and layered distortion creating a claustrophobic
+    texture. Production tends toward raw, lo-fi murkiness, prioritizing atmosphere
+    over clarity. The music is primarily vocal-driven, with declamatory, theatrically
+    expressive delivery sitting prominently above the instrumentation. Lyrically,
+    the work dwells in sacred and profane imagery — crucifixes, mortality, flesh,
+    transgression, spiritual decay, and blasphemy — rendered through a tone of theatrical
+    anguish and erotic morbidity. Religious iconography is consistently subverted
+    or corrupted. The emotional register is one of existential dread interlaced with
+    perverse ecstasy — psychologically intense, confrontational, and deliberately
+    unsettling. The overall affect leans toward ritualistic darkness, occupying a
+    space between horror, grief, and nihilistic provocation.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4153
+      present: 0.2651
+      future: 0.3196
+    spatial:
+      thing: 0.4162
+      place: 0.3191
+      person: 0.2647
+    ontological:
+      imagined: 0.3425
+      forgotten: 0.3061
+      known: 0.3514
+    confidence: 0.021
   discogs_id: 94647
   notes: ''
 Tears For Fears:
   slug: tears_for_fears
   status: draft
-  description: 'Tears For Fears occupies a dense, layered sonic world rooted in synthesizer-driven pop-rock. Production is
-    lush and atmospheric, combining warm analog pads, gated drums, textured guitars, and studio-crafted depth. Arrangements
-    often shift between intimate, stripped vulnerability and expansive orchestral grandeur. The approach favors controlled
-    tension — carefully built climaxes that feel both cinematic and emotionally immediate.
+  description: 'Tears For Fears occupies a dense, layered sonic world rooted in synthesizer-driven
+    pop-rock. Production is lush and atmospheric, combining warm analog pads, gated
+    drums, textured guitars, and studio-crafted depth. Arrangements often shift between
+    intimate, stripped vulnerability and expansive orchestral grandeur. The approach
+    favors controlled tension — carefully built climaxes that feel both cinematic
+    and emotionally immediate.
 
 
-    Lyrically, themes circle around psychological introspection, trauma, power dynamics, collective anxiety, and the search
-    for inner healing. Imagery draws from the interior landscape — the mind as battleground, emotional repression, and yearning
-    for release or transformation. Tone balances earnest vulnerability with underlying unease.
+    Lyrically, themes circle around psychological introspection, trauma, power dynamics,
+    collective anxiety, and the search for inner healing. Imagery draws from the interior
+    landscape — the mind as battleground, emotional repression, and yearning for release
+    or transformation. Tone balances earnest vulnerability with underlying unease.
 
 
-    The emotional register is complex: simultaneously melancholic and cathartic, carrying a brooding psychological weight
-    shot through with moments of anthemic uplift. Darkness is present but never nihilistic.
+    The emotional register is complex: simultaneously melancholic and cathartic, carrying
+    a brooding psychological weight shot through with moments of anthemic uplift.
+    Darkness is present but never nihilistic.
 
 
     The project is primarily vocal-forward, with dual lead vocals central to identity.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4244
+      present: 0.2629
+      future: 0.3127
+    spatial:
+      thing: 0.4253
+      place: 0.3124
+      person: 0.2623
+    ontological:
+      imagined: 0.3466
+      forgotten: 0.2978
+      known: 0.3555
+    confidence: 0.0245
   discogs_id: 19814
   notes: ''
 Godspeed You Black Emperor!:
   slug: godspeed_you_black_emperor
   status: draft
-  description: 'Godspeed You! Black Emperor operates almost entirely in the instrumental domain, with voice appearing only
-    as processed field recordings, radio static, and fragmented spoken monologue rather than conventional song. Sonically,
-    the ensemble builds dense orchestral-rock textures from layered guitars, strings, brass, bass, and drums, favouring slow
-    crescendos that accumulate from near-silence into overwhelming walls of distortion and sustain. Production carries a deliberate
-    rawness—analogue warmth, ambient hiss, and spatial depth suggesting both intimacy and vast emptiness. Thematic imagery
-    circles around societal collapse, urban decay, institutional failure, and apocalyptic landscape, rendered through a tone
-    that is elegiac and foreboding rather than aggressive. The emotional register occupies grief, dread, and defiant melancholy
-    simultaneously, sustaining tension across extended movements that rarely resolve cleanly, leaving the listener in a state
+  description: 'Godspeed You! Black Emperor operates almost entirely in the instrumental
+    domain, with voice appearing only as processed field recordings, radio static,
+    and fragmented spoken monologue rather than conventional song. Sonically, the
+    ensemble builds dense orchestral-rock textures from layered guitars, strings,
+    brass, bass, and drums, favouring slow crescendos that accumulate from near-silence
+    into overwhelming walls of distortion and sustain. Production carries a deliberate
+    rawness—analogue warmth, ambient hiss, and spatial depth suggesting both intimacy
+    and vast emptiness. Thematic imagery circles around societal collapse, urban decay,
+    institutional failure, and apocalyptic landscape, rendered through a tone that
+    is elegiac and foreboding rather than aggressive. The emotional register occupies
+    grief, dread, and defiant melancholy simultaneously, sustaining tension across
+    extended movements that rarely resolve cleanly, leaving the listener in a state
     of unresolved, searching unease.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4548
+      present: 0.2436
+      future: 0.3016
+    spatial:
+      thing: 0.4558
+      place: 0.3014
+      person: 0.2428
+    ontological:
+      imagined: 0.3537
+      forgotten: 0.2857
+      known: 0.3607
+    confidence: 0.0307
   discogs_id: 280442
   notes: ''
 Paul White (4):
   slug: paul_white_4
-  status: Paul White's music ranges from searing electric guitar-led dirges to dreamlike ballads to ghostly atmospheric experiments
-    and has been issued in tiny quantities since the 1990s on the Subliminal Sounds label. Paul White And The Purple Brain
-    is a remarkably diverse album that defies easy categorization. Which suits him and his home label One-Handed Music (in
-    collaboration with whom Now-Again releases this album) just fine. Praised as someone who embodies all that is good about
-    a new generation of producers by Dazed & Confused magazine, Paul White has won over fans of left-leaning sounds and interesting
-    Hip Hop, including Diplo, Mary Anne Hobbs, Benji B and Gilles Peterson
-  description: 'Paul White builds music from the detritus of recorded history — vintage samples excavated, fragmented, and
-    recombined into new psychedelic wholes. Production is deliberately murky, favouring low-pass filtering, soft compression,
-    and a lo-fi warmth that blurs timbral edges and gives processed sounds the quality of recovered artefacts. Beats are sample-driven
-    and rhythmically erratic — drum patterns shift unpredictably, loops are cut at unexpected points, and the overall rhythmic
-    feel prioritises feel over metronomic regularity. Melodic content emerges from unexpected sources: orchestral fragments,
-    soul vocal snippets, jazz piano bars, each stripped of original context and reassembled into collage structures. When
-    vocal collaborators appear, their contributions are treated as another sampled element, woven into the production rather
-    than placed over it. Thematic territory is eclectic and associative — the work accumulates atmosphere through juxtaposition
-    rather than narrative. The emotional register is both playful and melancholic, evoking a pleasurable disorientation —
-    the uncanny familiarity of sounds heard before but never quite like this.'
+  status: Paul White's music ranges from searing electric guitar-led dirges to dreamlike
+    ballads to ghostly atmospheric experiments and has been issued in tiny quantities
+    since the 1990s on the Subliminal Sounds label. Paul White And The Purple Brain
+    is a remarkably diverse album that defies easy categorization. Which suits him
+    and his home label One-Handed Music (in collaboration with whom Now-Again releases
+    this album) just fine. Praised as someone who embodies all that is good about
+    a new generation of producers by Dazed & Confused magazine, Paul White has won
+    over fans of left-leaning sounds and interesting Hip Hop, including Diplo, Mary
+    Anne Hobbs, Benji B and Gilles Peterson
+  description: 'Paul White builds music from the detritus of recorded history — vintage
+    samples excavated, fragmented, and recombined into new psychedelic wholes. Production
+    is deliberately murky, favouring low-pass filtering, soft compression, and a lo-fi
+    warmth that blurs timbral edges and gives processed sounds the quality of recovered
+    artefacts. Beats are sample-driven and rhythmically erratic — drum patterns shift
+    unpredictably, loops are cut at unexpected points, and the overall rhythmic feel
+    prioritises feel over metronomic regularity. Melodic content emerges from unexpected
+    sources: orchestral fragments, soul vocal snippets, jazz piano bars, each stripped
+    of original context and reassembled into collage structures. When vocal collaborators
+    appear, their contributions are treated as another sampled element, woven into
+    the production rather than placed over it. Thematic territory is eclectic and
+    associative — the work accumulates atmosphere through juxtaposition rather than
+    narrative. The emotional register is both playful and melancholic, evoking a pleasurable
+    disorientation — the uncanny familiarity of sounds heard before but never quite
+    like this.'
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4461
+      present: 0.2467
+      future: 0.3072
+    spatial:
+      thing: 0.4469
+      place: 0.3067
+      person: 0.2463
+    ontological:
+      imagined: 0.3491
+      forgotten: 0.2897
+      known: 0.3612
+    confidence: 0.0378
   discogs_id: 934385
   notes: Unknown artist — fill description manually
 Basil Kirchin:
   slug: basil_kirchin
   status: draft
-  description: 'Kirchin''s sonic world is densely layered, built from orchestral textures interwoven with electronics, field
-    recordings, and processed natural sounds. His production favours a murky, atmospheric depth — sounds emerge and dissolve
-    rather than assert themselves clearly, creating a sense of acoustic space that feels both interior and alien. The studio
-    functions as a compositional instrument, with tape manipulation and unconventional signal processing central to his method.
+  description: 'Kirchin''s sonic world is densely layered, built from orchestral textures
+    interwoven with electronics, field recordings, and processed natural sounds. His
+    production favours a murky, atmospheric depth — sounds emerge and dissolve rather
+    than assert themselves clearly, creating a sense of acoustic space that feels
+    both interior and alien. The studio functions as a compositional instrument, with
+    tape manipulation and unconventional signal processing central to his method.
 
 
-    Primarily instrumental, his work carries no fixed lyrical content, though occasional wordless or treated vocal textures
-    surface as timbral elements rather than narrative vehicles. Thematically, the music circles around organic systems, environmental
-    ambiguity, and psychological interiority — evoking biological, mechanical, and environmental processes simultaneously.
+    Primarily instrumental, his work carries no fixed lyrical content, though occasional
+    wordless or treated vocal textures surface as timbral elements rather than narrative
+    vehicles. Thematically, the music circles around organic systems, environmental
+    ambiguity, and psychological interiority — evoking biological, mechanical, and
+    environmental processes simultaneously.
 
 
-    Emotionally, the register is unsettled and contemplative — hovering between unease and wonder, suggesting liminal psychological
-    states, suspended tension, and a cool, detached curiosity toward the uncanny.
+    Emotionally, the register is unsettled and contemplative — hovering between unease
+    and wonder, suggesting liminal psychological states, suspended tension, and a
+    cool, detached curiosity toward the uncanny.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4422
+      present: 0.2498
+      future: 0.3079
+    spatial:
+      thing: 0.4431
+      place: 0.3076
+      person: 0.2493
+    ontological:
+      imagined: 0.3392
+      forgotten: 0.2949
+      known: 0.3658
+    confidence: 0.034
   discogs_id: 202191
   notes: ''
 King Ghidra:
   slug: king_ghidra
   status: draft
-  description: King Ghirda aka MF DOOM operates primarily as a vocal artist layered over dense, sample-heavy production. Beats
-    are built from dusty, lo-fi textures—warped vinyl crackle, thick low-end, chopped jazz and cinematic soul samples compressed
-    into deliberately murky sonic palettes. Arrangements favor claustrophobic density over openness, with erratic rhythmic
-    placements and syncopated drum patterns sitting beneath heavily filtered loops. Lyrically, imagery draws from comic book
-    mythology, street-level surrealism, culinary references, wordplay, and coded allegory. Narrative perspective shifts fluidly,
-    adopting persona and mask as structural devices. Rhyme schemes are intricately layered, favoring internal rhyme, slant
-    rhyme, and multi-syllabic compression. Thematically, content moves between absurdist humor and nihilistic undercurrents,
-    with moments of oblique vulnerability concealed beneath irony. The emotional register is detached yet sardonic—cool, cerebral,
-    and slightly sinister—creating a mood that is simultaneously playful and unsettling, like noir filtered through a funhouse
-    lens.
+  description: King Ghirda aka MF DOOM operates primarily as a vocal artist layered
+    over dense, sample-heavy production. Beats are built from dusty, lo-fi textures—warped
+    vinyl crackle, thick low-end, chopped jazz and cinematic soul samples compressed
+    into deliberately murky sonic palettes. Arrangements favor claustrophobic density
+    over openness, with erratic rhythmic placements and syncopated drum patterns sitting
+    beneath heavily filtered loops. Lyrically, imagery draws from comic book mythology,
+    street-level surrealism, culinary references, wordplay, and coded allegory. Narrative
+    perspective shifts fluidly, adopting persona and mask as structural devices. Rhyme
+    schemes are intricately layered, favoring internal rhyme, slant rhyme, and multi-syllabic
+    compression. Thematically, content moves between absurdist humor and nihilistic
+    undercurrents, with moments of oblique vulnerability concealed beneath irony.
+    The emotional register is detached yet sardonic—cool, cerebral, and slightly sinister—creating
+    a mood that is simultaneously playful and unsettling, like noir filtered through
+    a funhouse lens.
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4237
+      present: 0.2619
+      future: 0.3144
+    spatial:
+      thing: 0.4244
+      place: 0.3142
+      person: 0.2614
+    ontological:
+      imagined: 0.3389
+      forgotten: 0.3034
+      known: 0.3578
+    confidence: 0.0144
   discogs_id: 113391
   notes: Unknown artist — fill description manually
 Bibio:
   slug: bibio
   status: draft
-  description: 'Bibio occupies a hazy intersection of folk, electronic, and psychedelic pop, blending warm analogue textures
-    with glitchy, lo-fi production character. Acoustic guitar fingerpicking sits alongside vintage drum machines, tape saturation,
-    and layered field recordings, creating a dense yet intimate sonic atmosphere. The studio approach favours organic imperfection
-    — subtle crackle, pitch drift, and soft compression lend a nostalgic, almost weathered quality. Both instrumental and
-    vocal works feature prominently; vocals are typically gentle, breathy, and understated, sitting deep within the mix. Lyrically,
-    themes orbit rural landscapes, memory, nature, and quiet introspection, rendered through pastoral imagery and a contemplative
-    tone. The emotional register is predominantly wistful and ruminative — evoking afternoon light, seasonal melancholy, and
-    a dreamlike sense of displacement in time, balancing warmth with an undercurrent of gentle unease.
+  description: 'Bibio occupies a hazy intersection of folk, electronic, and psychedelic
+    pop, blending warm analogue textures with glitchy, lo-fi production character.
+    Acoustic guitar fingerpicking sits alongside vintage drum machines, tape saturation,
+    and layered field recordings, creating a dense yet intimate sonic atmosphere.
+    The studio approach favours organic imperfection — subtle crackle, pitch drift,
+    and soft compression lend a nostalgic, almost weathered quality. Both instrumental
+    and vocal works feature prominently; vocals are typically gentle, breathy, and
+    understated, sitting deep within the mix. Lyrically, themes orbit rural landscapes,
+    memory, nature, and quiet introspection, rendered through pastoral imagery and
+    a contemplative tone. The emotional register is predominantly wistful and ruminative
+    — evoking afternoon light, seasonal melancholy, and a dreamlike sense of displacement
+    in time, balancing warmth with an undercurrent of gentle unease.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4332
+      present: 0.2556
+      future: 0.3112
+    spatial:
+      thing: 0.4342
+      place: 0.3108
+      person: 0.255
+    ontological:
+      imagined: 0.3556
+      forgotten: 0.2938
+      known: 0.3506
+    confidence: 0.0304
   discogs_id: 267474
   notes: ''
 The Beach Boys:
   slug: the_beach_boys
   status: draft
-  description: 'The Beach Boys are primarily a vocal ensemble, built around elaborate close harmony stacks — usually five
-    or more voices layered with countermelodies, falsetto leads, and dense unison doubling. Production is bright and saturated,
-    blending live instrumentation (guitars, keyboards, bass, percussion) with orchestral sweetening and unconventional studio
-    textures — theremins, bicycle bells, tape manipulation. Low-end tends toward warmth rather than weight; mid-range frequencies
-    are full and choir-like. Thematically, lyrics orbit idealized leisure, youth, romantic longing, oceanic imagery, automobiles,
-    and existential searching beneath surface cheerfulness. Emotional register oscillates between sun-drenched euphoria and
-    a subtler undercurrent of melancholy, nostalgia, and spiritual yearning. Arrangements frequently juxtapose major-key brightness
-    with unexpected chromatic movement and modal colour. Rhythmic feel ranges from surf-inflected drive to slow, suspended
+  description: 'The Beach Boys are primarily a vocal ensemble, built around elaborate
+    close harmony stacks — usually five or more voices layered with countermelodies,
+    falsetto leads, and dense unison doubling. Production is bright and saturated,
+    blending live instrumentation (guitars, keyboards, bass, percussion) with orchestral
+    sweetening and unconventional studio textures — theremins, bicycle bells, tape
+    manipulation. Low-end tends toward warmth rather than weight; mid-range frequencies
+    are full and choir-like. Thematically, lyrics orbit idealized leisure, youth,
+    romantic longing, oceanic imagery, automobiles, and existential searching beneath
+    surface cheerfulness. Emotional register oscillates between sun-drenched euphoria
+    and a subtler undercurrent of melancholy, nostalgia, and spiritual yearning. Arrangements
+    frequently juxtapose major-key brightness with unexpected chromatic movement and
+    modal colour. Rhythmic feel ranges from surf-inflected drive to slow, suspended
     balladry. The overall sonic world is simultaneously communal and introspective.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4225
+      present: 0.2626
+      future: 0.3149
+    spatial:
+      thing: 0.4235
+      place: 0.3144
+      person: 0.2622
+    ontological:
+      imagined: 0.3438
+      forgotten: 0.3012
+      known: 0.355
+    confidence: 0.0172
   discogs_id: 70829
   notes: ''
 The Caretaker:
   slug: the_caretaker
   status: draft
-  description: 'The Caretaker works primarily in the instrumental domain, constructing music from degraded, heavily processed
-    ballroom and big-band recordings. Production is defined by extreme surface noise, vinyl crackle, loop-based repetition,
-    and progressive deterioration — textures dissolve, smear, and fragment across extended listening. Density shifts from
-    warmly nostalgic to unsettlingly hollow as decay accumulates. Individual timbres blur into spectral hazes; melody becomes
-    partially submerged beneath erosion. Where titles or surrounding text carry thematic weight, imagery centres on memory
-    loss, fading recollection, temporal dislocation, and the dissolution of selfhood — evoking pre-war nostalgia collapsing
-    into absence. The emotional register moves through melancholy, unease, and a dissociative dreamlike stillness, gradually
-    darkening toward disorientation and grief. Extended works follow arc-like progressions in which psychological coherence
-    deteriorates systematically, mirroring clinical or existential decline. The overall affect is haunted, elegiac, and quietly
-    destabilising.
+  description: 'The Caretaker works primarily in the instrumental domain, constructing
+    music from degraded, heavily processed ballroom and big-band recordings. Production
+    is defined by extreme surface noise, vinyl crackle, loop-based repetition, and
+    progressive deterioration — textures dissolve, smear, and fragment across extended
+    listening. Density shifts from warmly nostalgic to unsettlingly hollow as decay
+    accumulates. Individual timbres blur into spectral hazes; melody becomes partially
+    submerged beneath erosion. Where titles or surrounding text carry thematic weight,
+    imagery centres on memory loss, fading recollection, temporal dislocation, and
+    the dissolution of selfhood — evoking pre-war nostalgia collapsing into absence.
+    The emotional register moves through melancholy, unease, and a dissociative dreamlike
+    stillness, gradually darkening toward disorientation and grief. Extended works
+    follow arc-like progressions in which psychological coherence deteriorates systematically,
+    mirroring clinical or existential decline. The overall affect is haunted, elegiac,
+    and quietly destabilising.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4374
+      present: 0.252
+      future: 0.3105
+    spatial:
+      thing: 0.438
+      place: 0.3104
+      person: 0.2516
+    ontological:
+      imagined: 0.3229
+      forgotten: 0.3018
+      known: 0.3753
+    confidence: 0.0185
   discogs_id: 7734
   notes: ''
 The Books:
   slug: the_books
   status: draft
-  description: 'The Books blend acoustic and electronic elements through meticulous collage-based production, layering found-sound
-    samples, field recordings, voice fragments, and environmental noise against plucked acoustic guitar, cello, and sparse
-    electronic tones. The texture is intimate yet densely assembled, with a low-density warmth punctuated by unexpected sonic
-    intrusions. Vocals are present but function ambiguously — sampled speech, conversational fragments, and occasionally sung
-    passages operate on equal footing, blurring the line between instrumental and vocal work. Thematically, the material circles
-    around perception, memory, consciousness, and the strangeness of everyday experience, drawing imagery from nature, science,
-    and domestic life. The tone is curious and contemplative, occasionally absurdist, with a gentle philosophical undertow.
-    Emotionally, the register is quietly meditative, hovering between warmth and unease, producing a psychological colour
-    that feels both familiar and subtly disorienting — like recognizing something just outside full comprehension.
+  description: 'The Books blend acoustic and electronic elements through meticulous
+    collage-based production, layering found-sound samples, field recordings, voice
+    fragments, and environmental noise against plucked acoustic guitar, cello, and
+    sparse electronic tones. The texture is intimate yet densely assembled, with a
+    low-density warmth punctuated by unexpected sonic intrusions. Vocals are present
+    but function ambiguously — sampled speech, conversational fragments, and occasionally
+    sung passages operate on equal footing, blurring the line between instrumental
+    and vocal work. Thematically, the material circles around perception, memory,
+    consciousness, and the strangeness of everyday experience, drawing imagery from
+    nature, science, and domestic life. The tone is curious and contemplative, occasionally
+    absurdist, with a gentle philosophical undertow. Emotionally, the register is
+    quietly meditative, hovering between warmth and unease, producing a psychological
+    colour that feels both familiar and subtly disorienting — like recognizing something
+    just outside full comprehension.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4393
+      present: 0.2491
+      future: 0.3116
+    spatial:
+      thing: 0.44
+      place: 0.3113
+      person: 0.2487
+    ontological:
+      imagined: 0.3446
+      forgotten: 0.2951
+      known: 0.3603
+    confidence: 0.028
   discogs_id: 92547
   notes: ''
 Matmos:
   slug: matmos
   status: draft
-  description: 'Matmos operates in a sonic universe built from radically transformed found sounds — surgical instruments,
-    crayfish neurons, latex, household objects — processed into intricate electronic compositions with high conceptual density.
-    Production is meticulously layered, balancing clinical precision with organic warmth, often stitching together disparate
-    timbres into cohesive rhythmic and textural wholes. The studio functions as a laboratory, with sampling and live acoustic
-    elements treated as equal compositional materials.
+  description: 'Matmos operates in a sonic universe built from radically transformed
+    found sounds — surgical instruments, crayfish neurons, latex, household objects
+    — processed into intricate electronic compositions with high conceptual density.
+    Production is meticulously layered, balancing clinical precision with organic
+    warmth, often stitching together disparate timbres into cohesive rhythmic and
+    textural wholes. The studio functions as a laboratory, with sampling and live
+    acoustic elements treated as equal compositional materials.
 
 
-    Thematically, the work gravitates toward the body, science, materiality, and systems thinking — exploring how mundane
-    or transgressive physical phenomena generate meaning when abstracted through sound. Imagery tends toward the clinical,
-    the domestic, and the surreal simultaneously.
+    Thematically, the work gravitates toward the body, science, materiality, and systems
+    thinking — exploring how mundane or transgressive physical phenomena generate
+    meaning when abstracted through sound. Imagery tends toward the clinical, the
+    domestic, and the surreal simultaneously.
 
 
-    Emotional register ranges from playful and absurdist to contemplative and quietly uncanny, sustaining an atmosphere of
-    curious detachment punctuated by warmth. Occasionally vocal elements appear but serve textural or conceptual roles rather
-    than anchoring a song-based structure — the work is predominantly instrumental and process-driven.
+    Emotional register ranges from playful and absurdist to contemplative and quietly
+    uncanny, sustaining an atmosphere of curious detachment punctuated by warmth.
+    Occasionally vocal elements appear but serve textural or conceptual roles rather
+    than anchoring a song-based structure — the work is predominantly instrumental
+    and process-driven.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4113
+      present: 0.2664
+      future: 0.3223
+    spatial:
+      thing: 0.412
+      place: 0.3218
+      person: 0.2662
+    ontological:
+      imagined: 0.3453
+      forgotten: 0.3062
+      known: 0.3485
+    confidence: 0.0135
   discogs_id: 1926
   notes: ''
 Brian Wilson:
   slug: brian_wilson
   status: draft
-  description: 'Brian Wilson works primarily in a vocal and song-based idiom, layering dense choral harmonies over richly
-    orchestrated arrangements that blend conventional rock instrumentation with unconventional timbres—bicycle bells, theremin,
-    harpsichord, and thick string pads. Production is studio-centric, treating the recording space as a compositional tool,
-    with sounds stacked into wall-like textures that are simultaneously lush and meticulous. Lyrically, themes cluster around
-    adolescent longing, domestic comfort, coastal idyll, anxiety, and spiritual yearning, rendered through plain-spoken yet
-    imagistically precise language. Imagery tends toward sun, ocean, automobiles, and interior emotional states. The emotional
-    register oscillates between euphoric brightness and an underlying melancholy or unease, often holding both simultaneously—warmth
-    edged with wistfulness or barely suppressed dread. Vocal arrangements carry the primary melodic and harmonic weight, with
+  description: 'Brian Wilson works primarily in a vocal and song-based idiom, layering
+    dense choral harmonies over richly orchestrated arrangements that blend conventional
+    rock instrumentation with unconventional timbres—bicycle bells, theremin, harpsichord,
+    and thick string pads. Production is studio-centric, treating the recording space
+    as a compositional tool, with sounds stacked into wall-like textures that are
+    simultaneously lush and meticulous. Lyrically, themes cluster around adolescent
+    longing, domestic comfort, coastal idyll, anxiety, and spiritual yearning, rendered
+    through plain-spoken yet imagistically precise language. Imagery tends toward
+    sun, ocean, automobiles, and interior emotional states. The emotional register
+    oscillates between euphoric brightness and an underlying melancholy or unease,
+    often holding both simultaneously—warmth edged with wistfulness or barely suppressed
+    dread. Vocal arrangements carry the primary melodic and harmonic weight, with
     the voice treated as an orchestral instrument in its own right.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4383
+      present: 0.2513
+      future: 0.3104
+    spatial:
+      thing: 0.4391
+      place: 0.3099
+      person: 0.251
+    ontological:
+      imagined: 0.3425
+      forgotten: 0.2959
+      known: 0.3617
+    confidence: 0.0194
   discogs_id: 189718
   notes: ''
 His Name is Alive:
   slug: his_name_is_alive
   status: draft
-  description: 'His Name Is Alive occupies a dream-pop and art-rock space defined by heavily processed, gauze-like production.
-    Vocals are frequently submerged beneath dense layers of reverb, tape manipulation, and deliberate lo-fi degradation, creating
-    a blurred, almost submerged sonic texture. Instrumentation shifts between fragile acoustic arrangements and abrasive noise
-    passages, often within a single piece. Rhythmically, the work can be languid and floating or unexpectedly propulsive with
-    funk or soul undercurrents. Lyrically, themes circle dissociation, longing, the uncanny, domestic strangeness, and interior
-    psychological states rendered in fragmentary, elliptical imagery. Tone tends toward the ambiguous — neither fully mournful
-    nor celebratory — occupying a liminal emotional territory that feels suspended between waking and dreaming. The project
-    is primarily vocal, though extended instrumental passages contribute significantly to its atmospheric, immersive character.
+  description: 'His Name Is Alive occupies a dream-pop and art-rock space defined
+    by heavily processed, gauze-like production. Vocals are frequently submerged beneath
+    dense layers of reverb, tape manipulation, and deliberate lo-fi degradation, creating
+    a blurred, almost submerged sonic texture. Instrumentation shifts between fragile
+    acoustic arrangements and abrasive noise passages, often within a single piece.
+    Rhythmically, the work can be languid and floating or unexpectedly propulsive
+    with funk or soul undercurrents. Lyrically, themes circle dissociation, longing,
+    the uncanny, domestic strangeness, and interior psychological states rendered
+    in fragmentary, elliptical imagery. Tone tends toward the ambiguous — neither
+    fully mournful nor celebratory — occupying a liminal emotional territory that
+    feels suspended between waking and dreaming. The project is primarily vocal, though
+    extended instrumental passages contribute significantly to its atmospheric, immersive
+    character.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4285
+      present: 0.2628
+      future: 0.3088
+    spatial:
+      thing: 0.4295
+      place: 0.3084
+      person: 0.262
+    ontological:
+      imagined: 0.3529
+      forgotten: 0.2935
+      known: 0.3536
+    confidence: 0.0235
   discogs_id: 61796
   notes: ''
 Helios:
   slug: helios
   status: draft
-  description: 'Helios (Keith Kenniff) works primarily in instrumental electronic and ambient music, though occasional wordless
-    vocals or minimal sung phrases appear as textural elements rather than lyrical statements. Sonically, the music favors
-    warm, slightly diffuse production — soft synthesizer pads layered with treated acoustic guitar, gentle piano figures,
-    and organic field-recording textures woven into electronic frameworks. Drum programming tends toward understated, brushed
-    rhythmic pulses rather than sharp percussive attacks, creating a cushioned, almost suspended density. Thematically, the
-    work gestures toward natural quietude, introspective space, and the passage of light — imagery evoking dusk, open landscape,
-    and stillness implied through tonal color rather than explicit narrative. The emotional register is consistently contemplative
-    and melancholic without heaviness, occupying a psychological space between solitude and calm acceptance. Production choices
-    emphasize warmth and subtle compression, lending the overall sound an intimate, close-miked softness.
+  description: 'Helios (Keith Kenniff) works primarily in instrumental electronic
+    and ambient music, though occasional wordless vocals or minimal sung phrases appear
+    as textural elements rather than lyrical statements. Sonically, the music favors
+    warm, slightly diffuse production — soft synthesizer pads layered with treated
+    acoustic guitar, gentle piano figures, and organic field-recording textures woven
+    into electronic frameworks. Drum programming tends toward understated, brushed
+    rhythmic pulses rather than sharp percussive attacks, creating a cushioned, almost
+    suspended density. Thematically, the work gestures toward natural quietude, introspective
+    space, and the passage of light — imagery evoking dusk, open landscape, and stillness
+    implied through tonal color rather than explicit narrative. The emotional register
+    is consistently contemplative and melancholic without heaviness, occupying a psychological
+    space between solitude and calm acceptance. Production choices emphasize warmth
+    and subtle compression, lending the overall sound an intimate, close-miked softness.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4461
+      present: 0.2505
+      future: 0.3033
+    spatial:
+      thing: 0.447
+      place: 0.3035
+      person: 0.2496
+    ontological:
+      imagined: 0.3518
+      forgotten: 0.2903
+      known: 0.3579
+    confidence: 0.0263
   discogs_id: 121680
   notes: ''
 Sweet Valley:
   slug: sweet_valley
   status: draft
-  description: 'Sweet Valley produce instrumental and near-instrumental music built from lo-fi sample manipulation, soft drum
-    programming, and layered synthetic textures. Production is hazy and deliberately degraded — samples are processed until
-    their origins blur, bass frequencies are cushioned in warm compression, and higher registers shimmer with gentle distortion
-    or tape saturation. The overall texture is dense but unhurried, favouring horizontal drift over structural development.
-    Melodic content surfaces in looped fragments — keyboard lines, vocal snippets, guitar phrases — repeated with subtle variation
-    until they function as mantric atmosphere rather than song. When vocals appear they are treated and submerged, contributing
-    texture rather than narrative. Thematic affect centres on nostalgia, leisure, and emotional ambivalence — a summer afternoon
-    feeling that is pleasurable yet faintly melancholic, familiar yet slightly dissociated. The emotional register is dreamy
-    and soporific, occupying the psychological territory of mild intoxication: pleasantly disoriented, temporarily at ease,
-    the present moment softened at its edges.'
+  description: 'Sweet Valley produce instrumental and near-instrumental music built
+    from lo-fi sample manipulation, soft drum programming, and layered synthetic textures.
+    Production is hazy and deliberately degraded — samples are processed until their
+    origins blur, bass frequencies are cushioned in warm compression, and higher registers
+    shimmer with gentle distortion or tape saturation. The overall texture is dense
+    but unhurried, favouring horizontal drift over structural development. Melodic
+    content surfaces in looped fragments — keyboard lines, vocal snippets, guitar
+    phrases — repeated with subtle variation until they function as mantric atmosphere
+    rather than song. When vocals appear they are treated and submerged, contributing
+    texture rather than narrative. Thematic affect centres on nostalgia, leisure,
+    and emotional ambivalence — a summer afternoon feeling that is pleasurable yet
+    faintly melancholic, familiar yet slightly dissociated. The emotional register
+    is dreamy and soporific, occupying the psychological territory of mild intoxication:
+    pleasantly disoriented, temporarily at ease, the present moment softened at its
+    edges.'
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4567
+      present: 0.2393
+      future: 0.304
+    spatial:
+      thing: 0.4575
+      place: 0.3036
+      person: 0.2389
+    ontological:
+      imagined: 0.358
+      forgotten: 0.283
+      known: 0.3589
+    confidence: 0.0424
   discogs_id: 3075580
   notes: Unknown artist — fill description manually
 MF Doom:
   slug: mf_doom
   status: draft
-  description: 'MF DOOM operates primarily as a vocal artist layered over dense, sample-heavy production. Beats are built
-    from dusty, lo-fi textures—warped vinyl crackle, thick low-end, chopped jazz and cinematic soul samples compressed into
-    deliberately murky sonic palettes. Arrangements favor claustrophobic density over openness, with erratic rhythmic placements
-    and syncopated drum patterns sitting beneath heavily filtered loops. Lyrically, imagery draws from comic book mythology,
-    street-level surrealism, culinary references, wordplay, and coded allegory. Narrative perspective shifts fluidly, adopting
-    persona and mask as structural devices. Rhyme schemes are intricately layered, favoring internal rhyme, slant rhyme, and
-    multi-syllabic compression. Thematically, content moves between absurdist humor and nihilistic undercurrents, with moments
-    of oblique vulnerability concealed beneath irony. The emotional register is detached yet sardonic—cool, cerebral, and
-    slightly sinister—creating a mood that is simultaneously playful and unsettling, like noir filtered through a funhouse
-    lens.
+  description: 'MF DOOM operates primarily as a vocal artist layered over dense, sample-heavy
+    production. Beats are built from dusty, lo-fi textures—warped vinyl crackle, thick
+    low-end, chopped jazz and cinematic soul samples compressed into deliberately
+    murky sonic palettes. Arrangements favor claustrophobic density over openness,
+    with erratic rhythmic placements and syncopated drum patterns sitting beneath
+    heavily filtered loops. Lyrically, imagery draws from comic book mythology, street-level
+    surrealism, culinary references, wordplay, and coded allegory. Narrative perspective
+    shifts fluidly, adopting persona and mask as structural devices. Rhyme schemes
+    are intricately layered, favoring internal rhyme, slant rhyme, and multi-syllabic
+    compression. Thematically, content moves between absurdist humor and nihilistic
+    undercurrents, with moments of oblique vulnerability concealed beneath irony.
+    The emotional register is detached yet sardonic—cool, cerebral, and slightly sinister—creating
+    a mood that is simultaneously playful and unsettling, like noir filtered through
+    a funhouse lens.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4238
+      present: 0.2614
+      future: 0.3148
+    spatial:
+      thing: 0.4245
+      place: 0.3145
+      person: 0.2609
+    ontological:
+      imagined: 0.3379
+      forgotten: 0.3038
+      known: 0.3583
+    confidence: 0.0149
   discogs_id: 25058
   notes: ''
 Bowery Electric:
   slug: bowery_electric
   status: draft
-  description: 'Bowery Electric occupies a dense intersection of dream pop, shoegaze, and trip-hop, layering heavily processed
-    guitars beneath slow, hypnotic drum machine patterns. The production aesthetic is thick and submerged, favoring reverb-drenched
-    timbres, low-frequency weight, and a gauzy, narcotic sonic texture where individual elements blur into washes of sound.
-    Vocals, when present, are treated as another textural layer — breathy, distanced, and affectless rather than melodically
-    prominent, sitting inside the mix rather than above it. Thematically, the work gravitates toward urban nocturnal imagery,
-    dissociation, and states of suspension — neither wakefulness nor sleep. The emotional register is cool, melancholic, and
-    introspective, evoking psychological states of numbness and longing simultaneously. The project moves fluidly between
-    vocal and more purely atmospheric instrumental passages, with the boundary between the two remaining deliberately indistinct.
+  description: 'Bowery Electric occupies a dense intersection of dream pop, shoegaze,
+    and trip-hop, layering heavily processed guitars beneath slow, hypnotic drum machine
+    patterns. The production aesthetic is thick and submerged, favoring reverb-drenched
+    timbres, low-frequency weight, and a gauzy, narcotic sonic texture where individual
+    elements blur into washes of sound. Vocals, when present, are treated as another
+    textural layer — breathy, distanced, and affectless rather than melodically prominent,
+    sitting inside the mix rather than above it. Thematically, the work gravitates
+    toward urban nocturnal imagery, dissociation, and states of suspension — neither
+    wakefulness nor sleep. The emotional register is cool, melancholic, and introspective,
+    evoking psychological states of numbness and longing simultaneously. The project
+    moves fluidly between vocal and more purely atmospheric instrumental passages,
+    with the boundary between the two remaining deliberately indistinct.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4468
+      present: 0.2478
+      future: 0.3054
+    spatial:
+      thing: 0.4481
+      place: 0.3047
+      person: 0.2473
+    ontological:
+      imagined: 0.3609
+      forgotten: 0.2857
+      known: 0.3534
+    confidence: 0.0459
   discogs_id: 3800
   notes: ''
 Múm:
   slug: m_m
   status: draft
-  description: 'Múm crafts music from layered whispers of acoustic and electronic texture—melodica, glockenspiel, treated
-    strings, and fragmented field recordings woven through digital processing into something gauzy and dreamlike. Their production
-    approach favours low density, open space, and a handmade intimacy, allowing individual timbres to breathe within sparse
-    arrangements. Vocals, when present, are breathy and childlike, often treated as texture rather than foreground melodic
-    statement, blending into the instrumental fabric. The music is primarily instrumental in character even when voices appear.
-    Thematically, their work orbits childhood memory, winter landscapes, quiet longing, and the boundary between sleep and
-    waking. Imagery tends toward the domestic, the seasonal, and the small-scale magical. Emotionally, the register is tender,
-    melancholic, and gently otherworldly—fragile rather than dark, evoking a soft nostalgia tinged with unease, as though
-    remembering something half-forgotten.
+  description: 'Múm crafts music from layered whispers of acoustic and electronic
+    texture—melodica, glockenspiel, treated strings, and fragmented field recordings
+    woven through digital processing into something gauzy and dreamlike. Their production
+    approach favours low density, open space, and a handmade intimacy, allowing individual
+    timbres to breathe within sparse arrangements. Vocals, when present, are breathy
+    and childlike, often treated as texture rather than foreground melodic statement,
+    blending into the instrumental fabric. The music is primarily instrumental in
+    character even when voices appear. Thematically, their work orbits childhood memory,
+    winter landscapes, quiet longing, and the boundary between sleep and waking. Imagery
+    tends toward the domestic, the seasonal, and the small-scale magical. Emotionally,
+    the register is tender, melancholic, and gently otherworldly—fragile rather than
+    dark, evoking a soft nostalgia tinged with unease, as though remembering something
+    half-forgotten.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4511
+      present: 0.2448
+      future: 0.3041
+    spatial:
+      thing: 0.4522
+      place: 0.3036
+      person: 0.2442
+    ontological:
+      imagined: 0.3518
+      forgotten: 0.2868
+      known: 0.3614
+    confidence: 0.0499
   discogs_id: 8298
   notes: ''
 Tycho (3):
   slug: tycho_3
   status: draft
-  description: 'Tycho occupies a predominantly instrumental space, weaving together warm analog synthesizers, live drumming,
-    and electric guitar into densely layered yet breathable textures. The production favors a sun-saturated aesthetic — soft
-    compression, vintage warmth, and reverb-rich soundscapes that blur the boundary between electronic and organic sources.
-    Occasional vocal elements appear in later work, functioning more as textural color than lyrical foreground.
+  description: 'Tycho occupies a predominantly instrumental space, weaving together
+    warm analog synthesizers, live drumming, and electric guitar into densely layered
+    yet breathable textures. The production favors a sun-saturated aesthetic — soft
+    compression, vintage warmth, and reverb-rich soundscapes that blur the boundary
+    between electronic and organic sources. Occasional vocal elements appear in later
+    work, functioning more as textural color than lyrical foreground.
 
 
-    Thematically, the music evokes spatial openness — coastlines, late afternoons, transient moments suspended in light. When
-    lyrics appear, they lean toward impressionistic, introspective territory without narrative specificity, gesturing toward
-    longing and presence simultaneously.
+    Thematically, the music evokes spatial openness — coastlines, late afternoons,
+    transient moments suspended in light. When lyrics appear, they lean toward impressionistic,
+    introspective territory without narrative specificity, gesturing toward longing
+    and presence simultaneously.
 
 
-    The emotional register is consistently contemplative and bittersweet, occupying a psychological space between melancholy
-    and contentment — nostalgic without sentimentality. Rhythmic propulsion from live-sounding percussion grounds the dreamlike
-    textures, preventing pure ambience and maintaining gentle forward momentum throughout.
+    The emotional register is consistently contemplative and bittersweet, occupying
+    a psychological space between melancholy and contentment — nostalgic without sentimentality.
+    Rhythmic propulsion from live-sounding percussion grounds the dreamlike textures,
+    preventing pure ambience and maintaining gentle forward momentum throughout.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.426
+      present: 0.2606
+      future: 0.3134
+    spatial:
+      thing: 0.4268
+      place: 0.3131
+      person: 0.2602
+    ontological:
+      imagined: 0.352
+      forgotten: 0.2966
+      known: 0.3514
+    confidence: 0.0233
   discogs_id: 71827
   notes: ''
 Krzysztof Penderecki:
   slug: krzysztof_penderecki
   status: draft
-  description: 'Penderecki''s music occupies dense, turbulent sonic landscapes built from extended orchestral and choral techniques.
-    His textural language favors tone clusters, microtonal string clusters, sul ponticello bowing, col legno percussion, and
-    massive choral walls that dissolve pitched tone into noise. Production character is organic yet overwhelming, with waves
-    of sound expanding and collapsing like breathing architecture. Thematically, his work orbits suffering, grief, collective
-    trauma, and transcendence — imagery of lamentation and spiritual crisis dominates, often drawing from sacred and liturgical
-    frameworks. The emotional register is predominantly dark, anguished, and cathartic, with occasional passages of stark,
-    hollow stillness that heighten surrounding turbulence. His output is substantially orchestral and choral, treating the
-    human voice as one textural element among many rather than a narrative focal point. Works shift between violent sonic
-    density and suspended, near-silent fragility.
+  description: 'Penderecki''s music occupies dense, turbulent sonic landscapes built
+    from extended orchestral and choral techniques. His textural language favors tone
+    clusters, microtonal string clusters, sul ponticello bowing, col legno percussion,
+    and massive choral walls that dissolve pitched tone into noise. Production character
+    is organic yet overwhelming, with waves of sound expanding and collapsing like
+    breathing architecture. Thematically, his work orbits suffering, grief, collective
+    trauma, and transcendence — imagery of lamentation and spiritual crisis dominates,
+    often drawing from sacred and liturgical frameworks. The emotional register is
+    predominantly dark, anguished, and cathartic, with occasional passages of stark,
+    hollow stillness that heighten surrounding turbulence. His output is substantially
+    orchestral and choral, treating the human voice as one textural element among
+    many rather than a narrative focal point. Works shift between violent sonic density
+    and suspended, near-silent fragility.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4167
+      present: 0.263
+      future: 0.3203
+    spatial:
+      thing: 0.4174
+      place: 0.3199
+      person: 0.2627
+    ontological:
+      imagined: 0.3352
+      forgotten: 0.3084
+      known: 0.3564
+    confidence: 0.0145
   discogs_id: 227875
   notes: ''
 Charles Ives:
   slug: charles_ives
   status: draft
-  description: 'Charles Ives works primarily in the orchestral and chamber instrumental domain, though vocal settings appear
-    frequently within his output. His sonic texture is dense and often deliberately dissonant, layering multiple simultaneous
-    musical streams — marching band fragments, hymn tunes, folk melodies — colliding in thick, polytonal or polyrhythmic counterpoint.
-    The production character, conceived for acoustic forces, evokes spatial distance and outdoor ambience, with foreground
-    and background planes coexisting without resolution. Thematically, his work draws on American vernacular imagery: pastoral
-    landscapes, town squares, civic ceremony, and spiritual contemplation. Fragments of recognizable melody surface and dissolve
-    within larger chromatic fields. The emotional register oscillates between nostalgic warmth and unresolved tension, moving
-    through meditative stillness, rugged energy, and moments of transcendent ambiguity. A sense of memory, impermanence, and
-    searching introspection pervades the work, balanced against robust, almost rough-hewn vitality.
+  description: 'Charles Ives works primarily in the orchestral and chamber instrumental
+    domain, though vocal settings appear frequently within his output. His sonic texture
+    is dense and often deliberately dissonant, layering multiple simultaneous musical
+    streams — marching band fragments, hymn tunes, folk melodies — colliding in thick,
+    polytonal or polyrhythmic counterpoint. The production character, conceived for
+    acoustic forces, evokes spatial distance and outdoor ambience, with foreground
+    and background planes coexisting without resolution. Thematically, his work draws
+    on American vernacular imagery: pastoral landscapes, town squares, civic ceremony,
+    and spiritual contemplation. Fragments of recognizable melody surface and dissolve
+    within larger chromatic fields. The emotional register oscillates between nostalgic
+    warmth and unresolved tension, moving through meditative stillness, rugged energy,
+    and moments of transcendent ambiguity. A sense of memory, impermanence, and searching
+    introspection pervades the work, balanced against robust, almost rough-hewn vitality.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.439
+      present: 0.2508
+      future: 0.3103
+    spatial:
+      thing: 0.4395
+      place: 0.3099
+      person: 0.2506
+    ontological:
+      imagined: 0.3424
+      forgotten: 0.2947
+      known: 0.3628
+    confidence: 0.0146
   discogs_id: 202092
   notes: ''
 György Ligeti:
   slug: gy_rgy_ligeti
   status: draft
-  description: 'Ligeti''s music inhabits dense, continuously evolving sonic landscapes built from micropolyphony — vast clusters
-    of independent voices that blur into shimmering, breathing masses of sound. Textures shift organically between suffocating
-    density and eerie transparency, often evoking organic phenomena: clouds, swarms, mechanical clocks, labyrinthine forests.
-    His harmonic language resists traditional tonality, favoring chromatic saturation, slowly morphing pitch clouds, and gradual
-    spectral transformation. Rhythmically, he layers conflicting pulses into polymetric illusions of stillness or frenzied
-    complexity. Thematically, his work projects a sense of suspended time, cosmic dislocation, and dark playfulness — simultaneously
-    ominous and absurdist, mechanical and alive. The emotional register oscillates between quiet existential dread, grotesque
-    humor, and moments of luminous, fragile beauty. His output spans both instrumental and vocal domains, treating voices
-    instrumentally and instruments vocally, dissolving conventional boundaries between the two.
+  description: 'Ligeti''s music inhabits dense, continuously evolving sonic landscapes
+    built from micropolyphony — vast clusters of independent voices that blur into
+    shimmering, breathing masses of sound. Textures shift organically between suffocating
+    density and eerie transparency, often evoking organic phenomena: clouds, swarms,
+    mechanical clocks, labyrinthine forests. His harmonic language resists traditional
+    tonality, favoring chromatic saturation, slowly morphing pitch clouds, and gradual
+    spectral transformation. Rhythmically, he layers conflicting pulses into polymetric
+    illusions of stillness or frenzied complexity. Thematically, his work projects
+    a sense of suspended time, cosmic dislocation, and dark playfulness — simultaneously
+    ominous and absurdist, mechanical and alive. The emotional register oscillates
+    between quiet existential dread, grotesque humor, and moments of luminous, fragile
+    beauty. His output spans both instrumental and vocal domains, treating voices
+    instrumentally and instruments vocally, dissolving conventional boundaries between
+    the two.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4376
+      present: 0.2518
+      future: 0.3106
+    spatial:
+      thing: 0.4383
+      place: 0.3101
+      person: 0.2516
+    ontological:
+      imagined: 0.352
+      forgotten: 0.2923
+      known: 0.3557
+    confidence: 0.0292
   discogs_id: 190370
   notes: ''
 Robert Ashley:
   slug: robert_ashley
   status: draft
-  description: 'Robert Ashley''s work centers on the spoken voice as a primary compositional instrument, blurring boundaries
-    between speech, song, and operatic form. His sonic textures are sparse and intimate, often combining dry, conversational
-    narration with subtle electronic underpinning — synthesizers, treated keyboards, and ambient drone elements that sit quietly
-    beneath the vocal layer. Production tends toward minimalism, with deliberate use of silence and understated density. Thematically,
-    his work explores American vernacular experience, memory, social ritual, identity, and the subconscious dimensions of
-    everyday life, often filtered through surreal or dreamlike imagery. The emotional register is cool and detached yet psychologically
-    layered — contemplative, occasionally hypnotic, carrying an undertone of quiet strangeness. His output is predominantly
-    vocal in orientation, with instrumental elements serving as textural support rather than melodic focus, creating a meditative,
+  description: 'Robert Ashley''s work centers on the spoken voice as a primary compositional
+    instrument, blurring boundaries between speech, song, and operatic form. His sonic
+    textures are sparse and intimate, often combining dry, conversational narration
+    with subtle electronic underpinning — synthesizers, treated keyboards, and ambient
+    drone elements that sit quietly beneath the vocal layer. Production tends toward
+    minimalism, with deliberate use of silence and understated density. Thematically,
+    his work explores American vernacular experience, memory, social ritual, identity,
+    and the subconscious dimensions of everyday life, often filtered through surreal
+    or dreamlike imagery. The emotional register is cool and detached yet psychologically
+    layered — contemplative, occasionally hypnotic, carrying an undertone of quiet
+    strangeness. His output is predominantly vocal in orientation, with instrumental
+    elements serving as textural support rather than melodic focus, creating a meditative,
     slightly disorienting listening environment rooted in spoken narrative.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.407
+      present: 0.2717
+      future: 0.3213
+    spatial:
+      thing: 0.4079
+      place: 0.3211
+      person: 0.2711
+    ontological:
+      imagined: 0.3385
+      forgotten: 0.3098
+      known: 0.3517
+    confidence: 0.0156
   discogs_id: 32210
   notes: ''
 Ryoji Ikeda:
   slug: ryoji_ikeda
   status: draft
-  description: 'Ryoji Ikeda works primarily in the instrumental domain, constructing compositions from pure data, sine tones,
-    and ultra-precise digital signals. His sonic texture is clinical and austere — white noise bursts, sub-bass frequencies,
-    and staccato high-frequency pulses arranged with mathematical rigor. Production is immaculate and minimal, favouring silence
-    and negative space as structural elements. Density oscillates between near-inaudible quietude and overwhelming sonic mass,
-    often within the same work. Thematically, his practice engages with data systems, binary information, the quantification
-    of physical reality, and the perceptual limits of human hearing. Imagery is abstract and scientific rather than narrative.
-    The emotional register is cold, contemplative, and vertiginous — invoking precision, vastness, and a disquieting sense
-    of scale. Psychological colour suggests both the sublime and the mechanical, evoking the sensation of perceiving vast
-    informational structures beyond ordinary comprehension.
+  description: 'Ryoji Ikeda works primarily in the instrumental domain, constructing
+    compositions from pure data, sine tones, and ultra-precise digital signals. His
+    sonic texture is clinical and austere — white noise bursts, sub-bass frequencies,
+    and staccato high-frequency pulses arranged with mathematical rigor. Production
+    is immaculate and minimal, favouring silence and negative space as structural
+    elements. Density oscillates between near-inaudible quietude and overwhelming
+    sonic mass, often within the same work. Thematically, his practice engages with
+    data systems, binary information, the quantification of physical reality, and
+    the perceptual limits of human hearing. Imagery is abstract and scientific rather
+    than narrative. The emotional register is cold, contemplative, and vertiginous
+    — invoking precision, vastness, and a disquieting sense of scale. Psychological
+    colour suggests both the sublime and the mechanical, evoking the sensation of
+    perceiving vast informational structures beyond ordinary comprehension.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4228
+      present: 0.2605
+      future: 0.3167
+    spatial:
+      thing: 0.4235
+      place: 0.3162
+      person: 0.2603
+    ontological:
+      imagined: 0.3235
+      forgotten: 0.3084
+      known: 0.3681
+    confidence: 0.0152
   discogs_id: 11139
   notes: ''
 Autechre:
   slug: autechre
   status: draft
-  description: 'Autechre is a primarily instrumental electronic duo whose work is defined by dense, fragmented machine rhythms
-    and sculpted synthetic textures. Their production favours granular decay, abrasive glitch artifacts, and unpredictable
-    polyrhythmic structures layered beneath or alongside cold, processed tones. Timbres range from metallic and industrial
-    to deep, cavernous sub-bass, often within a single composition. Thematically, the work evokes abstract, post-human environments
-    — mechanical systems evolving autonomously, spaces without clear geography or warmth. There are no conventional vocals
-    or lyrical content; communication is entirely through sound architecture. The emotional register is detached, cerebral,
-    and occasionally unsettling, suggesting inhuman processes operating at enormous scale or microscopic precision. Tension
-    is sustained through rhythmic unpredictability and timbral mutation rather than melodic or harmonic resolution, producing
-    a psychological atmosphere of controlled disorientation and cool, almost clinical intensity.
+  description: 'Autechre is a primarily instrumental electronic duo whose work is
+    defined by dense, fragmented machine rhythms and sculpted synthetic textures.
+    Their production favours granular decay, abrasive glitch artifacts, and unpredictable
+    polyrhythmic structures layered beneath or alongside cold, processed tones. Timbres
+    range from metallic and industrial to deep, cavernous sub-bass, often within a
+    single composition. Thematically, the work evokes abstract, post-human environments
+    — mechanical systems evolving autonomously, spaces without clear geography or
+    warmth. There are no conventional vocals or lyrical content; communication is
+    entirely through sound architecture. The emotional register is detached, cerebral,
+    and occasionally unsettling, suggesting inhuman processes operating at enormous
+    scale or microscopic precision. Tension is sustained through rhythmic unpredictability
+    and timbral mutation rather than melodic or harmonic resolution, producing a psychological
+    atmosphere of controlled disorientation and cool, almost clinical intensity.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4325
+      present: 0.2603
+      future: 0.3072
+    spatial:
+      thing: 0.4336
+      place: 0.3071
+      person: 0.2593
+    ontological:
+      imagined: 0.3579
+      forgotten: 0.2911
+      known: 0.351
+    confidence: 0.0262
   discogs_id: 41
   notes: ''
 Kiln:
   slug: kiln
   status: draft
-  description: Kiln operates in a sonic space defined by warm, analog textures and a lo-fi aesthetic, blending elements of
-    ambient, post-rock, and electronic music. Their production approach emphasizes organic imperfection — tape hiss, vinyl
-    crackle, and subtle detuning create a nostalgic, weathered quality. Instrumentation includes treated guitars, vintage
-    synthesizers, and field recordings layered into dense yet intimate arrangements. Thematically, their work evokes natural
-    landscapes, memory, and the passage of time — imagery of rural environments, seasonal change, and quiet introspection
-    is common. The emotional register is contemplative and melancholic without heaviness, occupying a psychological space
-    between solitude and calm acceptance. Vocals are rare and typically treated as textural elements rather than lyrical focal
-    points.
+  description: Kiln operates in a sonic space defined by warm, analog textures and
+    a lo-fi aesthetic, blending elements of ambient, post-rock, and electronic music.
+    Their production approach emphasizes organic imperfection — tape hiss, vinyl crackle,
+    and subtle detuning create a nostalgic, weathered quality. Instrumentation includes
+    treated guitars, vintage synthesizers, and field recordings layered into dense
+    yet intimate arrangements. Thematically, their work evokes natural landscapes,
+    memory, and the passage of time — imagery of rural environments, seasonal change,
+    and quiet introspection is common. The emotional register is contemplative and
+    melancholic without heaviness, occupying a psychological space between solitude
+    and calm acceptance. Vocals are rare and typically treated as textural elements
+    rather than lyrical focal points.
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4183
+      present: 0.2616
+      future: 0.3202
+    spatial:
+      thing: 0.4191
+      place: 0.3194
+      person: 0.2615
+    ontological:
+      imagined: 0.3522
+      forgotten: 0.3006
+      known: 0.3472
+    confidence: 0.0205
   discogs_id: 53514
   notes: Unknown artist — fill description manually
 Fibreforms:
   slug: fibreforms
   status: draft
-  description: Fibreforms create a spooky, lofi electronic music that combines elements of post-punk, industrial, indie and
-    new music. The mood is haunted, dark and cinematic, with a strong emphasis on texture and atmosphere. The music is often
-    built around dense layers of distorted guitars, synths, and percussion, creating a sense of claustrophobia and unease.
-    Vocals are typically buried in the mix, adding to the overall sense of disorientation. Thematically, their work explores
-    themes of decay, urban isolation, and existential dread, often drawing on imagery of abandoned buildings, desolate landscapes,
-    and psychological turmoil. The emotional register is intense and unsettling, evoking feelings of anxiety, alienation,
-    and dark introspection.
+  description: Fibreforms create a spooky, lofi electronic music that combines elements
+    of post-punk, industrial, indie and new music. The mood is haunted, dark and cinematic,
+    with a strong emphasis on texture and atmosphere. The music is often built around
+    dense layers of distorted guitars, synths, and percussion, creating a sense of
+    claustrophobia and unease. Vocals are typically buried in the mix, adding to the
+    overall sense of disorientation. Thematically, their work explores themes of decay,
+    urban isolation, and existential dread, often drawing on imagery of abandoned
+    buildings, desolate landscapes, and psychological turmoil. The emotional register
+    is intense and unsettling, evoking feelings of anxiety, alienation, and dark introspection.
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4058
+      present: 0.2708
+      future: 0.3234
+    spatial:
+      thing: 0.4069
+      place: 0.3228
+      person: 0.2703
+    ontological:
+      imagined: 0.3564
+      forgotten: 0.3032
+      known: 0.3404
+    confidence: 0.0256
   discogs_id: 185564
   notes: Unknown artist — fill description manually
 Morton Subotnick:
   slug: morton_subotnick
   status: draft
-  description: 'Morton Subotnick operates exclusively in the instrumental electronic domain, producing works of rich, evolving
-    sonic architecture. His textural approach favors layered synthesis — oscillating tones, granular bursts, ghostly sustained
-    timbres, and percussive electronic gestures that shift fluidly between organic and mechanical qualities. Studio production
-    is central to his conception, treating the recording medium itself as compositional material, favoring spatial depth,
-    unconventional amplitude envelopes, and dynamic density contrast. Thematically, his work navigates abstract, non-narrative
-    sound worlds — evoking cosmic vastness, primordial natural forces, and dreamlike states of transformation. Imagery tends
-    toward the elemental and surreal rather than the personal or programmatic. The emotional register balances cool, analytical
-    detachment with undercurrents of tension, wonder, and subtle menace. Psychological colour is often liminal — hovering
-    between the familiar and alien, inviting contemplative yet unsettled listening states.
+  description: 'Morton Subotnick operates exclusively in the instrumental electronic
+    domain, producing works of rich, evolving sonic architecture. His textural approach
+    favors layered synthesis — oscillating tones, granular bursts, ghostly sustained
+    timbres, and percussive electronic gestures that shift fluidly between organic
+    and mechanical qualities. Studio production is central to his conception, treating
+    the recording medium itself as compositional material, favoring spatial depth,
+    unconventional amplitude envelopes, and dynamic density contrast. Thematically,
+    his work navigates abstract, non-narrative sound worlds — evoking cosmic vastness,
+    primordial natural forces, and dreamlike states of transformation. Imagery tends
+    toward the elemental and surreal rather than the personal or programmatic. The
+    emotional register balances cool, analytical detachment with undercurrents of
+    tension, wonder, and subtle menace. Psychological colour is often liminal — hovering
+    between the familiar and alien, inviting contemplative yet unsettled listening
+    states.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4265
+      present: 0.2588
+      future: 0.3147
+    spatial:
+      thing: 0.4273
+      place: 0.3144
+      person: 0.2583
+    ontological:
+      imagined: 0.3318
+      forgotten: 0.3044
+      known: 0.3638
+    confidence: 0.0237
   discogs_id: 32196
   notes: ''
 Arthur Russell:
   slug: arthur_russell
   status: draft
-  description: 'Arthur Russell''s work blends sparse, lo-fi production with unexpectedly warm, intimate textures — cello drones,
-    echoing percussion, and softly layered vocals create a hazy, enveloping density. His studio approach favors deliberate
-    imperfection: tape hiss, gentle distortion, and loose rhythmic feel give recordings an organic, handmade quality. Thematically,
-    his output circles around longing, spiritual searching, transient connection, and the quiet strangeness of everyday experience,
-    often rendered through fragmentary, impressionistic imagery that resists narrative closure. Emotionally, the register
-    is tender yet melancholic, conveying vulnerability and an almost childlike openness alongside an undercurrent of wistfulness.
-    Russell is primarily vocal — his voice, wavering and unguarded, sits centrally in the mix — though instrumentation, particularly
-    cello, carries equal expressive weight. Disco and minimalist influences coexist with folk-like simplicity, producing an
-    aesthetic that feels simultaneously danceable and deeply introspective.
+  description: 'Arthur Russell''s work blends sparse, lo-fi production with unexpectedly
+    warm, intimate textures — cello drones, echoing percussion, and softly layered
+    vocals create a hazy, enveloping density. His studio approach favors deliberate
+    imperfection: tape hiss, gentle distortion, and loose rhythmic feel give recordings
+    an organic, handmade quality. Thematically, his output circles around longing,
+    spiritual searching, transient connection, and the quiet strangeness of everyday
+    experience, often rendered through fragmentary, impressionistic imagery that resists
+    narrative closure. Emotionally, the register is tender yet melancholic, conveying
+    vulnerability and an almost childlike openness alongside an undercurrent of wistfulness.
+    Russell is primarily vocal — his voice, wavering and unguarded, sits centrally
+    in the mix — though instrumentation, particularly cello, carries equal expressive
+    weight. Disco and minimalist influences coexist with folk-like simplicity, producing
+    an aesthetic that feels simultaneously danceable and deeply introspective.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4539
+      present: 0.2482
+      future: 0.2979
+    spatial:
+      thing: 0.455
+      place: 0.2977
+      person: 0.2473
+    ontological:
+      imagined: 0.361
+      forgotten: 0.2813
+      known: 0.3576
+    confidence: 0.0575
   discogs_id: 23524
   notes: ''
 The Dead C:
   slug: the_dead_c
   status: draft
-  description: 'The Dead C operate in a zone of extreme sonic distortion and deliberate structural collapse. Their production
-    favours raw, lo-fi density — guitars dissolve into noise fields, drums feel both primitive and destabilising, and the
-    overall mix carries a corroded, tape-damaged quality. Textures accumulate into overwhelming walls of feedback and dissonance,
-    with tonal clarity largely abandoned in favour of abrasive, unresolved sound masses. The work is primarily instrumental
-    in orientation, though vocals appear sporadically — when present, they are treated as another textural layer rather than
-    a melodic or narrative vehicle. Thematically, the music evokes entropy, isolation, and psychic disintegration, favouring
-    abstract, fragmented imagery over direct communication. The emotional register is bleak and pressurised, with an underlying
-    tension that rarely resolves, sustaining a mood of sustained unease, desolation, and a kind of transcendent, drone-induced
-    dissociation.
+  description: 'The Dead C operate in a zone of extreme sonic distortion and deliberate
+    structural collapse. Their production favours raw, lo-fi density — guitars dissolve
+    into noise fields, drums feel both primitive and destabilising, and the overall
+    mix carries a corroded, tape-damaged quality. Textures accumulate into overwhelming
+    walls of feedback and dissonance, with tonal clarity largely abandoned in favour
+    of abrasive, unresolved sound masses. The work is primarily instrumental in orientation,
+    though vocals appear sporadically — when present, they are treated as another
+    textural layer rather than a melodic or narrative vehicle. Thematically, the music
+    evokes entropy, isolation, and psychic disintegration, favouring abstract, fragmented
+    imagery over direct communication. The emotional register is bleak and pressurised,
+    with an underlying tension that rarely resolves, sustaining a mood of sustained
+    unease, desolation, and a kind of transcendent, drone-induced dissociation.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4372
+      present: 0.2539
+      future: 0.309
+    spatial:
+      thing: 0.4382
+      place: 0.3085
+      person: 0.2533
+    ontological:
+      imagined: 0.3416
+      forgotten: 0.2956
+      known: 0.3628
+    confidence: 0.0473
   discogs_id: 103196
   notes: ''
 Merzbow:
   slug: merzbow
   status: draft
-  description: 'Merzbow operates in the realm of harsh noise, producing densely layered walls of abrasive sound built from
-    feedback, distortion, synthesizers, circuit-bent electronics, and heavily processed field recordings. The production approach
-    is extreme, often monolithic in density, with little conventional dynamic variation — texture itself becomes the primary
-    compositional element. Timbres range from searing high-frequency squall to low grinding rumble, frequently existing simultaneously
-    in crushing superposition. The work is almost entirely instrumental and non-vocal, with sound-mass replacing melody, harmony,
-    or rhythm in traditional senses. Thematically, the aesthetic frequently engages with industrial decay, animalist imagery,
-    transgression, and the physical limits of sonic perception. Emotionally, the register is intense and confrontational —
-    simultaneously cathartic and oppressive, evoking psychological states of overwhelm, dissociation, or hypnotic immersion.
-    Duration and volume are treated as expressive parameters equal in weight to pitch or timbre.
+  description: 'Merzbow operates in the realm of harsh noise, producing densely layered
+    walls of abrasive sound built from feedback, distortion, synthesizers, circuit-bent
+    electronics, and heavily processed field recordings. The production approach is
+    extreme, often monolithic in density, with little conventional dynamic variation
+    — texture itself becomes the primary compositional element. Timbres range from
+    searing high-frequency squall to low grinding rumble, frequently existing simultaneously
+    in crushing superposition. The work is almost entirely instrumental and non-vocal,
+    with sound-mass replacing melody, harmony, or rhythm in traditional senses. Thematically,
+    the aesthetic frequently engages with industrial decay, animalist imagery, transgression,
+    and the physical limits of sonic perception. Emotionally, the register is intense
+    and confrontational — simultaneously cathartic and oppressive, evoking psychological
+    states of overwhelm, dissociation, or hypnotic immersion. Duration and volume
+    are treated as expressive parameters equal in weight to pitch or timbre.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4236
+      present: 0.2555
+      future: 0.3209
+    spatial:
+      thing: 0.4242
+      place: 0.3204
+      person: 0.2554
+    ontological:
+      imagined: 0.3271
+      forgotten: 0.3105
+      known: 0.3624
+    confidence: 0.0193
   discogs_id: 12551
   notes: ''
 Pork Queen:
   slug: pork_queen
   status: draft
-  description: At the intersection of harsh noise and muisque concreate is the mysterious Pork Queen. Their music is a dense,
-    abrasive blend of distorted electronics, field recordings, and manipulated acoustic sounds, creating a sonic landscape
-    that is both chaotic and meticulously crafted. The production style emphasizes raw intensity, with layers of noise and
-    texture that can feel overwhelming yet strangely immersive. Vocals, if present, are often heavily processed and buried
-    within the mix, adding to the overall sense of disorientation. Thematically, Pork Queen's work explores themes of decay,
-    urban isolation, and existential dread, often drawing on imagery of abandoned buildings, desolate landscapes, and psychological
-    turmoil. The emotional register is intense and unsettling, evoking feelings of anxiety, alienation, and dark introspection.
+  description: At the intersection of harsh noise and muisque concreate is the mysterious
+    Pork Queen. Their music is a dense, abrasive blend of distorted electronics, field
+    recordings, and manipulated acoustic sounds, creating a sonic landscape that is
+    both chaotic and meticulously crafted. The production style emphasizes raw intensity,
+    with layers of noise and texture that can feel overwhelming yet strangely immersive.
+    Vocals, if present, are often heavily processed and buried within the mix, adding
+    to the overall sense of disorientation. Thematically, Pork Queen's work explores
+    themes of decay, urban isolation, and existential dread, often drawing on imagery
+    of abandoned buildings, desolate landscapes, and psychological turmoil. The emotional
+    register is intense and unsettling, evoking feelings of anxiety, alienation, and
+    dark introspection.
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4326
+      present: 0.2524
+      future: 0.315
+    spatial:
+      thing: 0.4336
+      place: 0.3141
+      person: 0.2523
+    ontological:
+      imagined: 0.3616
+      forgotten: 0.2924
+      known: 0.3459
+    confidence: 0.0401
   discogs_id: 244274
   notes: Unknown artist — fill description manually
 Malcolm Williamson:
   slug: malcolm_williamson
   status: draft
-  description: 'Malcolm Williamson was a vocal and instrumental composer working primarily in the Western classical tradition.
-    His sonic textures blend post-Romantic harmonic language with modernist dissonance, often incorporating jazz-inflected
-    rhythms and popular idioms within orchestral and chamber frameworks, creating an accessible yet structurally complex density.
-    His production character is acoustic and concert-hall oriented, with transparent orchestration punctuated by moments of
-    rich choral weight. Thematically, his work gravitates toward spiritual and liturgical imagery, human celebration, and
-    occasional darkness, balancing sacred solemnity with playful accessibility. His choral writing carries warmth and communal
-    resonance, while instrumental passages shift between lyrical expressiveness and rhythmic drive. The emotional register
-    spans contemplative introspection to jubilant exuberance, with an underlying tension between tradition and innovation.
-    His output ranges across opera, symphony, and educational pieces, reflecting tonal flexibility and expressive versatility.
+  description: 'Malcolm Williamson was a vocal and instrumental composer working primarily
+    in the Western classical tradition. His sonic textures blend post-Romantic harmonic
+    language with modernist dissonance, often incorporating jazz-inflected rhythms
+    and popular idioms within orchestral and chamber frameworks, creating an accessible
+    yet structurally complex density. His production character is acoustic and concert-hall
+    oriented, with transparent orchestration punctuated by moments of rich choral
+    weight. Thematically, his work gravitates toward spiritual and liturgical imagery,
+    human celebration, and occasional darkness, balancing sacred solemnity with playful
+    accessibility. His choral writing carries warmth and communal resonance, while
+    instrumental passages shift between lyrical expressiveness and rhythmic drive.
+    The emotional register spans contemplative introspection to jubilant exuberance,
+    with an underlying tension between tradition and innovation. His output ranges
+    across opera, symphony, and educational pieces, reflecting tonal flexibility and
+    expressive versatility.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4267
+      present: 0.2633
+      future: 0.3099
+    spatial:
+      thing: 0.4275
+      place: 0.3101
+      person: 0.2624
+    ontological:
+      imagined: 0.3532
+      forgotten: 0.2945
+      known: 0.3523
+    confidence: 0.0192
   discogs_id: 1290977
   notes: ''
 Iannis Xenakis:
   slug: iannis_xenakis
   status: draft
-  description: 'Xenakis works almost entirely in the instrumental domain, though occasional vocal elements appear as textural
-    masses rather than melodic or lyrical forces. His sonic world is defined by extreme density — swarms of sound derived
-    from stochastic processes, resulting in granular clouds, glissandi cascades, and percussive storms that blur the boundary
-    between pitch and noise. Textures shift between chaotic turbulence and sudden, stark silences. His studio and acoustic
-    output alike favor architectural weight, with brass, strings, and percussion treated as collective masses rather than
-    individual voices. Thematically, the work evokes primordial forces — chaos, cosmic scale, geological pressure, and the
-    mathematics underlying natural phenomena. The emotional register is intense and impersonal simultaneously: awe-inducing,
-    overwhelming, occasionally terrifying. There is minimal warmth or intimacy; instead, a cold grandeur dominates, as if
-    mapping forces larger than human experience onto sound.
+  description: 'Xenakis works almost entirely in the instrumental domain, though occasional
+    vocal elements appear as textural masses rather than melodic or lyrical forces.
+    His sonic world is defined by extreme density — swarms of sound derived from stochastic
+    processes, resulting in granular clouds, glissandi cascades, and percussive storms
+    that blur the boundary between pitch and noise. Textures shift between chaotic
+    turbulence and sudden, stark silences. His studio and acoustic output alike favor
+    architectural weight, with brass, strings, and percussion treated as collective
+    masses rather than individual voices. Thematically, the work evokes primordial
+    forces — chaos, cosmic scale, geological pressure, and the mathematics underlying
+    natural phenomena. The emotional register is intense and impersonal simultaneously:
+    awe-inducing, overwhelming, occasionally terrifying. There is minimal warmth or
+    intimacy; instead, a cold grandeur dominates, as if mapping forces larger than
+    human experience onto sound.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.428
+      present: 0.259
+      future: 0.313
+    spatial:
+      thing: 0.4288
+      place: 0.3126
+      person: 0.2587
+    ontological:
+      imagined: 0.3395
+      forgotten: 0.2996
+      known: 0.3609
+    confidence: 0.0243
   discogs_id: 32202
   notes: ''
 Angela Morley:
   slug: angela_morley
   status: draft
-  description: 'Angela Morley works in orchestral and cinematic idioms, producing arrangements of considerable lushness and
-    structural sophistication. String writing is central to her palette — warm, legato passages that carry sustained melodic
-    lines, punctuated by woodwind detail and occasional brass colour. Production accommodates both the intimate and the expansive:
-    some works favour chamber-scaled delicacy, others build toward cinematic sweep through careful orchestral accumulation.
-    Her compositions integrate electronics without privileging them — synthesiser textures and treated instrumental sounds
-    are woven into orchestral contexts rather than foregrounded as novelty, creating hybrids that feel neither purely acoustic
-    nor wholly synthetic. Harmonically, the writing gravitates toward late-Romantic warmth, with a tendency to dwell in chromatic
-    transition rather than resolving quickly toward tonal centres. Thematic affect is predominantly introspective and elegiac
-    — imagery suggests interiority, the passage of time, and the emotional weight of memory. The emotional register is tender
-    and quietly sorrowful, evoking yearning and bittersweet reflection without sentimentality.'
+  description: 'Angela Morley works in orchestral and cinematic idioms, producing
+    arrangements of considerable lushness and structural sophistication. String writing
+    is central to her palette — warm, legato passages that carry sustained melodic
+    lines, punctuated by woodwind detail and occasional brass colour. Production accommodates
+    both the intimate and the expansive: some works favour chamber-scaled delicacy,
+    others build toward cinematic sweep through careful orchestral accumulation. Her
+    compositions integrate electronics without privileging them — synthesiser textures
+    and treated instrumental sounds are woven into orchestral contexts rather than
+    foregrounded as novelty, creating hybrids that feel neither purely acoustic nor
+    wholly synthetic. Harmonically, the writing gravitates toward late-Romantic warmth,
+    with a tendency to dwell in chromatic transition rather than resolving quickly
+    toward tonal centres. Thematic affect is predominantly introspective and elegiac
+    — imagery suggests interiority, the passage of time, and the emotional weight
+    of memory. The emotional register is tender and quietly sorrowful, evoking yearning
+    and bittersweet reflection without sentimentality.'
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4502
+      present: 0.2459
+      future: 0.304
+    spatial:
+      thing: 0.4513
+      place: 0.3036
+      person: 0.2451
+    ontological:
+      imagined: 0.3536
+      forgotten: 0.2888
+      known: 0.3576
+    confidence: 0.0327
   discogs_id: 562800
   notes: Unknown artist — fill description manually
 Timesbold:
   slug: timesbold
   status: draft
-  description: Timesbold work within an Americana framework darkened by literary sensibility and orchestral weight. Acoustic
-    guitar and piano anchor song structures that move slowly, carrying the rhetorical gravity of folk balladry without its
-    communal lightness. String arrangements arrive not as embellishment but as emotional infrastructure — swelling beneath
-    verses to reinforce a sense of consequence and weight. Vocals are central, delivered with restraint and precision that
-    recall country's confessional directness while carrying the fatalism of existentialist drama. Production is measured and
-    deliberate, favouring dynamics — tension built through space as much as sound. Lyrically, themes circle mortality, failure,
-    endurance, and the stubborn dignity of lives lived under pressure — imagery drawn from the American interior, rendered
-    with an oblique, literary quality that favours implication over statement. The emotional register is stoic and sorrowful
-    simultaneously — hard-edged rather than sentimental, evoking grief that has been lived with long enough to become something
-    like acceptance.
+  description: Timesbold work within an Americana framework darkened by literary sensibility
+    and orchestral weight. Acoustic guitar and piano anchor song structures that move
+    slowly, carrying the rhetorical gravity of folk balladry without its communal
+    lightness. String arrangements arrive not as embellishment but as emotional infrastructure
+    — swelling beneath verses to reinforce a sense of consequence and weight. Vocals
+    are central, delivered with restraint and precision that recall country's confessional
+    directness while carrying the fatalism of existentialist drama. Production is
+    measured and deliberate, favouring dynamics — tension built through space as much
+    as sound. Lyrically, themes circle mortality, failure, endurance, and the stubborn
+    dignity of lives lived under pressure — imagery drawn from the American interior,
+    rendered with an oblique, literary quality that favours implication over statement.
+    The emotional register is stoic and sorrowful simultaneously — hard-edged rather
+    than sentimental, evoking grief that has been lived with long enough to become
+    something like acceptance.
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4424
+      present: 0.2493
+      future: 0.3083
+    spatial:
+      thing: 0.4432
+      place: 0.3081
+      person: 0.2488
+    ontological:
+      imagined: 0.355
+      forgotten: 0.2899
+      known: 0.3551
+    confidence: 0.0307
   discogs_id: 319016
   notes: Unknown artist — fill description manually
 The Paper Kites:
   slug: the_paper_kites
   status: draft
-  description: 'The Paper Kites craft intimate, folk-inflected indie music built around sparse acoustic arrangements — fingerpicked
-    guitar, gentle percussion, and subtle atmospheric ornamentation including pedal steel, light strings, and understated
-    reverb. Production favours warmth and restraint, preserving a close, bedroom-adjacent texture that feels unpolished yet
-    deliberate. Vocals are central, delivered softly with a hushed, conversational quality; harmonies layer delicately without
-    crowding the mix. Lyrically, the work explores quiet domesticity, romantic longing, seasonal melancholy, and the passage
-    of time, drawing imagery from nature, light, and interior emotional states. Themes tend toward introspection and tender
-    vulnerability rather than dramatic conflict. The emotional register is consistently subdued — melancholic yet gentle,
-    evoking stillness, nostalgia, and a kind of bittersweet contentment. The overall palette is cool and muted, prioritising
-    spaciousness and emotional understatement over dynamic contrast or sonic density.
+  description: 'The Paper Kites craft intimate, folk-inflected indie music built around
+    sparse acoustic arrangements — fingerpicked guitar, gentle percussion, and subtle
+    atmospheric ornamentation including pedal steel, light strings, and understated
+    reverb. Production favours warmth and restraint, preserving a close, bedroom-adjacent
+    texture that feels unpolished yet deliberate. Vocals are central, delivered softly
+    with a hushed, conversational quality; harmonies layer delicately without crowding
+    the mix. Lyrically, the work explores quiet domesticity, romantic longing, seasonal
+    melancholy, and the passage of time, drawing imagery from nature, light, and interior
+    emotional states. Themes tend toward introspection and tender vulnerability rather
+    than dramatic conflict. The emotional register is consistently subdued — melancholic
+    yet gentle, evoking stillness, nostalgia, and a kind of bittersweet contentment.
+    The overall palette is cool and muted, prioritising spaciousness and emotional
+    understatement over dynamic contrast or sonic density.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4284
+      present: 0.2589
+      future: 0.3127
+    spatial:
+      thing: 0.4292
+      place: 0.3124
+      person: 0.2585
+    ontological:
+      imagined: 0.3466
+      forgotten: 0.2966
+      known: 0.3567
+    confidence: 0.0239
   discogs_id: 3456024
   notes: ''
 Sufjan Stevens:
   slug: sufjan_stevens
   status: draft
-  description: 'Sufjan Stevens works primarily as a vocalist, weaving intimate, confessional tenor voice through densely layered
-    arrangements. Production blends acoustic folk instrumentation — banjo, acoustic guitar, strings, woodwinds — with electronic
-    textures, synthesizers, and meticulous studio ornamentation, creating a warm yet intricate sonic density. Quieter passages
-    feel chamber-like and delicate; larger arrangements swell into orchestral or electronic grandeur without losing intimacy.
+  description: 'Sufjan Stevens works primarily as a vocalist, weaving intimate, confessional
+    tenor voice through densely layered arrangements. Production blends acoustic folk
+    instrumentation — banjo, acoustic guitar, strings, woodwinds — with electronic
+    textures, synthesizers, and meticulous studio ornamentation, creating a warm yet
+    intricate sonic density. Quieter passages feel chamber-like and delicate; larger
+    arrangements swell into orchestral or electronic grandeur without losing intimacy.
 
 
-    Lyrically, his work explores grief, mortality, faith, doubt, domestic memory, and spiritual longing, often grounding transcendent
-    or theological themes in precise, sensory, everyday imagery. Sacred and secular coexist uneasily, with religious vocabulary
-    filtered through deeply personal emotional experience.
+    Lyrically, his work explores grief, mortality, faith, doubt, domestic memory,
+    and spiritual longing, often grounding transcendent or theological themes in precise,
+    sensory, everyday imagery. Sacred and secular coexist uneasily, with religious
+    vocabulary filtered through deeply personal emotional experience.
 
 
-    The emotional register is characteristically tender, mournful, and quietly ecstatic — psychologically interior and contemplative,
-    sometimes carrying an ache of unresolved longing. Tonal colour moves between fragile vulnerability and restrained rapture,
+    The emotional register is characteristically tender, mournful, and quietly ecstatic
+    — psychologically interior and contemplative, sometimes carrying an ache of unresolved
+    longing. Tonal colour moves between fragile vulnerability and restrained rapture,
     rarely fully resolving into either despair or consolation.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4148
+      present: 0.2698
+      future: 0.3154
+    spatial:
+      thing: 0.4156
+      place: 0.3151
+      person: 0.2693
+    ontological:
+      imagined: 0.3426
+      forgotten: 0.3029
+      known: 0.3546
+    confidence: 0.0166
   discogs_id: 202598
   notes: ''
 George Harrison:
   slug: george_harrison
   status: draft
-  description: 'George Harrison''s work is primarily vocal, blending melodic rock with Eastern-influenced textures — sitar,
-    slide guitar, and tamboura layered over dense studio arrangements that fuse Western and Indian classical sensibilities.
-    His production character tends toward warmth and spaciousness, with deliberate timbral contrast between acoustic and electric
-    elements. Lyrically, his work gravitates toward spiritual seeking, devotional contemplation, and the tension between material
-    attachment and transcendence, often drawing on Vedic philosophy filtered through personal introspection. Imagery tends
-    toward the universal and the ineffable — light, surrender, inner stillness, and the dissolution of ego. The emotional
-    register is quietly earnest, reflective, and inward-facing, carrying an undertow of longing balanced by acceptance. Even
-    within ensemble contexts his voice maintains an intimate, almost confessional quality, and his guitar work — particularly
-    slide — functions as an emotional extension of lyrical themes, sustained and searching in tone.
+  description: 'George Harrison''s work is primarily vocal, blending melodic rock
+    with Eastern-influenced textures — sitar, slide guitar, and tamboura layered over
+    dense studio arrangements that fuse Western and Indian classical sensibilities.
+    His production character tends toward warmth and spaciousness, with deliberate
+    timbral contrast between acoustic and electric elements. Lyrically, his work gravitates
+    toward spiritual seeking, devotional contemplation, and the tension between material
+    attachment and transcendence, often drawing on Vedic philosophy filtered through
+    personal introspection. Imagery tends toward the universal and the ineffable —
+    light, surrender, inner stillness, and the dissolution of ego. The emotional register
+    is quietly earnest, reflective, and inward-facing, carrying an undertow of longing
+    balanced by acceptance. Even within ensemble contexts his voice maintains an intimate,
+    almost confessional quality, and his guitar work — particularly slide — functions
+    as an emotional extension of lyrical themes, sustained and searching in tone.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4239
+      present: 0.2611
+      future: 0.315
+    spatial:
+      thing: 0.4251
+      place: 0.3143
+      person: 0.2606
+    ontological:
+      imagined: 0.3491
+      forgotten: 0.2994
+      known: 0.3515
+    confidence: 0.0232
   discogs_id: 243955
   notes: ''
 Julio Iglesias:
   slug: julio_iglesias
   status: draft
-  description: 'Julio Iglesias is a vocal artist whose sound centers on a warm, smooth baritone voice placed forward in a
-    lush, orchestrated mix. Production leans toward romantic ballad arrangements featuring strings, subtle brass, nylon-string
-    guitar, and soft percussion, creating a dense yet silky texture. The studio approach prioritizes vocal intimacy, often
-    bathed in gentle reverb. Thematically, lyrics circle around romantic longing, passionate love, nostalgic yearning, and
-    tender devotion, frequently drawing on imagery of night, the sea, and emotional vulnerability. The tone remains consistently
-    earnest and deeply personal, avoiding irony or detachment. Emotionally, the register is warmly melancholic yet sensuous
-    — tenderness tinged with bittersweet ache and sometimes celebratory passion. Multilingual delivery across Spanish, French,
-    Italian, English, and Portuguese adds a cosmopolitan, universally romantic quality to the overall artistic palette.
+  description: 'Julio Iglesias is a vocal artist whose sound centers on a warm, smooth
+    baritone voice placed forward in a lush, orchestrated mix. Production leans toward
+    romantic ballad arrangements featuring strings, subtle brass, nylon-string guitar,
+    and soft percussion, creating a dense yet silky texture. The studio approach prioritizes
+    vocal intimacy, often bathed in gentle reverb. Thematically, lyrics circle around
+    romantic longing, passionate love, nostalgic yearning, and tender devotion, frequently
+    drawing on imagery of night, the sea, and emotional vulnerability. The tone remains
+    consistently earnest and deeply personal, avoiding irony or detachment. Emotionally,
+    the register is warmly melancholic yet sensuous — tenderness tinged with bittersweet
+    ache and sometimes celebratory passion. Multilingual delivery across Spanish,
+    French, Italian, English, and Portuguese adds a cosmopolitan, universally romantic
+    quality to the overall artistic palette.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4064
+      present: 0.2745
+      future: 0.3191
+    spatial:
+      thing: 0.4072
+      place: 0.319
+      person: 0.2738
+    ontological:
+      imagined: 0.34
+      forgotten: 0.3078
+      known: 0.3522
+    confidence: 0.0138
   discogs_id: 67331
   notes: ''
 The Band:
   slug: the_band
   status: draft
-  description: 'The Band occupies a rootsy, weathered sonic terrain where acoustic and electric instruments interweave with
-    organic warmth — piano, organ, mandolin, drums, and guitar blending into a dense but breathable ensemble texture. Production
-    favors an lived-in, slightly rough-hewn quality, avoiding sterile polish in favor of room ambience and natural resonance.
-    Vocals rotate among multiple singers, each carrying a distinctly rough, soulful character, lending a communal, weathered
-    humanity to the sound. Lyrically, themes circle around rural Americana, displacement, memory, labour, myth, and the weight
-    of history — imagery drawn from rivers, fields, small towns, and fading ways of life. The emotional register is nostalgic
-    without sentimentality, tinged with melancholy, perseverance, and quiet dignity. Songs carry a sense of dusty, lived experience
-    — emotionally grounded rather than theatrical — occupying space between sorrow, resilience, and communal belonging.
+  description: 'The Band occupies a rootsy, weathered sonic terrain where acoustic
+    and electric instruments interweave with organic warmth — piano, organ, mandolin,
+    drums, and guitar blending into a dense but breathable ensemble texture. Production
+    favors an lived-in, slightly rough-hewn quality, avoiding sterile polish in favor
+    of room ambience and natural resonance. Vocals rotate among multiple singers,
+    each carrying a distinctly rough, soulful character, lending a communal, weathered
+    humanity to the sound. Lyrically, themes circle around rural Americana, displacement,
+    memory, labour, myth, and the weight of history — imagery drawn from rivers, fields,
+    small towns, and fading ways of life. The emotional register is nostalgic without
+    sentimentality, tinged with melancholy, perseverance, and quiet dignity. Songs
+    carry a sense of dusty, lived experience — emotionally grounded rather than theatrical
+    — occupying space between sorrow, resilience, and communal belonging.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4041
+      present: 0.2728
+      future: 0.3231
+    spatial:
+      thing: 0.4049
+      place: 0.3226
+      person: 0.2725
+    ontological:
+      imagined: 0.3333
+      forgotten: 0.3124
+      known: 0.3543
+    confidence: 0.0173
   discogs_id: 254199
   notes: ''
 Small Faces:
   slug: small_faces
   status: draft
-  description: 'Small Faces occupy a dense, warmly saturated sonic world rooted in rhythm and blues but shot through with
-    psychedelic colour. Production tends toward a compressed, punchy intimacy — close-miked vocals, driving Hammond organ,
-    thick rhythm guitar, and a crisp, propulsive rhythm section. Studio textures range from raw, swaggering mod energy to
-    layered, orchestrated dreamscapes with tape effects and music-hall whimsy. Lyrically, themes circle around working-class
-    London life, romantic longing, street-level escapism, pleasure-seeking, and occasional surrealist fantasy. Imagery blends
-    the mundane and the fanciful, delivered with cockney directness and occasional gentle melancholy. The emotional register
-    shifts between bright, brash exuberance and wistful introspection, sometimes within a single track. The approach is fundamentally
-    vocal-led, with lead and harmony singing central to the identity, though instrumental interplay — particularly organ and
-    guitar conversation — carries significant expressive weight.
+  description: 'Small Faces occupy a dense, warmly saturated sonic world rooted in
+    rhythm and blues but shot through with psychedelic colour. Production tends toward
+    a compressed, punchy intimacy — close-miked vocals, driving Hammond organ, thick
+    rhythm guitar, and a crisp, propulsive rhythm section. Studio textures range from
+    raw, swaggering mod energy to layered, orchestrated dreamscapes with tape effects
+    and music-hall whimsy. Lyrically, themes circle around working-class London life,
+    romantic longing, street-level escapism, pleasure-seeking, and occasional surrealist
+    fantasy. Imagery blends the mundane and the fanciful, delivered with cockney directness
+    and occasional gentle melancholy. The emotional register shifts between bright,
+    brash exuberance and wistful introspection, sometimes within a single track. The
+    approach is fundamentally vocal-led, with lead and harmony singing central to
+    the identity, though instrumental interplay — particularly organ and guitar conversation
+    — carries significant expressive weight.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4524
+      present: 0.2457
+      future: 0.3019
+    spatial:
+      thing: 0.4535
+      place: 0.3015
+      person: 0.2449
+    ontological:
+      imagined: 0.3575
+      forgotten: 0.2846
+      known: 0.3579
+    confidence: 0.0294
   discogs_id: 152682
   notes: ''
 The Waterboys:
   slug: the_waterboys
   status: draft
-  description: 'The Waterboys blend expansive, layered sonic textures — electric and acoustic guitars interweaving with violin,
-    saxophone, keyboards, and mandolin — producing a sound that oscillates between intimate folk simplicity and surging rock
-    density. Production approaches range from sparse, candlelit arrangements to cathedral-scale walls of sound. Lyrically,
-    imagery draws heavily from Celtic mythology, mysticism, spiritual seeking, rivers, wild landscapes, and transcendence,
-    rendered in a prophetic, visionary tone with strong romantic and elemental currents. Thematically, the work circles around
-    longing, divine encounter, rootedness in land, and the tension between worldly life and spiritual aspiration. The emotional
-    register shifts between ecstatic uplift, aching melancholy, and reverent wonder — frequently occupying a luminous, searching
-    psychological space. The project is primarily vocal-driven, with Mike Scott''s impassioned, declaratory voice functioning
+  description: 'The Waterboys blend expansive, layered sonic textures — electric and
+    acoustic guitars interweaving with violin, saxophone, keyboards, and mandolin
+    — producing a sound that oscillates between intimate folk simplicity and surging
+    rock density. Production approaches range from sparse, candlelit arrangements
+    to cathedral-scale walls of sound. Lyrically, imagery draws heavily from Celtic
+    mythology, mysticism, spiritual seeking, rivers, wild landscapes, and transcendence,
+    rendered in a prophetic, visionary tone with strong romantic and elemental currents.
+    Thematically, the work circles around longing, divine encounter, rootedness in
+    land, and the tension between worldly life and spiritual aspiration. The emotional
+    register shifts between ecstatic uplift, aching melancholy, and reverent wonder
+    — frequently occupying a luminous, searching psychological space. The project
+    is primarily vocal-driven, with Mike Scott''s impassioned, declaratory voice functioning
     as the central expressive instrument throughout.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.412
+      present: 0.2693
+      future: 0.3187
+    spatial:
+      thing: 0.4128
+      place: 0.3182
+      person: 0.2689
+    ontological:
+      imagined: 0.3412
+      forgotten: 0.3053
+      known: 0.3536
+    confidence: 0.0179
   discogs_id: 125174
   notes: ''
 John's Children:
   slug: john_s_children
   status: draft
-  description: 'John''s Children occupy a sonic space of frenzied, maximalist garage-rock energy, driven by abrasive, trebly
-    guitar textures layered over pounding, almost tribal percussion. Production tends toward raw density — distorted, chaotic,
-    with little separation between elements, creating a deliberately overwhelming wall of sound. Vocals are central, delivered
-    with theatrical urgency and adolescent hysteria rather than conventional melodic polish. Lyrically, themes orbit youthful
-    desire, transgression, emotional desperation, and a kind of confrontational innocence — imagery tends toward the visceral
-    and immediate, with a charged, slightly surreal edge. The emotional register is hyperactive and unstable, oscillating
-    between euphoria and aggression, evoking teenage restlessness pushed to an almost absurdist extreme. The overall affect
-    is provocative and feverish, prioritising intensity over refinement, with a deliberately primitive sonic palette that
-    underscores the psychological urgency running through the material.
+  description: 'John''s Children occupy a sonic space of frenzied, maximalist garage-rock
+    energy, driven by abrasive, trebly guitar textures layered over pounding, almost
+    tribal percussion. Production tends toward raw density — distorted, chaotic, with
+    little separation between elements, creating a deliberately overwhelming wall
+    of sound. Vocals are central, delivered with theatrical urgency and adolescent
+    hysteria rather than conventional melodic polish. Lyrically, themes orbit youthful
+    desire, transgression, emotional desperation, and a kind of confrontational innocence
+    — imagery tends toward the visceral and immediate, with a charged, slightly surreal
+    edge. The emotional register is hyperactive and unstable, oscillating between
+    euphoria and aggression, evoking teenage restlessness pushed to an almost absurdist
+    extreme. The overall affect is provocative and feverish, prioritising intensity
+    over refinement, with a deliberately primitive sonic palette that underscores
+    the psychological urgency running through the material.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4165
+      present: 0.2656
+      future: 0.3179
+    spatial:
+      thing: 0.4174
+      place: 0.3174
+      person: 0.2652
+    ontological:
+      imagined: 0.3511
+      forgotten: 0.3021
+      known: 0.3468
+    confidence: 0.0218
   discogs_id: 377038
   notes: ''
 The Mountain Goats:
   slug: the_mountain_goats
   status: draft
-  description: 'The Mountain Goats center on John Darnielle''s expressive tenor vocal, positioned intimately within spare,
-    often lo-fi arrangements. Early recordings favor raw acoustic guitar and cassette-hiss warmth; later work incorporates
-    piano, strings, and fuller band production while retaining a confessional closeness. Lyrically, the writing orbits domestic
-    conflict, addiction, survival, mythology, subcultures, and faith—rendered through precise, literary imagery drawn from
-    everyday objects, geography, and arcane reference. Narratives frequently inhabit damaged or marginalized perspectives,
-    approaching catastrophe with dark irony and unexpected tenderness. The emotional register oscillates between desperation
-    and defiant resilience, often simultaneously, producing a psychological tension that feels both intimate and universally
-    legible. Melodic structures tend toward folk and indie rock simplicity, serving lyrical density rather than sonic complexity.
-    The overall texture prioritizes emotional transparency over production gloss, regardless of recording era.
+  description: 'The Mountain Goats center on John Darnielle''s expressive tenor vocal,
+    positioned intimately within spare, often lo-fi arrangements. Early recordings
+    favor raw acoustic guitar and cassette-hiss warmth; later work incorporates piano,
+    strings, and fuller band production while retaining a confessional closeness.
+    Lyrically, the writing orbits domestic conflict, addiction, survival, mythology,
+    subcultures, and faith—rendered through precise, literary imagery drawn from everyday
+    objects, geography, and arcane reference. Narratives frequently inhabit damaged
+    or marginalized perspectives, approaching catastrophe with dark irony and unexpected
+    tenderness. The emotional register oscillates between desperation and defiant
+    resilience, often simultaneously, producing a psychological tension that feels
+    both intimate and universally legible. Melodic structures tend toward folk and
+    indie rock simplicity, serving lyrical density rather than sonic complexity. The
+    overall texture prioritizes emotional transparency over production gloss, regardless
+    of recording era.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4402
+      present: 0.2511
+      future: 0.3086
+    spatial:
+      thing: 0.4411
+      place: 0.3083
+      person: 0.2506
+    ontological:
+      imagined: 0.353
+      forgotten: 0.2918
+      known: 0.3552
+    confidence: 0.0291
   discogs_id: 95417
   notes: ''
 The Pogues:
   slug: the_pogues
   status: draft
-  description: 'The Pogues blend raw, abrasive folk instrumentation — tin whistle, accordion, banjo, mandolin, upright bass
-    — with punk-inflected energy, creating a dense, rough-edged sonic texture marked by aggressive tempos and loose, live-feeling
-    production. Arrangements oscillate between raucous, full-ensemble chaos and stripped, intimate balladry. Vocals are central:
-    delivered in a gravelled, emotionally unguarded style that prioritises expression over technical polish. Lyrically, themes
-    orbit displacement, exile, urban poverty, alcohol, longing, mortality, and romanticised suffering, often filtered through
-    Irish diaspora imagery — harbours, emigrant ships, tenement streets, whiskey, and distant homelands. The emotional register
-    is simultaneously celebratory and deeply melancholic, capturing a defiant, bittersweet affect — joy and grief coexisting
-    without resolution. A persistent undercurrent of dark romanticism and fatalism runs through both uptempo and slow material,
+  description: 'The Pogues blend raw, abrasive folk instrumentation — tin whistle,
+    accordion, banjo, mandolin, upright bass — with punk-inflected energy, creating
+    a dense, rough-edged sonic texture marked by aggressive tempos and loose, live-feeling
+    production. Arrangements oscillate between raucous, full-ensemble chaos and stripped,
+    intimate balladry. Vocals are central: delivered in a gravelled, emotionally unguarded
+    style that prioritises expression over technical polish. Lyrically, themes orbit
+    displacement, exile, urban poverty, alcohol, longing, mortality, and romanticised
+    suffering, often filtered through Irish diaspora imagery — harbours, emigrant
+    ships, tenement streets, whiskey, and distant homelands. The emotional register
+    is simultaneously celebratory and deeply melancholic, capturing a defiant, bittersweet
+    affect — joy and grief coexisting without resolution. A persistent undercurrent
+    of dark romanticism and fatalism runs through both uptempo and slow material,
     giving even playful pieces a bruised psychological undertone.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.428
+      present: 0.2596
+      future: 0.3124
+    spatial:
+      thing: 0.4291
+      place: 0.3117
+      person: 0.2592
+    ontological:
+      imagined: 0.3503
+      forgotten: 0.2965
+      known: 0.3532
+    confidence: 0.0283
   discogs_id: 253234
   notes: ''
 Lambchop:
   slug: lambchop
   status: draft
-  description: 'Lambchop operates in a richly layered sonic world where chamber arrangements — strings, horns, pedal steel,
-    and subtle percussion — drift beneath Kurt Wagner''s soft, processed baritone, increasingly filtered through Auto-Tune
-    as an expressive rather than corrective tool. Production is warm, unhurried, and intimate, favoring textural density built
-    from gentle accumulation rather than momentum. The band is fundamentally vocal-led, though instrumentation often carries
-    equal emotional weight. Lyrically, imagery tends toward the domestic, mundane, and quietly surreal — everyday observations
-    rendered strange through oblique angles and deliberate understatement. Thematic concerns circle mortality, memory, displacement,
-    and tenderness. The emotional register is muted yet deeply felt: melancholic without melodrama, contemplative and occasionally
-    darkly wry. There is a persistent sense of unresolved longing, as though the music exists in a perpetual late-evening
+  description: 'Lambchop operates in a richly layered sonic world where chamber arrangements
+    — strings, horns, pedal steel, and subtle percussion — drift beneath Kurt Wagner''s
+    soft, processed baritone, increasingly filtered through Auto-Tune as an expressive
+    rather than corrective tool. Production is warm, unhurried, and intimate, favoring
+    textural density built from gentle accumulation rather than momentum. The band
+    is fundamentally vocal-led, though instrumentation often carries equal emotional
+    weight. Lyrically, imagery tends toward the domestic, mundane, and quietly surreal
+    — everyday observations rendered strange through oblique angles and deliberate
+    understatement. Thematic concerns circle mortality, memory, displacement, and
+    tenderness. The emotional register is muted yet deeply felt: melancholic without
+    melodrama, contemplative and occasionally darkly wry. There is a persistent sense
+    of unresolved longing, as though the music exists in a perpetual late-evening
     state — reflective, soft-lit, and emotionally ambiguous.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.431
+      present: 0.2587
+      future: 0.3102
+    spatial:
+      thing: 0.4322
+      place: 0.3098
+      person: 0.258
+    ontological:
+      imagined: 0.351
+      forgotten: 0.2945
+      known: 0.3545
+    confidence: 0.0344
   discogs_id: 10551
   notes: ''
 The Monks:
   slug: the_monks
   status: draft
-  description: 'The Monks were a primarily vocal-driven group, with raw, abrasive sound textures built on minimal, repetitive
-    instrumentation — fuzz-drenched guitar, pounding drums, and deliberately primitive organ tones creating a dense, confrontational
-    sonic mass. Production was stripped, lo-fi by design, favouring aggression over polish, with a hammering rhythmic insistence
-    that bordered on ritual.
+  description: 'The Monks were a primarily vocal-driven group, with raw, abrasive
+    sound textures built on minimal, repetitive instrumentation — fuzz-drenched guitar,
+    pounding drums, and deliberately primitive organ tones creating a dense, confrontational
+    sonic mass. Production was stripped, lo-fi by design, favouring aggression over
+    polish, with a hammering rhythmic insistence that bordered on ritual.
 
 
-    Lyrically, themes circled obsessively around war, violence, political authority, complicity, and psychological alienation
-    — imagery was blunt, declarative, and destabilizing, delivered with a hectoring, provocative tone that demanded response
+    Lyrically, themes circled obsessively around war, violence, political authority,
+    complicity, and psychological alienation — imagery was blunt, declarative, and
+    destabilizing, delivered with a hectoring, provocative tone that demanded response
     rather than passive listening. Language was weaponized for repetition and disorientation.
 
 
-    Emotionally, the register was relentlessly tense, aggressive, and claustrophobic — evoking paranoia, frustration, and
-    collective unease. There was a confrontational theatricality to the affect, combining nihilistic despair with sardonic
-    provocation. The overall psychological colour was deeply unsettled, ritualistic, and deliberately hostile to comfort.
+    Emotionally, the register was relentlessly tense, aggressive, and claustrophobic
+    — evoking paranoia, frustration, and collective unease. There was a confrontational
+    theatricality to the affect, combining nihilistic despair with sardonic provocation.
+    The overall psychological colour was deeply unsettled, ritualistic, and deliberately
+    hostile to comfort.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4006
+      present: 0.2739
+      future: 0.3256
+    spatial:
+      thing: 0.4013
+      place: 0.3252
+      person: 0.2735
+    ontological:
+      imagined: 0.334
+      forgotten: 0.3147
+      known: 0.3512
+    confidence: 0.014
   discogs_id: 153804
   notes: ''
 Tomorrow (2):
   slug: tomorrow_2
   status: draft
-  description: 'Tomorrow (2) was a psychedelic rock band whose sound blended swirling, reverb-drenched guitars, organ, and
-    a rhythm section that alternated between driving and languid grooves. Production favored a dense, immersive quality, with
-    layered instrumentation creating a kaleidoscopic sonic texture. Vocals were central, delivered with a dreamy, detached
-    quality that complemented the music''s trippy atmosphere. Lyrically, themes circled around surrealism, romantic longing,
-    and existential musings — imagery was often abstract and impressionistic, evoking a sense of disorientation and wonder.
-    The emotional register shifted between euphoric highs and melancholic introspection, capturing the duality of psychedelic
-    experience. The overall affect was one of hazy enchantment tinged with an undercurrent of unease.
+  description: 'Tomorrow (2) was a psychedelic rock band whose sound blended swirling,
+    reverb-drenched guitars, organ, and a rhythm section that alternated between driving
+    and languid grooves. Production favored a dense, immersive quality, with layered
+    instrumentation creating a kaleidoscopic sonic texture. Vocals were central, delivered
+    with a dreamy, detached quality that complemented the music''s trippy atmosphere.
+    Lyrically, themes circled around surrealism, romantic longing, and existential
+    musings — imagery was often abstract and impressionistic, evoking a sense of disorientation
+    and wonder. The emotional register shifted between euphoric highs and melancholic
+    introspection, capturing the duality of psychedelic experience. The overall affect
+    was one of hazy enchantment tinged with an undercurrent of unease.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4513
+      present: 0.2494
+      future: 0.2993
+    spatial:
+      thing: 0.4524
+      place: 0.2989
+      person: 0.2487
+    ontological:
+      imagined: 0.3595
+      forgotten: 0.2797
+      known: 0.3608
+    confidence: 0.0552
   discogs_id: 283141
   notes: Unknown artist — fill description manually
 Bobb Trimble:
   slug: bobb_trimble
   status: draft
-  description: 'Bobb Trimble crafts lo-fi psychedelic folk with a distinctly homespun, cassette-warped production aesthetic.
-    His sonic texture is intimate and slightly degraded — thin reverb trails, softly distorted edges, layered acoustic and
-    electric guitar figures hovering in murky stereo fields. The density is sparse yet dreamlike, with melodic fragments drifting
-    through haze rather than anchoring themselves firmly. He is primarily a vocal artist, delivering lyrics in a plaintive,
-    breathy tenor that blurs vulnerability with detachment. Thematically, his writing circles around interior landscapes,
-    childhood innocence fractured by unease, cosmic longing, and a sense of domestic strangeness — familiar imagery rendered
-    subtly uncanny. The emotional register is melancholic and dissociative, hovering between reverie and anxiety, with an
-    underlying tenderness that prevents the mood from collapsing entirely into darkness. The overall affect suggests private
-    ritual rather than public performance.
+  description: 'Bobb Trimble crafts lo-fi psychedelic folk with a distinctly homespun,
+    cassette-warped production aesthetic. His sonic texture is intimate and slightly
+    degraded — thin reverb trails, softly distorted edges, layered acoustic and electric
+    guitar figures hovering in murky stereo fields. The density is sparse yet dreamlike,
+    with melodic fragments drifting through haze rather than anchoring themselves
+    firmly. He is primarily a vocal artist, delivering lyrics in a plaintive, breathy
+    tenor that blurs vulnerability with detachment. Thematically, his writing circles
+    around interior landscapes, childhood innocence fractured by unease, cosmic longing,
+    and a sense of domestic strangeness — familiar imagery rendered subtly uncanny.
+    The emotional register is melancholic and dissociative, hovering between reverie
+    and anxiety, with an underlying tenderness that prevents the mood from collapsing
+    entirely into darkness. The overall affect suggests private ritual rather than
+    public performance.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4493
+      present: 0.246
+      future: 0.3046
+    spatial:
+      thing: 0.4503
+      place: 0.3044
+      person: 0.2453
+    ontological:
+      imagined: 0.3507
+      forgotten: 0.2875
+      known: 0.3618
+    confidence: 0.0459
   discogs_id: 920076
   notes: ''
 The Zombies:
   slug: the_zombies
   status: draft
-  description: 'The Zombies blend intimate vocal harmonies with a cool, chamber-like sonic texture, favouring sparse arrangements
-    that allow keyboards — particularly electric piano and organ — to breathe alongside understated rhythm sections. Production
-    carries a polished yet organic quality, with layered vocals treated almost orchestrally. Lyrically, their work gravitates
-    toward romantic longing, emotional ambiguity, and introspective melancholy, rendered through gentle, literary imagery
-    without sentimentality. Themes frequently circle alienation softened by tenderness, and the passage of fleeting emotional
-    states. The emotional register is consistently bittersweet — wistful rather than despairing, restrained rather than euphoric,
-    occupying a psychologically complex space between yearning and resignation. The band is primarily vocal in orientation,
-    with Rod Argent''s keyboard writing serving as the principal melodic voice beneath layered ensemble singing, giving their
+  description: 'The Zombies blend intimate vocal harmonies with a cool, chamber-like
+    sonic texture, favouring sparse arrangements that allow keyboards — particularly
+    electric piano and organ — to breathe alongside understated rhythm sections. Production
+    carries a polished yet organic quality, with layered vocals treated almost orchestrally.
+    Lyrically, their work gravitates toward romantic longing, emotional ambiguity,
+    and introspective melancholy, rendered through gentle, literary imagery without
+    sentimentality. Themes frequently circle alienation softened by tenderness, and
+    the passage of fleeting emotional states. The emotional register is consistently
+    bittersweet — wistful rather than despairing, restrained rather than euphoric,
+    occupying a psychologically complex space between yearning and resignation. The
+    band is primarily vocal in orientation, with Rod Argent''s keyboard writing serving
+    as the principal melodic voice beneath layered ensemble singing, giving their
     sound an almost choral intimacy set within pop structure.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4382
+      present: 0.2533
+      future: 0.3085
+    spatial:
+      thing: 0.4391
+      place: 0.3084
+      person: 0.2525
+    ontological:
+      imagined: 0.3564
+      forgotten: 0.2904
+      known: 0.3532
+    confidence: 0.0269
   discogs_id: 262221
   notes: ''
 Chris Gantry:
   slug: chris_gantry
   status: draft
-  description: A visionary folk and country songwriter whose work blends traditional Americana with a psychedelic, often surreal
-    sensibility. His sonic palette ranges from sparse acoustic arrangements to fuller, more atmospheric productions that incorporate
-    electric guitar, organ, and subtle studio effects. Lyrically, Gantry's writing is marked by vivid, sometimes cryptic imagery
-    that explores themes of love, loss, existential longing, and the darker undercurrents of human experience. The emotional
-    register is deeply introspective and melancholic, often tinged with a sense of yearning and unresolved tension. His vocal
-    delivery is intimate and expressive, conveying a raw vulnerability that draws listeners into his unique narrative world.
+  description: A visionary folk and country songwriter whose work blends traditional
+    Americana with a psychedelic, often surreal sensibility. His sonic palette ranges
+    from sparse acoustic arrangements to fuller, more atmospheric productions that
+    incorporate electric guitar, organ, and subtle studio effects. Lyrically, Gantry's
+    writing is marked by vivid, sometimes cryptic imagery that explores themes of
+    love, loss, existential longing, and the darker undercurrents of human experience.
+    The emotional register is deeply introspective and melancholic, often tinged with
+    a sense of yearning and unresolved tension. His vocal delivery is intimate and
+    expressive, conveying a raw vulnerability that draws listeners into his unique
+    narrative world.
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.415
+      present: 0.2698
+      future: 0.3152
+    spatial:
+      thing: 0.4162
+      place: 0.3145
+      person: 0.2693
+    ontological:
+      imagined: 0.3524
+      forgotten: 0.2988
+      known: 0.3488
+    confidence: 0.0343
   discogs_id: 990239
   notes: Unknown artist — fill description manually
 10cc:
   slug: 10cc
   status: draft
-  description: '10cc blend meticulous studio craftsmanship with a layered, often sardonic sensibility. Their sonic palette
-    ranges from lush, multi-tracked vocal harmonies to angular, dry rock instrumentation, frequently incorporating pastiches
-    of other genres — music hall, doo-wop, balladry — woven into a densely arranged whole. Production is precise and self-conscious,
-    treating the studio itself as a compositional tool, with deliberate sonic juxtapositions and ironic tonal shifts. Lyrically,
-    themes circle around romantic dysfunction, social observation, and theatrical self-awareness, employing deadpan wit alongside
-    moments of genuine pathos. Imagery tends toward the mundane rendered absurd, or the sentimental undercut by detachment.
-    Emotionally, the register oscillates between cool irony and unexpected vulnerability, creating a psychological ambiguity
-    — earnestness masked by artifice or vice versa. Vocals are central and expressive, with complex harmony arrangements forming
-    a primary textural signature.
+  description: '10cc blend meticulous studio craftsmanship with a layered, often sardonic
+    sensibility. Their sonic palette ranges from lush, multi-tracked vocal harmonies
+    to angular, dry rock instrumentation, frequently incorporating pastiches of other
+    genres — music hall, doo-wop, balladry — woven into a densely arranged whole.
+    Production is precise and self-conscious, treating the studio itself as a compositional
+    tool, with deliberate sonic juxtapositions and ironic tonal shifts. Lyrically,
+    themes circle around romantic dysfunction, social observation, and theatrical
+    self-awareness, employing deadpan wit alongside moments of genuine pathos. Imagery
+    tends toward the mundane rendered absurd, or the sentimental undercut by detachment.
+    Emotionally, the register oscillates between cool irony and unexpected vulnerability,
+    creating a psychological ambiguity — earnestness masked by artifice or vice versa.
+    Vocals are central and expressive, with complex harmony arrangements forming a
+    primary textural signature.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4594
+      present: 0.2423
+      future: 0.2983
+    spatial:
+      thing: 0.4605
+      place: 0.2981
+      person: 0.2413
+    ontological:
+      imagined: 0.3541
+      forgotten: 0.2841
+      known: 0.3619
+    confidence: 0.0449
   discogs_id: 39775
   notes: ''
 Electric Light Orchestra:
   slug: electric_light_orchestra
   status: draft
-  description: 'Electric Light Orchestra layers orchestral strings and brass over rock instrumentation — electric guitars,
-    synthesizers, and propulsive drums — creating a dense, richly textured sonic tapestry with a polished, studio-crafted
-    warmth. Production favors meticulous multi-tracking, prominent cello arrangements, and shimmering vocal harmonies, achieving
-    a cinematic, full-bodied sound. Lyrically, themes orbit romantic longing, escapism, temporal displacement, dreams versus
-    reality, and a wistful sense of wonder at technology and the cosmos. Imagery tends toward the nocturnal, celestial, and
-    bittersweet. The emotional register is primarily melodic melancholy tinged with optimism — a kind of hopeful yearning
-    that carries both tenderness and grandeur. The project is decidedly vocal-led, with layered harmonies functioning almost
-    as additional orchestral voices, blurring the boundary between ensemble singing and instrumental arrangement.
+  description: 'Electric Light Orchestra layers orchestral strings and brass over
+    rock instrumentation — electric guitars, synthesizers, and propulsive drums —
+    creating a dense, richly textured sonic tapestry with a polished, studio-crafted
+    warmth. Production favors meticulous multi-tracking, prominent cello arrangements,
+    and shimmering vocal harmonies, achieving a cinematic, full-bodied sound. Lyrically,
+    themes orbit romantic longing, escapism, temporal displacement, dreams versus
+    reality, and a wistful sense of wonder at technology and the cosmos. Imagery tends
+    toward the nocturnal, celestial, and bittersweet. The emotional register is primarily
+    melodic melancholy tinged with optimism — a kind of hopeful yearning that carries
+    both tenderness and grandeur. The project is decidedly vocal-led, with layered
+    harmonies functioning almost as additional orchestral voices, blurring the boundary
+    between ensemble singing and instrumental arrangement.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4131
+      present: 0.2715
+      future: 0.3155
+    spatial:
+      thing: 0.4141
+      place: 0.315
+      person: 0.2709
+    ontological:
+      imagined: 0.3344
+      forgotten: 0.3063
+      known: 0.3593
+    confidence: 0.0192
   discogs_id: 112154
   notes: ''
 Led Zeppelin:
   slug: led_zeppelin
   status: draft
-  description: 'Led Zeppelin''s sonic texture combines thick, distorted electric guitar riffs with dynamic contrasts between
-    explosive heaviness and delicate acoustic passages. Production is raw yet layered, emphasizing physical impact through
-    prominent bass frequencies, live-room ambience, and occasional studio experimentation including backward tape and echo
-    manipulation. The ensemble balances prominent lead vocals — expressive, wide-ranging, and blues-rooted — with extended
-    instrumental passages featuring improvisation and rhythmic complexity.
+  description: 'Led Zeppelin''s sonic texture combines thick, distorted electric guitar
+    riffs with dynamic contrasts between explosive heaviness and delicate acoustic
+    passages. Production is raw yet layered, emphasizing physical impact through prominent
+    bass frequencies, live-room ambience, and occasional studio experimentation including
+    backward tape and echo manipulation. The ensemble balances prominent lead vocals
+    — expressive, wide-ranging, and blues-rooted — with extended instrumental passages
+    featuring improvisation and rhythmic complexity.
 
 
-    Lyrically, themes draw from mythology, folklore, mysticism, erotic longing, travel, and primal natural forces. Imagery
-    tends toward the ancient and elemental — oceans, mountains, celestial bodies, and archaic symbolism. Tone shifts between
-    euphoric abandon, brooding menace, and tender yearning.
+    Lyrically, themes draw from mythology, folklore, mysticism, erotic longing, travel,
+    and primal natural forces. Imagery tends toward the ancient and elemental — oceans,
+    mountains, celestial bodies, and archaic symbolism. Tone shifts between euphoric
+    abandon, brooding menace, and tender yearning.
 
 
-    Emotionally, the register moves fluidly between ecstatic release and dark introspection, carrying an underlying tension
-    between light and shadow, restraint and excess, vulnerability and overwhelming power.
+    Emotionally, the register moves fluidly between ecstatic release and dark introspection,
+    carrying an underlying tension between light and shadow, restraint and excess,
+    vulnerability and overwhelming power.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4245
+      present: 0.2626
+      future: 0.3129
+    spatial:
+      thing: 0.4254
+      place: 0.3124
+      person: 0.2622
+    ontological:
+      imagined: 0.3403
+      forgotten: 0.2996
+      known: 0.3601
+    confidence: 0.0174
   discogs_id: 34278
   notes: ''
 Black Moth Super Rainbow:
   slug: black_moth_super_rainbow
   status: draft
-  description: 'Black Moth Super Rainbow constructs dense, lo-fi psychedelic soundscapes built from vintage analog synthesizers,
-    heavily processed drum machines, and vocoder-treated vocals that dissolve human speech into texture. Production feels
-    deliberately decayed — warm, saturated, and hazy, as though recorded through layers of tape dust and summer heat. Arrangements
-    blend lush melodic repetition with murky low-end density, creating a suffocating yet hypnotic sonic environment. Thematically,
-    imagery orbits childhood, rural strangeness, bodily dissolution, nature, and dreamlike unease — familiar suburban and
-    pastoral settings rendered uncanny. Lyrically sparse, with vocals functioning more as tonal elements than narrative vehicles.
-    The emotional register sits in an ambiguous zone between euphoria and dread, evoking nostalgic warmth contaminated by
-    something subtly wrong. The project is primarily vocal but treats voice as instrument rather than storytelling device,
-    maintaining an overall hallucinatory, introspective psychological atmosphere throughout.
+  description: 'Black Moth Super Rainbow constructs dense, lo-fi psychedelic soundscapes
+    built from vintage analog synthesizers, heavily processed drum machines, and vocoder-treated
+    vocals that dissolve human speech into texture. Production feels deliberately
+    decayed — warm, saturated, and hazy, as though recorded through layers of tape
+    dust and summer heat. Arrangements blend lush melodic repetition with murky low-end
+    density, creating a suffocating yet hypnotic sonic environment. Thematically,
+    imagery orbits childhood, rural strangeness, bodily dissolution, nature, and dreamlike
+    unease — familiar suburban and pastoral settings rendered uncanny. Lyrically sparse,
+    with vocals functioning more as tonal elements than narrative vehicles. The emotional
+    register sits in an ambiguous zone between euphoria and dread, evoking nostalgic
+    warmth contaminated by something subtly wrong. The project is primarily vocal
+    but treats voice as instrument rather than storytelling device, maintaining an
+    overall hallucinatory, introspective psychological atmosphere throughout.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4324
+      present: 0.2589
+      future: 0.3087
+    spatial:
+      thing: 0.4333
+      place: 0.3086
+      person: 0.2581
+    ontological:
+      imagined: 0.3458
+      forgotten: 0.2953
+      known: 0.3589
+    confidence: 0.0226
   discogs_id: 165373
   notes: ''
 Harry Nilsson:
   slug: harry_nilsson
   status: draft
-  description: 'Harry Nilsson is a primarily vocal artist, though his recordings integrate lush orchestral and piano-driven
-    arrangements with intimate, often sparse interludes. His production character favors warmth and roundness — strings rendered
-    with a soft sheen, vocals placed forward and dry or gently treated, creating an intimate parlor-like texture. Density
-    shifts dramatically, from bare piano-voice settings to densely layered orchestrations. Lyrically, his work explores loneliness,
-    longing, romantic disillusionment, whimsy, and existential melancholy, frequently employing childlike imagery, dark humor,
-    and circular or dreamlike narrative structures. Wordplay and absurdism sit alongside genuine pathos. The emotional register
-    is distinctly dualistic — tender and bittersweet, capable of pivoting between playful lightness and aching vulnerability
-    within a single piece. A sense of theatrical intimacy pervades his work, suggesting introspection performed for an unseen
-    audience, blurring sincerity and self-aware artifice.
+  description: 'Harry Nilsson is a primarily vocal artist, though his recordings integrate
+    lush orchestral and piano-driven arrangements with intimate, often sparse interludes.
+    His production character favors warmth and roundness — strings rendered with a
+    soft sheen, vocals placed forward and dry or gently treated, creating an intimate
+    parlor-like texture. Density shifts dramatically, from bare piano-voice settings
+    to densely layered orchestrations. Lyrically, his work explores loneliness, longing,
+    romantic disillusionment, whimsy, and existential melancholy, frequently employing
+    childlike imagery, dark humor, and circular or dreamlike narrative structures.
+    Wordplay and absurdism sit alongside genuine pathos. The emotional register is
+    distinctly dualistic — tender and bittersweet, capable of pivoting between playful
+    lightness and aching vulnerability within a single piece. A sense of theatrical
+    intimacy pervades his work, suggesting introspection performed for an unseen audience,
+    blurring sincerity and self-aware artifice.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.43
+      present: 0.2603
+      future: 0.3098
+    spatial:
+      thing: 0.4307
+      place: 0.3096
+      person: 0.2597
+    ontological:
+      imagined: 0.3482
+      forgotten: 0.2947
+      known: 0.3571
+    confidence: 0.021
   discogs_id: 152685
   notes: ''
 Stereolab:
   slug: stereolab
   status: draft
-  description: 'Stereolab weaves densely layered sonic tapestries, blending analogue synthesizer drones, motorik rhythmic
-    patterns, and warm vintage organ tones. Production favors a lush, slightly saturated quality — sounds overlap in smooth,
-    hypnotic clusters, with clean electric guitar, vibraphone, and mellotron frequently woven into mid-century pop structures.
-    The studio approach is meticulous yet organic, emphasizing textural repetition and gradual harmonic drift. Vocals are
-    present and central, delivered in a cool, detached manner, often in French and English simultaneously, functioning partly
-    as another melodic instrument. Lyrically, themes gravitate toward utopian politics, materialist philosophy, everyday domesticity
-    examined through an ideological lens, and abstract meditations on consciousness and systems. The emotional register is
-    paradoxically serene and cerebral — a kind of pleasurable intellectual detachment, evoking warmth without sentimentality,
-    curiosity without urgency, and a dreamy but measured optimism rooted in theoretical inquiry.
+  description: 'Stereolab weaves densely layered sonic tapestries, blending analogue
+    synthesizer drones, motorik rhythmic patterns, and warm vintage organ tones. Production
+    favors a lush, slightly saturated quality — sounds overlap in smooth, hypnotic
+    clusters, with clean electric guitar, vibraphone, and mellotron frequently woven
+    into mid-century pop structures. The studio approach is meticulous yet organic,
+    emphasizing textural repetition and gradual harmonic drift. Vocals are present
+    and central, delivered in a cool, detached manner, often in French and English
+    simultaneously, functioning partly as another melodic instrument. Lyrically, themes
+    gravitate toward utopian politics, materialist philosophy, everyday domesticity
+    examined through an ideological lens, and abstract meditations on consciousness
+    and systems. The emotional register is paradoxically serene and cerebral — a kind
+    of pleasurable intellectual detachment, evoking warmth without sentimentality,
+    curiosity without urgency, and a dreamy but measured optimism rooted in theoretical
+    inquiry.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4167
+      present: 0.2686
+      future: 0.3146
+    spatial:
+      thing: 0.4175
+      place: 0.3144
+      person: 0.2681
+    ontological:
+      imagined: 0.3484
+      forgotten: 0.3004
+      known: 0.3512
+    confidence: 0.0149
   discogs_id: 388
   notes: ''
 Mercury Rev:
   slug: mercury_rev
   status: draft
-  description: 'Mercury Rev craft densely layered, orchestral rock with a dreamlike production character. Lush strings, brass,
-    and mellotron weave through electric guitars and crashing percussion, creating a cinematic, wide-screen texture that balances
-    intimacy with grandeur. Studio arrangements favour warm analog richness, blending acoustic and synthetic timbres into
-    shimmering, cloud-like density.
+  description: 'Mercury Rev craft densely layered, orchestral rock with a dreamlike
+    production character. Lush strings, brass, and mellotron weave through electric
+    guitars and crashing percussion, creating a cinematic, wide-screen texture that
+    balances intimacy with grandeur. Studio arrangements favour warm analog richness,
+    blending acoustic and synthetic timbres into shimmering, cloud-like density.
 
 
-    Lyrically, the work draws on cosmic imagery, childhood wonder, altered states, and existential longing. Themes circle
-    around transformation, dissolution of self, and the fragile boundary between dream and waking life. Imagery tends toward
-    the celestial, natural, and surreal.
+    Lyrically, the work draws on cosmic imagery, childhood wonder, altered states,
+    and existential longing. Themes circle around transformation, dissolution of self,
+    and the fragile boundary between dream and waking life. Imagery tends toward the
+    celestial, natural, and surreal.
 
 
-    Emotionally, the register is bittersweet and transcendent — simultaneously euphoric and melancholic, evoking a sense of
-    yearning suspended between loss and possibility. There is a psychological fragility beneath the orchestral sweep.
+    Emotionally, the register is bittersweet and transcendent — simultaneously euphoric
+    and melancholic, evoking a sense of yearning suspended between loss and possibility.
+    There is a psychological fragility beneath the orchestral sweep.
 
 
-    The music is primarily vocal-led, with narrative vocal melodies central to each composition.
+    The music is primarily vocal-led, with narrative vocal melodies central to each
+    composition.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4236
+      present: 0.2648
+      future: 0.3116
+    spatial:
+      thing: 0.4245
+      place: 0.3114
+      person: 0.264
+    ontological:
+      imagined: 0.3441
+      forgotten: 0.2976
+      known: 0.3583
+    confidence: 0.0243
   discogs_id: 9658
   notes: ''
 13th Floor Elevators:
   slug: 13th_floor_elevators
   status: draft
-  description: 'The 13th Floor Elevators occupy a dense, reverb-saturated sonic space where electric jug produces unearthly,
-    bubbling tones beneath fuzz-drenched guitars and raw, impassioned vocals. Production is deliberately primitive and live-feeling,
-    with a murky, ecstatic quality. The ensemble is vocal-led, with Roky Erickson''s voice conveying urgency and transcendence
-    simultaneously. Lyrically, their work circulates around themes of consciousness expansion, spiritual awakening, cosmic
-    perception, and the dissolution of ordinary ego boundaries. Imagery tends toward the visionary and esoteric, drawing on
-    mystical frameworks and interior psychological states. The emotional register is fervent and psychically charged — simultaneously
-    euphoric and unsettling, suggesting altered states of mind and metaphysical yearning. Rhythmically propulsive and hypnotic,
-    the music balances garage-rock rawness with an earnest, almost evangelical intensity, creating an atmosphere that feels
-    ritualistic and urgently searching.
+  description: 'The 13th Floor Elevators occupy a dense, reverb-saturated sonic space
+    where electric jug produces unearthly, bubbling tones beneath fuzz-drenched guitars
+    and raw, impassioned vocals. Production is deliberately primitive and live-feeling,
+    with a murky, ecstatic quality. The ensemble is vocal-led, with Roky Erickson''s
+    voice conveying urgency and transcendence simultaneously. Lyrically, their work
+    circulates around themes of consciousness expansion, spiritual awakening, cosmic
+    perception, and the dissolution of ordinary ego boundaries. Imagery tends toward
+    the visionary and esoteric, drawing on mystical frameworks and interior psychological
+    states. The emotional register is fervent and psychically charged — simultaneously
+    euphoric and unsettling, suggesting altered states of mind and metaphysical yearning.
+    Rhythmically propulsive and hypnotic, the music balances garage-rock rawness with
+    an earnest, almost evangelical intensity, creating an atmosphere that feels ritualistic
+    and urgently searching.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4075
+      present: 0.2751
+      future: 0.3173
+    spatial:
+      thing: 0.4087
+      place: 0.3168
+      person: 0.2746
+    ontological:
+      imagined: 0.3329
+      forgotten: 0.309
+      known: 0.358
+    confidence: 0.0187
   discogs_id: 304455
   notes: ''
 Supercollider:
   slug: supercollider
   status: draft
-  description: Post rock band with minimal and drone elements but whose fragile beautiful lyrics and vocals are the main focus
-    of the music. The music is often melancholic and emotional, with a focus on themes of love, loss, and longing. The production
-    is often sparse and atmospheric, with a focus on creating a sense of intimacy and vulnerability. The band's sound is often
-    compared to that of other post rock bands such as Sigur Rós and Explosions in the Sky, but with a more vocal-centric approach.
+  description: Post rock band with minimal and drone elements but whose fragile beautiful
+    lyrics and vocals are the main focus of the music. The music is often melancholic
+    and emotional, with a focus on themes of love, loss, and longing. The production
+    is often sparse and atmospheric, with a focus on creating a sense of intimacy
+    and vulnerability. The band's sound is often compared to that of other post rock
+    bands such as Sigur Rós and Explosions in the Sky, but with a more vocal-centric
+    approach.
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4187
+      present: 0.2636
+      future: 0.3176
+    spatial:
+      thing: 0.4202
+      place: 0.3171
+      person: 0.2627
+    ontological:
+      imagined: 0.358
+      forgotten: 0.2973
+      known: 0.3447
+    confidence: 0.0547
   discogs_id: 244281
   notes: Unknown artist — fill description manually
 Laurie Anderson:
   slug: laurie_anderson
   status: draft
-  description: 'Laurie Anderson works primarily as a vocal artist, weaving spoken word and processed voice through sparse,
-    layered electronic textures. Her production favors minimalist density — sustained synthesizer drones, filtered loops,
-    and treated violin — creating an intimate yet vast sonic space. Studio work often blurs acoustic and electronic boundaries,
-    with deliberate pacing and silence used as compositional elements.
+  description: 'Laurie Anderson works primarily as a vocal artist, weaving spoken
+    word and processed voice through sparse, layered electronic textures. Her production
+    favors minimalist density — sustained synthesizer drones, filtered loops, and
+    treated violin — creating an intimate yet vast sonic space. Studio work often
+    blurs acoustic and electronic boundaries, with deliberate pacing and silence used
+    as compositional elements.
 
 
-    Lyrically, her work explores technology, language, perception, time, and the strangeness of everyday experience. Imagery
-    tends toward the philosophical and surreal, drawing from mythology, science, and domestic observation. Narratives are
-    fragmented, parable-like, often delivered in a detached, conversational tone that feels simultaneously clinical and tender.
+    Lyrically, her work explores technology, language, perception, time, and the strangeness
+    of everyday experience. Imagery tends toward the philosophical and surreal, drawing
+    from mythology, science, and domestic observation. Narratives are fragmented,
+    parable-like, often delivered in a detached, conversational tone that feels simultaneously
+    clinical and tender.
 
 
-    The emotional register is cool yet quietly vulnerable — cerebral wonder tinged with melancholy and dry wit. Psychological
-    colour shifts between introspective stillness and unsettled curiosity, maintaining an atmosphere of meditative estrangement.
+    The emotional register is cool yet quietly vulnerable — cerebral wonder tinged
+    with melancholy and dry wit. Psychological colour shifts between introspective
+    stillness and unsettled curiosity, maintaining an atmosphere of meditative estrangement.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4265
+      present: 0.2565
+      future: 0.317
+    spatial:
+      thing: 0.4271
+      place: 0.3166
+      person: 0.2563
+    ontological:
+      imagined: 0.3513
+      forgotten: 0.2964
+      known: 0.3523
+    confidence: 0.0259
   discogs_id: 26050
   notes: ''
 The Velvet Underground:
   slug: the_velvet_underground
   status: draft
-  description: 'The Velvet Underground operates primarily as a vocal ensemble layered over spare-to-dense rock instrumentation.
-    Sonically, the band favors raw, minimally processed textures — dry guitars oscillating between gentle fingerpicking and
-    abrasive, feedback-laden drones, rudimentary drumming, and viola adding an unusual, often dissonant string presence. Production
-    tends toward deliberate crudeness and controlled chaos. Lyrically, themes gravitate toward urban decay, altered states,
-    transgression, alienation, obsession, and the mundane alongside the transgressive, rendered in a detached, reportorial
-    tone stripped of sentimentality. Imagery is street-level and unflinching, frequently inhabiting marginal social spaces.
-    Emotionally, the register shifts between cool detachment and unnerving intensity — simultaneously numb and visceral, evoking
-    psychological unease, longing, and dissociation. Dynamic range is extreme, moving from hushed, tender passages to near-noise
-    bombardment within single compositions, creating an unsettling push-pull between vulnerability and aggression.
+  description: 'The Velvet Underground operates primarily as a vocal ensemble layered
+    over spare-to-dense rock instrumentation. Sonically, the band favors raw, minimally
+    processed textures — dry guitars oscillating between gentle fingerpicking and
+    abrasive, feedback-laden drones, rudimentary drumming, and viola adding an unusual,
+    often dissonant string presence. Production tends toward deliberate crudeness
+    and controlled chaos. Lyrically, themes gravitate toward urban decay, altered
+    states, transgression, alienation, obsession, and the mundane alongside the transgressive,
+    rendered in a detached, reportorial tone stripped of sentimentality. Imagery is
+    street-level and unflinching, frequently inhabiting marginal social spaces. Emotionally,
+    the register shifts between cool detachment and unnerving intensity — simultaneously
+    numb and visceral, evoking psychological unease, longing, and dissociation. Dynamic
+    range is extreme, moving from hushed, tender passages to near-noise bombardment
+    within single compositions, creating an unsettling push-pull between vulnerability
+    and aggression.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4503
+      present: 0.2462
+      future: 0.3035
+    spatial:
+      thing: 0.4513
+      place: 0.3034
+      person: 0.2453
+    ontological:
+      imagined: 0.3551
+      forgotten: 0.2864
+      known: 0.3586
+    confidence: 0.0274
   discogs_id: 39766
   notes: ''
 The Feelies:
   slug: the_feelies
   status: draft
-  description: 'The Feelies craft a predominantly guitar-driven sound built on interlocking, repetitive picking patterns that
-    accumulate hypnotic density through layered rhythmic precision. Production favors a dry, close-miked clarity where individual
-    strands remain distinct within dense weave — trebly, clean tones over propulsive, often double-time drumming. Textures
-    shift between nervous, jittery momentum and spacious, droning calm. Vocals are present but understated, delivered in a
-    flat, detached murmur that recedes into the instrumental fabric rather than commanding it. Lyrically, imagery tends toward
-    the mundane and suburban — ordinary moments, domestic observation, quiet displacement — rendered without sentimentality.
-    The emotional register is simultaneously anxious and meditative: restless surface energy containing an underlying stillness.
-    Repetition functions as both structural device and psychological state, evoking a dissociated awareness of everyday routine.
-    The overall affect is cool, slightly alienated, and inward-turned.
+  description: 'The Feelies craft a predominantly guitar-driven sound built on interlocking,
+    repetitive picking patterns that accumulate hypnotic density through layered rhythmic
+    precision. Production favors a dry, close-miked clarity where individual strands
+    remain distinct within dense weave — trebly, clean tones over propulsive, often
+    double-time drumming. Textures shift between nervous, jittery momentum and spacious,
+    droning calm. Vocals are present but understated, delivered in a flat, detached
+    murmur that recedes into the instrumental fabric rather than commanding it. Lyrically,
+    imagery tends toward the mundane and suburban — ordinary moments, domestic observation,
+    quiet displacement — rendered without sentimentality. The emotional register is
+    simultaneously anxious and meditative: restless surface energy containing an underlying
+    stillness. Repetition functions as both structural device and psychological state,
+    evoking a dissociated awareness of everyday routine. The overall affect is cool,
+    slightly alienated, and inward-turned.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4771
+      present: 0.2308
+      future: 0.2921
+    spatial:
+      thing: 0.4781
+      place: 0.292
+      person: 0.2299
+    ontological:
+      imagined: 0.3596
+      forgotten: 0.2753
+      known: 0.3651
+    confidence: 0.0487
   discogs_id: 152428
   notes: ''
 Severed Heads:
   slug: severed_heads
   status: draft
-  description: 'Severed Heads occupies a dense, abrasive electronic soundscape where industrial noise, decayed tape loops,
-    and synthetic percussion collide with unexpected moments of pop melody. The production character is deliberately fragmented
-    — layers of processed vocals, distorted rhythmic machinery, and collage-like studio manipulation create a claustrophobic
-    yet hypnotic texture. Sounds appear corroded, as though filtered through malfunctioning equipment or degraded media. Vocal
-    elements are present but often treated as textural objects rather than conventional melodic carriers, blurring the line
-    between instrumental and vocal work. Lyrically, when decipherable, imagery tends toward urban alienation, mechanical bodies,
-    surveillance, and psychological dislocation — delivered with clinical detachment or flat affect. The emotional register
-    oscillates between paranoia and numbness, occasionally punctuated by unsettling dark humor. The overall mood suggests
-    a dystopian mundanity, anxiety rendered banal through repetition and sonic erosion.
+  description: 'Severed Heads occupies a dense, abrasive electronic soundscape where
+    industrial noise, decayed tape loops, and synthetic percussion collide with unexpected
+    moments of pop melody. The production character is deliberately fragmented — layers
+    of processed vocals, distorted rhythmic machinery, and collage-like studio manipulation
+    create a claustrophobic yet hypnotic texture. Sounds appear corroded, as though
+    filtered through malfunctioning equipment or degraded media. Vocal elements are
+    present but often treated as textural objects rather than conventional melodic
+    carriers, blurring the line between instrumental and vocal work. Lyrically, when
+    decipherable, imagery tends toward urban alienation, mechanical bodies, surveillance,
+    and psychological dislocation — delivered with clinical detachment or flat affect.
+    The emotional register oscillates between paranoia and numbness, occasionally
+    punctuated by unsettling dark humor. The overall mood suggests a dystopian mundanity,
+    anxiety rendered banal through repetition and sonic erosion.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4457
+      present: 0.2472
+      future: 0.3072
+    spatial:
+      thing: 0.4465
+      place: 0.3069
+      person: 0.2466
+    ontological:
+      imagined: 0.351
+      forgotten: 0.2894
+      known: 0.3596
+    confidence: 0.034
   discogs_id: 26212
   notes: ''
 Sabrina Carpenter:
   slug: sabrina_carpenter
   status: draft
-  description: 'Sabrina Carpenter operates as a vocal-forward pop artist, with production that favours polished, mid-density
-    arrangements blending retro-inflected warmth with contemporary brightness. Sonically, her work draws on vintage pop and
-    bubblegum textures — light acoustic guitar, crisp percussion, airy synth pads — balanced against clean, intimate vocal
-    production that keeps the voice centred and conversational. Studio treatment is glossy but not overcrowded, maintaining
-    a sense of lightness even in emotionally layered moments. Lyrically, she gravitates toward themes of romantic tension,
-    self-possession, irony, and interpersonal dynamics, often employing clever wordplay and a slightly sardonic, self-aware
-    tone. Imagery tends toward the playful and personal rather than abstract. The emotional register blends confidence with
-    vulnerability — a psychological colour of composed wryness undercut by genuine feeling, projecting ease while acknowledging
-    complexity beneath the surface.
+  description: 'Sabrina Carpenter operates as a vocal-forward pop artist, with production
+    that favours polished, mid-density arrangements blending retro-inflected warmth
+    with contemporary brightness. Sonically, her work draws on vintage pop and bubblegum
+    textures — light acoustic guitar, crisp percussion, airy synth pads — balanced
+    against clean, intimate vocal production that keeps the voice centred and conversational.
+    Studio treatment is glossy but not overcrowded, maintaining a sense of lightness
+    even in emotionally layered moments. Lyrically, she gravitates toward themes of
+    romantic tension, self-possession, irony, and interpersonal dynamics, often employing
+    clever wordplay and a slightly sardonic, self-aware tone. Imagery tends toward
+    the playful and personal rather than abstract. The emotional register blends confidence
+    with vulnerability — a psychological colour of composed wryness undercut by genuine
+    feeling, projecting ease while acknowledging complexity beneath the surface.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4273
+      present: 0.26
+      future: 0.3127
+    spatial:
+      thing: 0.428
+      place: 0.3126
+      person: 0.2594
+    ontological:
+      imagined: 0.3533
+      forgotten: 0.2948
+      known: 0.3519
+    confidence: 0.0187
   discogs_id: 4378284
   notes: ''
 Billie Eilish:
   slug: billie_eilish
   status: draft
-  description: 'Billie Eilish works primarily as a vocalist, her voice placed intimately close in the mix — breathy, whispering,
-    often layered in tight harmonic stacks that blur the boundary between human and processed sound. Production is sparse
-    and deliberately low-register, favouring sub-bass rumble, muted percussion, and unsettling silences over dense instrumentation.
-    Textures feel claustrophobic and interior, as though recorded inside a small, padded space. Lyrically, her work circles
-    obsession, self-perception, dread, romantic ambivalence, and dissociation, frequently using domestic or bodily imagery
-    to ground abstract psychological states. Tone shifts between detached irony and raw vulnerability within single pieces.
-    The emotional register is predominantly dark and introspective — melancholic, sometimes menacing — with moments of sardonic
-    lightness that heighten rather than relieve tension. The overall aesthetic feels confessional yet guarded, prioritising
+  description: 'Billie Eilish works primarily as a vocalist, her voice placed intimately
+    close in the mix — breathy, whispering, often layered in tight harmonic stacks
+    that blur the boundary between human and processed sound. Production is sparse
+    and deliberately low-register, favouring sub-bass rumble, muted percussion, and
+    unsettling silences over dense instrumentation. Textures feel claustrophobic and
+    interior, as though recorded inside a small, padded space. Lyrically, her work
+    circles obsession, self-perception, dread, romantic ambivalence, and dissociation,
+    frequently using domestic or bodily imagery to ground abstract psychological states.
+    Tone shifts between detached irony and raw vulnerability within single pieces.
+    The emotional register is predominantly dark and introspective — melancholic,
+    sometimes menacing — with moments of sardonic lightness that heighten rather than
+    relieve tension. The overall aesthetic feels confessional yet guarded, prioritising
     psychological texture over melodic extroversion.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.415
+      present: 0.2702
+      future: 0.3148
+    spatial:
+      thing: 0.4159
+      place: 0.3145
+      person: 0.2696
+    ontological:
+      imagined: 0.3434
+      forgotten: 0.3033
+      known: 0.3533
+    confidence: 0.0213
   discogs_id: 5590213
   notes: ''
 Television:
   slug: television
   status: draft
-  description: 'Television crafts a distinctly angular, interlocking guitar-driven sound built from two lead guitars weaving
-    contrapuntal lines with a lean, dry studio clarity. The production favors transparency over density — minimal reverb,
-    exposed textures, and a restrained rhythm section that creates space for melodic improvisation. The timbre is clean yet
-    urgent, favoring sustained single-note runs over chord-heavy saturation.
+  description: 'Television crafts a distinctly angular, interlocking guitar-driven
+    sound built from two lead guitars weaving contrapuntal lines with a lean, dry
+    studio clarity. The production favors transparency over density — minimal reverb,
+    exposed textures, and a restrained rhythm section that creates space for melodic
+    improvisation. The timbre is clean yet urgent, favoring sustained single-note
+    runs over chord-heavy saturation.
 
 
-    Lyrically, the work dwells in urban alienation, romantic dissolution, spiritual searching, and street-level perception
-    filtered through a detached, literary sensibility. Imagery tends toward nocturnal city landscapes, fragmented consciousness,
-    and existential drift rendered in compressed, elliptical phrases.
+    Lyrically, the work dwells in urban alienation, romantic dissolution, spiritual
+    searching, and street-level perception filtered through a detached, literary sensibility.
+    Imagery tends toward nocturnal city landscapes, fragmented consciousness, and
+    existential drift rendered in compressed, elliptical phrases.
 
 
-    Emotionally, the register is cool and cerebral yet carries an undercurrent of yearning and restless tension — intellectually
-    distant but emotionally charged beneath the surface. The work is primarily vocal, with extended instrumental passages
+    Emotionally, the register is cool and cerebral yet carries an undercurrent of
+    yearning and restless tension — intellectually distant but emotionally charged
+    beneath the surface. The work is primarily vocal, with extended instrumental passages
     that carry equal expressive weight.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4496
+      present: 0.2474
+      future: 0.303
+    spatial:
+      thing: 0.4503
+      place: 0.3032
+      person: 0.2465
+    ontological:
+      imagined: 0.3582
+      forgotten: 0.2846
+      known: 0.3572
+    confidence: 0.025
   discogs_id: 254494
   notes: ''
 James Blake:
   slug: james_blake
   status: draft
-  description: 'James Blake occupies a space between minimalist soul and electronic abstraction. Productions are sparse yet
-    dense in texture, built from processed vocal fragments, sub-bass tones, and precisely placed negative space. Studio work
-    emphasises heavy pitch-correction and formant manipulation as compositional elements rather than corrections, creating
-    uncanny, spectral vocal timbres. Synthesisers breathe with slow attack and long release, while rhythmic structures often
-    feel suspended or deliberately unresolved.
+  description: 'James Blake occupies a space between minimalist soul and electronic
+    abstraction. Productions are sparse yet dense in texture, built from processed
+    vocal fragments, sub-bass tones, and precisely placed negative space. Studio work
+    emphasises heavy pitch-correction and formant manipulation as compositional elements
+    rather than corrections, creating uncanny, spectral vocal timbres. Synthesisers
+    breathe with slow attack and long release, while rhythmic structures often feel
+    suspended or deliberately unresolved.
 
 
-    Blake is primarily a vocal artist, his voice carrying an intimate, confessional quality. Thematically, the work circles
-    around emotional withdrawal, romantic vulnerability, grief, and the difficulty of genuine connection. Imagery tends toward
-    interiority — psychological states rendered as environmental or atmospheric metaphors.
+    Blake is primarily a vocal artist, his voice carrying an intimate, confessional
+    quality. Thematically, the work circles around emotional withdrawal, romantic
+    vulnerability, grief, and the difficulty of genuine connection. Imagery tends
+    toward interiority — psychological states rendered as environmental or atmospheric
+    metaphors.
 
 
-    The emotional register is consistently melancholic and introspective, hovering between longing and resignation, occasionally
-    punctuated by moments of restrained tenderness or fragile hope.
+    The emotional register is consistently melancholic and introspective, hovering
+    between longing and resignation, occasionally punctuated by moments of restrained
+    tenderness or fragile hope.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4259
+      present: 0.2589
+      future: 0.3152
+    spatial:
+      thing: 0.4264
+      place: 0.3151
+      person: 0.2586
+    ontological:
+      imagined: 0.34
+      forgotten: 0.302
+      known: 0.358
+    confidence: 0.0157
   discogs_id: 1500084
   notes: ''
 Harry Styles:
   slug: harry_styles
   status: draft
-  description: 'Harry Styles operates as a vocal-forward artist, with production that blends warm analogue textures against
-    polished, arena-ready arrangements. His sonic palette draws from 1970s soft rock and glam influences, featuring layered
-    electric guitars, lush string accents, and deliberate use of space and reverb to create an intimate yet expansive feel.
-    Production density shifts fluidly between sparse, breath-forward verses and dense, chorus-driven climaxes.
+  description: 'Harry Styles operates as a vocal-forward artist, with production that
+    blends warm analogue textures against polished, arena-ready arrangements. His
+    sonic palette draws from 1970s soft rock and glam influences, featuring layered
+    electric guitars, lush string accents, and deliberate use of space and reverb
+    to create an intimate yet expansive feel. Production density shifts fluidly between
+    sparse, breath-forward verses and dense, chorus-driven climaxes.
 
 
-    Lyrically, his work circles themes of romantic longing, self-discovery, vulnerability, and hedonistic freedom, often rendered
-    through sensory and tactile imagery. Tone oscillates between tender introspection and playful, carefree liberation.
+    Lyrically, his work circles themes of romantic longing, self-discovery, vulnerability,
+    and hedonistic freedom, often rendered through sensory and tactile imagery. Tone
+    oscillates between tender introspection and playful, carefree liberation.
 
 
-    Emotionally, his catalogue occupies a warm, nostalgic register with undercurrents of wistfulness and yearning, occasionally
-    brightened by euphoric, sun-drenched optimism. The psychological colour is consistently human-scaled — intimate rather
+    Emotionally, his catalogue occupies a warm, nostalgic register with undercurrents
+    of wistfulness and yearning, occasionally brightened by euphoric, sun-drenched
+    optimism. The psychological colour is consistently human-scaled — intimate rather
     than grandiose — even within large-scale sonic contexts.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4344
+      present: 0.2566
+      future: 0.309
+    spatial:
+      thing: 0.4354
+      place: 0.3088
+      person: 0.2557
+    ontological:
+      imagined: 0.3512
+      forgotten: 0.2933
+      known: 0.3556
+    confidence: 0.0315
   discogs_id: 2508414
   notes: ''
 Lauv:
   slug: lauv
   status: draft
-  description: 'Lauv operates in polished, minimalist pop production — sparse electronic beds layered with warm synthesizers,
-    soft-clipped beats, and intimate acoustic or electric guitar textures. The sonic density remains deliberately restrained,
-    favouring space and breath over saturation, with vocals sitting close in the mix, dry and confessional. Studio treatment
-    emphasizes crisp transients against lush, reverb-washed pads, creating a simultaneously digital and emotionally organic
+  description: 'Lauv operates in polished, minimalist pop production — sparse electronic
+    beds layered with warm synthesizers, soft-clipped beats, and intimate acoustic
+    or electric guitar textures. The sonic density remains deliberately restrained,
+    favouring space and breath over saturation, with vocals sitting close in the mix,
+    dry and confessional. Studio treatment emphasizes crisp transients against lush,
+    reverb-washed pads, creating a simultaneously digital and emotionally organic
     character.
 
 
-    Lyrically, themes circle romantic longing, self-doubt, emotional dependency, anxiety, and the internal dissonance of modern
-    relationships. Imagery tends toward the personal and everyday — interior emotional landscapes rendered in direct, conversational
+    Lyrically, themes circle romantic longing, self-doubt, emotional dependency, anxiety,
+    and the internal dissonance of modern relationships. Imagery tends toward the
+    personal and everyday — interior emotional landscapes rendered in direct, conversational
     language.
 
 
-    The emotional register is bittersweet and introspective, occupying territory between vulnerability and quiet resilience.
-    Psychological colour skews melancholic but remains accessible rather than heavy, suffused with a gentle wistfulness.
+    The emotional register is bittersweet and introspective, occupying territory between
+    vulnerability and quiet resilience. Psychological colour skews melancholic but
+    remains accessible rather than heavy, suffused with a gentle wistfulness.
 
 
-    Lauv is primarily a vocal artist, with melody and lyrical intimacy as the central compositional anchors.
+    Lauv is primarily a vocal artist, with melody and lyrical intimacy as the central
+    compositional anchors.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4347
+      present: 0.2545
+      future: 0.3107
+    spatial:
+      thing: 0.4356
+      place: 0.3106
+      person: 0.2538
+    ontological:
+      imagined: 0.3427
+      forgotten: 0.2978
+      known: 0.3595
+    confidence: 0.0263
   discogs_id: 5047975
   notes: ''
 Lana Del Rey:
   slug: lana_del_rey
   status: draft
-  description: 'Lana Del Rey operates as a vocal-centred artist, her voice occupying a low, breathy mezzo-soprano register
-    layered with reverb and subtle double-tracking, creating an intimate yet cinematic presence. Production is lush and slow-moving,
-    often built on orchestral strings, sub-bass drones, vintage drum machine patterns, and hazy atmospheric pads, favouring
-    spaciousness over density. Studio textures lean heavily toward warmth and analogue softness, with deliberate tempos that
-    resist urgency. Lyrically, her work gravitates toward romanticised melancholy, nostalgia, power imbalance within relationships,
-    Americana iconography, and a tension between glamour and self-destruction. Imagery draws on coastal landscapes, vintage
-    Americana, and a dreamlike Californian mythology. Emotionally, the register is consistently elegiac and wistful, carrying
-    an undertow of fatalism and longing. The mood maintains psychological ambivalence — simultaneously surrendered and self-aware
-    — sustaining a tone of suspended, bittersweet introspection throughout.
+  description: 'Lana Del Rey operates as a vocal-centred artist, her voice occupying
+    a low, breathy mezzo-soprano register layered with reverb and subtle double-tracking,
+    creating an intimate yet cinematic presence. Production is lush and slow-moving,
+    often built on orchestral strings, sub-bass drones, vintage drum machine patterns,
+    and hazy atmospheric pads, favouring spaciousness over density. Studio textures
+    lean heavily toward warmth and analogue softness, with deliberate tempos that
+    resist urgency. Lyrically, her work gravitates toward romanticised melancholy,
+    nostalgia, power imbalance within relationships, Americana iconography, and a
+    tension between glamour and self-destruction. Imagery draws on coastal landscapes,
+    vintage Americana, and a dreamlike Californian mythology. Emotionally, the register
+    is consistently elegiac and wistful, carrying an undertow of fatalism and longing.
+    The mood maintains psychological ambivalence — simultaneously surrendered and
+    self-aware — sustaining a tone of suspended, bittersweet introspection throughout.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4269
+      present: 0.2638
+      future: 0.3093
+    spatial:
+      thing: 0.4281
+      place: 0.3089
+      person: 0.263
+    ontological:
+      imagined: 0.3446
+      forgotten: 0.2975
+      known: 0.3578
+    confidence: 0.0292
   discogs_id: 2445772
   notes: ''
 St. Vincent:
   slug: st_vincent
   status: draft
-  description: 'St. Vincent crafts densely layered, art-rock soundscapes where sculpted guitar textures — ranging from abrasive,
-    angular riffs to pristine, clinical tones — sit against meticulous electronic production. The studio approach favours
-    controlled artificiality: crisp, compressed drums, synthetic warmth, and deliberate timbral contrast between harshness
-    and delicacy. Primarily vocal-led, her voice navigates a wide dynamic range, shifting between intimate vulnerability and
-    theatrical detachment within single compositions. Lyrically, themes explore alienation, consumerism, bodily anxiety, desire,
-    and psychological fragmentation, often rendered through surreal or clinical imagery that blurs the domestic and the uncanny.
-    The emotional register is characteristically ambivalent — simultaneously cold and yearning, ironic and sincere, disorienting
-    yet controlled. Arrangements tend toward tension and release, with dense polyphonic layering punctuated by sudden textural
-    stripping, creating an overall affect of sophisticated unease.
+  description: 'St. Vincent crafts densely layered, art-rock soundscapes where sculpted
+    guitar textures — ranging from abrasive, angular riffs to pristine, clinical tones
+    — sit against meticulous electronic production. The studio approach favours controlled
+    artificiality: crisp, compressed drums, synthetic warmth, and deliberate timbral
+    contrast between harshness and delicacy. Primarily vocal-led, her voice navigates
+    a wide dynamic range, shifting between intimate vulnerability and theatrical detachment
+    within single compositions. Lyrically, themes explore alienation, consumerism,
+    bodily anxiety, desire, and psychological fragmentation, often rendered through
+    surreal or clinical imagery that blurs the domestic and the uncanny. The emotional
+    register is characteristically ambivalent — simultaneously cold and yearning,
+    ironic and sincere, disorienting yet controlled. Arrangements tend toward tension
+    and release, with dense polyphonic layering punctuated by sudden textural stripping,
+    creating an overall affect of sophisticated unease.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4316
+      present: 0.2573
+      future: 0.311
+    spatial:
+      thing: 0.4323
+      place: 0.311
+      person: 0.2567
+    ontological:
+      imagined: 0.3507
+      forgotten: 0.2953
+      known: 0.354
+    confidence: 0.0244
   discogs_id: 849853
   notes: ''
 Toro Y Moi:
   slug: toro_y_moi
   status: draft
-  description: 'Toro Y Moi operates in a layered, warm sonic world rooted in chillwave and bedroom pop production aesthetics.
-    Textures lean toward lush, tape-saturated synthesis, dusty drum machine grooves, and softly compressed guitars blending
-    into dense but intimate arrangements. The studio approach favors analog warmth, subtle lo-fi grain, and carefully sculpted
-    reverb that creates spatial depth without sacrificing clarity. Vocals are present and central, often delivered in a relaxed,
-    breathy mid-range, sometimes treated with light processing to blend into the instrumental bed. Lyrically, themes drift
-    through introspection, leisure, urban ennui, and quiet romantic ambiguity, rendered through impressionistic, everyday
-    imagery with a conversational, non-confrontational tone. The emotional register is consistently mellow and contemplative
-    — nostalgic without sentimentality, restless beneath apparent calm. Psychologically, the music occupies a hazy, afternoon
-    quality, suspended between contentment and mild dissatisfaction.
+  description: 'Toro Y Moi operates in a layered, warm sonic world rooted in chillwave
+    and bedroom pop production aesthetics. Textures lean toward lush, tape-saturated
+    synthesis, dusty drum machine grooves, and softly compressed guitars blending
+    into dense but intimate arrangements. The studio approach favors analog warmth,
+    subtle lo-fi grain, and carefully sculpted reverb that creates spatial depth without
+    sacrificing clarity. Vocals are present and central, often delivered in a relaxed,
+    breathy mid-range, sometimes treated with light processing to blend into the instrumental
+    bed. Lyrically, themes drift through introspection, leisure, urban ennui, and
+    quiet romantic ambiguity, rendered through impressionistic, everyday imagery with
+    a conversational, non-confrontational tone. The emotional register is consistently
+    mellow and contemplative — nostalgic without sentimentality, restless beneath
+    apparent calm. Psychologically, the music occupies a hazy, afternoon quality,
+    suspended between contentment and mild dissatisfaction.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4511
+      present: 0.245
+      future: 0.3039
+    spatial:
+      thing: 0.4519
+      place: 0.304
+      person: 0.2441
+    ontological:
+      imagined: 0.3547
+      forgotten: 0.2872
+      known: 0.3581
+    confidence: 0.0333
   discogs_id: 1362799
   notes: ''
 Tame Impala:
   slug: tame_impala
   status: draft
-  description: 'Tame Impala is a vocal-led project layering sung melodies over densely processed psychedelic rock and electronic
-    pop textures. Production favours saturated, warm analogue tones — fuzz-drenched guitars, pillowy synthesisers, heavily
-    compressed and reverb-soaked drums — creating an immersive, almost liquefied sonic environment. Studio manipulation is
-    central: pitch-shifted vocals, tape flutter, phasing, and tremolo contribute to a woozy, hallucinatory depth. Lyrically,
-    themes circle introspection, self-doubt, emotional paralysis, romantic ambivalence, and the tension between change and
-    stagnation. Imagery tends toward internal landscapes — consciousness, dreams, displacement, and the difficulty of escaping
-    one''s own mind. The emotional register is simultaneously melancholic and euphoric, occupying a psychologically complex
-    middle ground: contemplative yet kinetic, vulnerable yet detached. Rhythmic foundations are often hypnotic and groove-oriented,
-    balancing propulsive energy against a prevailing sense of drifting, suspended time.
+  description: 'Tame Impala is a vocal-led project layering sung melodies over densely
+    processed psychedelic rock and electronic pop textures. Production favours saturated,
+    warm analogue tones — fuzz-drenched guitars, pillowy synthesisers, heavily compressed
+    and reverb-soaked drums — creating an immersive, almost liquefied sonic environment.
+    Studio manipulation is central: pitch-shifted vocals, tape flutter, phasing, and
+    tremolo contribute to a woozy, hallucinatory depth. Lyrically, themes circle introspection,
+    self-doubt, emotional paralysis, romantic ambivalence, and the tension between
+    change and stagnation. Imagery tends toward internal landscapes — consciousness,
+    dreams, displacement, and the difficulty of escaping one''s own mind. The emotional
+    register is simultaneously melancholic and euphoric, occupying a psychologically
+    complex middle ground: contemplative yet kinetic, vulnerable yet detached. Rhythmic
+    foundations are often hypnotic and groove-oriented, balancing propulsive energy
+    against a prevailing sense of drifting, suspended time.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4372
+      present: 0.2518
+      future: 0.311
+    spatial:
+      thing: 0.4382
+      place: 0.3103
+      person: 0.2515
+    ontological:
+      imagined: 0.3467
+      forgotten: 0.2938
+      known: 0.3595
+    confidence: 0.0355
   discogs_id: 1245513
   notes: ''
 The Weeknd:
   slug: the_weeknd
   status: draft
-  description: 'The Weeknd operates primarily as a vocalist within lush, maximalist R&B-pop production environments. Sonically,
-    his work favors dense layering of synthesizers, reverb-saturated vocal stacks, sub-heavy bass, and polished 1980s-inflected
-    electronic textures alongside trap-adjacent percussion and occasional live instrumentation. Production maintains a cinematic,
-    nocturnal quality with significant dynamic contrast between sparse verses and euphoric or crushing choruses. Thematically,
-    lyrics navigate hedonism, emotional dissociation, romantic obsession, self-destruction, and moral ambiguity, frequently
-    employing nocturnal urban imagery and an unreliable-narrator perspective. The tone oscillates between seduction and menace,
-    pleasure and psychological unease, creating a distinctive tension between surface glamour and underlying emptiness. Emotionally,
-    the register is cold yet yearning — detached intimacy, numbness masking vulnerability, and a pervasive sense of melancholic
-    grandiosity. Falsetto and mid-range vocal runs are central expressive tools throughout.
+  description: 'The Weeknd operates primarily as a vocalist within lush, maximalist
+    R&B-pop production environments. Sonically, his work favors dense layering of
+    synthesizers, reverb-saturated vocal stacks, sub-heavy bass, and polished 1980s-inflected
+    electronic textures alongside trap-adjacent percussion and occasional live instrumentation.
+    Production maintains a cinematic, nocturnal quality with significant dynamic contrast
+    between sparse verses and euphoric or crushing choruses. Thematically, lyrics
+    navigate hedonism, emotional dissociation, romantic obsession, self-destruction,
+    and moral ambiguity, frequently employing nocturnal urban imagery and an unreliable-narrator
+    perspective. The tone oscillates between seduction and menace, pleasure and psychological
+    unease, creating a distinctive tension between surface glamour and underlying
+    emptiness. Emotionally, the register is cold yet yearning — detached intimacy,
+    numbness masking vulnerability, and a pervasive sense of melancholic grandiosity.
+    Falsetto and mid-range vocal runs are central expressive tools throughout.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4227
+      present: 0.2666
+      future: 0.3107
+    spatial:
+      thing: 0.4238
+      place: 0.3106
+      person: 0.2656
+    ontological:
+      imagined: 0.3409
+      forgotten: 0.3004
+      known: 0.3588
+    confidence: 0.0204
   discogs_id: 2171152
   notes: ''
 Henry Mancini:
   slug: henry_mancini
   status: draft
-  description: 'Henry Mancini works predominantly in instrumental orchestral jazz, blending lush string arrangements with
-    cool-toned woodwinds, muted brass, and jazz rhythm sections. His sonic texture favors a mid-century studio polish — intimate
-    yet cinematic, with warm analog depth and carefully layered density that never feels cluttered. When vocals appear, they
-    function atmospherically, often wordless or restrained, subordinate to the orchestral palette.
+  description: 'Henry Mancini works predominantly in instrumental orchestral jazz,
+    blending lush string arrangements with cool-toned woodwinds, muted brass, and
+    jazz rhythm sections. His sonic texture favors a mid-century studio polish — intimate
+    yet cinematic, with warm analog depth and carefully layered density that never
+    feels cluttered. When vocals appear, they function atmospherically, often wordless
+    or restrained, subordinate to the orchestral palette.
 
 
-    Thematically, his compositions evoke urban nocturnes, romantic longing, playful intrigue, and cinematic suspense. Imagery
-    tends toward moonlit sophistication, melancholy wandering, and stylized tension — worlds that feel simultaneously glamorous
+    Thematically, his compositions evoke urban nocturnes, romantic longing, playful
+    intrigue, and cinematic suspense. Imagery tends toward moonlit sophistication,
+    melancholy wandering, and stylized tension — worlds that feel simultaneously glamorous
     and quietly wistful.
 
 
-    Emotionally, the register balances cool detachment with understated warmth, occupying a psychological space between melancholy
-    and gentle elation. Moods shift fluidly — from breezy lightness to contemplative stillness — sustained by precise rhythmic
+    Emotionally, the register balances cool detachment with understated warmth, occupying
+    a psychological space between melancholy and gentle elation. Moods shift fluidly
+    — from breezy lightness to contemplative stillness — sustained by precise rhythmic
     elegance and a tonal language that privileges nuance over dramatic extremes.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4517
+      present: 0.2487
+      future: 0.2996
+    spatial:
+      thing: 0.4526
+      place: 0.2997
+      person: 0.2477
+    ontological:
+      imagined: 0.3479
+      forgotten: 0.2872
+      known: 0.3649
+    confidence: 0.0306
   discogs_id: 10529
   notes: ''
 ABBA:
   slug: abba
   status: draft
-  description: 'ABBA''s sound is defined by lush, layered vocal harmonies — primarily female leads over male backing — set
-    within a polished, studio-refined pop production. Sonic textures are dense yet transparent, combining bright synthesizers,
-    melodic electric piano, punchy rhythm guitar, and orchestral string embellishments. Production favours warmth and clarity
-    simultaneously, with vocals sitting prominently forward in the mix. Lyrically, themes circle around romantic longing,
-    relationship dissolution, emotional resilience, and bittersweet nostalgia, rendered in direct, conversational imagery.
-    The tone balances candour with accessibility, often undercutting celebratory musical settings with emotional ambivalence
-    or melancholy subtext. The emotional register oscillates between euphoric lift and underlying wistfulness — surfaces bright
-    and danceable, interior frequently tender or elegiac. The project is fundamentally vocal-centric, with instrumental arrangements
-    functioning as expressive scaffolding rather than focal points.
+  description: 'ABBA''s sound is defined by lush, layered vocal harmonies — primarily
+    female leads over male backing — set within a polished, studio-refined pop production.
+    Sonic textures are dense yet transparent, combining bright synthesizers, melodic
+    electric piano, punchy rhythm guitar, and orchestral string embellishments. Production
+    favours warmth and clarity simultaneously, with vocals sitting prominently forward
+    in the mix. Lyrically, themes circle around romantic longing, relationship dissolution,
+    emotional resilience, and bittersweet nostalgia, rendered in direct, conversational
+    imagery. The tone balances candour with accessibility, often undercutting celebratory
+    musical settings with emotional ambivalence or melancholy subtext. The emotional
+    register oscillates between euphoric lift and underlying wistfulness — surfaces
+    bright and danceable, interior frequently tender or elegiac. The project is fundamentally
+    vocal-centric, with instrumental arrangements functioning as expressive scaffolding
+    rather than focal points.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4326
+      present: 0.2634
+      future: 0.304
+    spatial:
+      thing: 0.4339
+      place: 0.3039
+      person: 0.2622
+    ontological:
+      imagined: 0.3524
+      forgotten: 0.2934
+      known: 0.3543
+    confidence: 0.0312
   discogs_id: 69866
   notes: ''
 OutKast:
   slug: outkast
   status: draft
-  description: 'OutKast blends dense, layered production spanning funk, soul, hip-hop, psychedelia, and Southern gothic textures.
-    Sonically, tracks range from warm analog bass-heavy grooves to crackling, distorted synth arrangements, with deliberate
-    contrasts between lush orchestration and raw, percussive minimalism. The studio approach favors sonic collage — unexpected
-    timbral juxtapositions, live instrumentation woven against electronic programming, and richly saturated spatial depth.
+  description: 'OutKast blends dense, layered production spanning funk, soul, hip-hop,
+    psychedelia, and Southern gothic textures. Sonically, tracks range from warm analog
+    bass-heavy grooves to crackling, distorted synth arrangements, with deliberate
+    contrasts between lush orchestration and raw, percussive minimalism. The studio
+    approach favors sonic collage — unexpected timbral juxtapositions, live instrumentation
+    woven against electronic programming, and richly saturated spatial depth.
 
 
-    Lyrically and thematically, content moves between introspective vulnerability, surreal futurism, Southern identity, social
-    alienation, romantic complexity, and absurdist humor. Imagery tends toward vivid, hyper-specific detail grounded in place
-    and body, oscillating between confessional intimacy and theatrical exaggeration.
+    Lyrically and thematically, content moves between introspective vulnerability,
+    surreal futurism, Southern identity, social alienation, romantic complexity, and
+    absurdist humor. Imagery tends toward vivid, hyper-specific detail grounded in
+    place and body, oscillating between confessional intimacy and theatrical exaggeration.
 
 
-    Emotionally, the register shifts fluidly — euphoric and celebratory, melancholic and searching, dissonant and anxious,
-    occasionally tender. This emotional instability is a defining characteristic.
+    Emotionally, the register shifts fluidly — euphoric and celebratory, melancholic
+    and searching, dissonant and anxious, occasionally tender. This emotional instability
+    is a defining characteristic.
 
 
-    The project is primarily vocal, with two contrasting lyrical voices providing tonal and stylistic duality throughout.
+    The project is primarily vocal, with two contrasting lyrical voices providing
+    tonal and stylistic duality throughout.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4292
+      present: 0.259
+      future: 0.3118
+    spatial:
+      thing: 0.4301
+      place: 0.3116
+      person: 0.2584
+    ontological:
+      imagined: 0.3411
+      forgotten: 0.2984
+      known: 0.3605
+    confidence: 0.0216
   discogs_id: 38561
   notes: ''
 Steve Lacy (4):
   slug: steve_lacy_4
   status: draft
-  description: 'Steve Lacy''s sonic world is built on lo-fi warmth and deliberate imperfection — iPhone-recorded guitars,
-    dusty analog textures, and tight funk-influenced grooves layered beneath polished but intimate production. The density
-    is intentionally sparse in places, allowing breathing room between elements, with vintage-toned guitar riffs sitting alongside
-    neo-soul keyboards and understated rhythmic beds. His work is primarily vocal, featuring a light, slightly airy tenor
-    that blurs genre boundaries between R&B, funk, and indie rock. Lyrically, his themes orbit romantic vulnerability, desire,
-    identity, and emotional ambiguity, often rendered through conversational and sensory imagery that feels simultaneously
-    casual and introspective. The emotional register hovers in a warm, bittersweet zone — longing tinged with ease, tension
-    softened by groove. There is a deliberate blurring of the polished and the rough-edged, creating an emotional texture
-    that feels confessional yet stylistically playful.
+  description: 'Steve Lacy''s sonic world is built on lo-fi warmth and deliberate
+    imperfection — iPhone-recorded guitars, dusty analog textures, and tight funk-influenced
+    grooves layered beneath polished but intimate production. The density is intentionally
+    sparse in places, allowing breathing room between elements, with vintage-toned
+    guitar riffs sitting alongside neo-soul keyboards and understated rhythmic beds.
+    His work is primarily vocal, featuring a light, slightly airy tenor that blurs
+    genre boundaries between R&B, funk, and indie rock. Lyrically, his themes orbit
+    romantic vulnerability, desire, identity, and emotional ambiguity, often rendered
+    through conversational and sensory imagery that feels simultaneously casual and
+    introspective. The emotional register hovers in a warm, bittersweet zone — longing
+    tinged with ease, tension softened by groove. There is a deliberate blurring of
+    the polished and the rough-edged, creating an emotional texture that feels confessional
+    yet stylistically playful.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4145
+      present: 0.2671
+      future: 0.3184
+    spatial:
+      thing: 0.4152
+      place: 0.3182
+      person: 0.2666
+    ontological:
+      imagined: 0.3461
+      forgotten: 0.3031
+      known: 0.3509
+    confidence: 0.0181
   discogs_id: 4740695
   notes: ''
 Mazzy Star:
   slug: mazzy_star
   status: draft
-  description: 'Mazzy Star is primarily a vocal ensemble, centered on a breathy, languid female voice set within spare, unhurried
-    arrangements. Production is warm and analog in character — reverb-laden electric and acoustic guitars, soft drumming,
-    occasional organ or pedal steel — creating a gauzy, intimate density. The sonic texture favors restraint; space and silence
-    are deliberate compositional elements. Lyrically, imagery tends toward dusk, dissolution, longing, wandering, and emotional
-    ambiguity, rendered in simple, elliptical language that resists narrative resolution. Themes of distance — geographical,
-    emotional, temporal — recur alongside impressions of loss and transient desire. The emotional register is melancholic
-    but not despairing: languid, suspended, and introspective, carrying a quality of muted yearning. The overall psychological
-    colour resembles late-afternoon light — faded, soft-edged, and contemplative — evoking a dreamlike stillness that feels
-    both intimate and remote.
+  description: 'Mazzy Star is primarily a vocal ensemble, centered on a breathy, languid
+    female voice set within spare, unhurried arrangements. Production is warm and
+    analog in character — reverb-laden electric and acoustic guitars, soft drumming,
+    occasional organ or pedal steel — creating a gauzy, intimate density. The sonic
+    texture favors restraint; space and silence are deliberate compositional elements.
+    Lyrically, imagery tends toward dusk, dissolution, longing, wandering, and emotional
+    ambiguity, rendered in simple, elliptical language that resists narrative resolution.
+    Themes of distance — geographical, emotional, temporal — recur alongside impressions
+    of loss and transient desire. The emotional register is melancholic but not despairing:
+    languid, suspended, and introspective, carrying a quality of muted yearning. The
+    overall psychological colour resembles late-afternoon light — faded, soft-edged,
+    and contemplative — evoking a dreamlike stillness that feels both intimate and
+    remote.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4223
+      present: 0.2596
+      future: 0.3182
+    spatial:
+      thing: 0.4231
+      place: 0.3175
+      person: 0.2594
+    ontological:
+      imagined: 0.3363
+      forgotten: 0.3045
+      known: 0.3592
+    confidence: 0.0254
   discogs_id: 15262
   notes: ''
 Jessica Pratt:
   slug: jessica_pratt
   status: draft
-  description: 'Jessica Pratt creates intimate, voice-forward folk music with a distinctly vintage sonic palette. Her production
-    favors sparse, close-miked arrangements — fingerpicked acoustic guitar, occasional organ or piano — with a warm, slightly
-    hazy quality suggesting tape recordings or lo-fi studio methods. Density remains deliberately minimal, allowing silence
-    and breath to function as compositional elements.
+  description: 'Jessica Pratt creates intimate, voice-forward folk music with a distinctly
+    vintage sonic palette. Her production favors sparse, close-miked arrangements
+    — fingerpicked acoustic guitar, occasional organ or piano — with a warm, slightly
+    hazy quality suggesting tape recordings or lo-fi studio methods. Density remains
+    deliberately minimal, allowing silence and breath to function as compositional
+    elements.
 
 
-    Lyrically, her work gravitates toward dreamlike, elliptical imagery — fragmented observations of time, memory, longing,
-    and interior states. Themes resist direct narrative, instead accumulating associative impressions with an almost surrealist
+    Lyrically, her work gravitates toward dreamlike, elliptical imagery — fragmented
+    observations of time, memory, longing, and interior states. Themes resist direct
+    narrative, instead accumulating associative impressions with an almost surrealist
     quality. Language is carefully chosen, occasionally archaic in phrasing.
 
 
-    Her emotional register is hushed and contemplative, carrying an undertow of melancholy and gentle disorientation. The
-    psychological colour is introspective and slightly spectral — present yet distant, as if recalled rather than experienced.
-    Her voice — high, wavering, softly vibrato — functions simultaneously as instrument and primary expressive vehicle.
+    Her emotional register is hushed and contemplative, carrying an undertow of melancholy
+    and gentle disorientation. The psychological colour is introspective and slightly
+    spectral — present yet distant, as if recalled rather than experienced. Her voice
+    — high, wavering, softly vibrato — functions simultaneously as instrument and
+    primary expressive vehicle.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4233
+      present: 0.2638
+      future: 0.313
+    spatial:
+      thing: 0.4242
+      place: 0.3126
+      person: 0.2631
+    ontological:
+      imagined: 0.3403
+      forgotten: 0.3013
+      known: 0.3585
+    confidence: 0.0287
   discogs_id: 2084222
   notes: ''
 Halsey:
   slug: halsey
   status: draft
-  description: 'Halsey is a vocal-forward artist whose work blends pop, alternative, and industrial textures across a wide
-    sonic spectrum. Production ranges from sparse, intimate bedroom-pop atmospheres to dense, distorted, and abrasive soundscapes
-    with heavy electronic layering. Vocals shift between breathy vulnerability and raw, chest-forward intensity, often processed
-    with subtle effects to blur warmth and artifice. Lyrically, themes orbit duality, fractured identity, romantic obsession,
-    mental instability, and bodily experience, frequently employing vivid, visceral imagery and contrasting softness with
-    aggression. Imagery often draws from blood, fire, water, and liminal spaces. The emotional register is restless and psychologically
-    saturated — oscillating between euphoria and despair, tenderness and rage, intimacy and alienation. Arrangements frequently
-    use dynamic contrast, shifting abruptly from delicate passages to overdriven, wall-of-sound moments, reflecting an interior
+  description: 'Halsey is a vocal-forward artist whose work blends pop, alternative,
+    and industrial textures across a wide sonic spectrum. Production ranges from sparse,
+    intimate bedroom-pop atmospheres to dense, distorted, and abrasive soundscapes
+    with heavy electronic layering. Vocals shift between breathy vulnerability and
+    raw, chest-forward intensity, often processed with subtle effects to blur warmth
+    and artifice. Lyrically, themes orbit duality, fractured identity, romantic obsession,
+    mental instability, and bodily experience, frequently employing vivid, visceral
+    imagery and contrasting softness with aggression. Imagery often draws from blood,
+    fire, water, and liminal spaces. The emotional register is restless and psychologically
+    saturated — oscillating between euphoria and despair, tenderness and rage, intimacy
+    and alienation. Arrangements frequently use dynamic contrast, shifting abruptly
+    from delicate passages to overdriven, wall-of-sound moments, reflecting an interior
     emotional volatility embedded directly into the compositional architecture.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4149
+      present: 0.2661
+      future: 0.319
+    spatial:
+      thing: 0.4157
+      place: 0.3186
+      person: 0.2657
+    ontological:
+      imagined: 0.3467
+      forgotten: 0.3037
+      known: 0.3495
+    confidence: 0.0197
   discogs_id: 4298621
   notes: ''
 Perfume Genius:
   slug: perfume_genius
   status: draft
-  description: 'Perfume Genius is a primarily vocal artist whose music blends intimate chamber-pop with moments of abrasive,
-    distorted grandeur. Production ranges from sparse, close-miked piano and voice to lush orchestral arrangements and industrial-tinged
-    rock surges, creating stark contrasts between vulnerability and aggression. The sonic palette shifts between delicate,
-    whispering textures and dense, layered walls of sound with dramatic dynamic tension. Lyrically, themes circle around bodily
-    experience, shame, desire, queerness, tenderness, and the negotiation of identity under social or religious pressure,
-    often employing visceral physical imagery alongside moments of transcendence and defiance. The emotional register is psychologically
-    complex — simultaneously fragile and fierce, mournful and ecstatic, self-exposing and confrontational. Vocals are central,
-    delivered in a falsetto-leaning, intimate tone that can shift toward raw intensity. The overall aesthetic merges confessional
-    songwriting with experimental production sensibility, creating music of pronounced emotional and textural contrast.
+  description: 'Perfume Genius is a primarily vocal artist whose music blends intimate
+    chamber-pop with moments of abrasive, distorted grandeur. Production ranges from
+    sparse, close-miked piano and voice to lush orchestral arrangements and industrial-tinged
+    rock surges, creating stark contrasts between vulnerability and aggression. The
+    sonic palette shifts between delicate, whispering textures and dense, layered
+    walls of sound with dramatic dynamic tension. Lyrically, themes circle around
+    bodily experience, shame, desire, queerness, tenderness, and the negotiation of
+    identity under social or religious pressure, often employing visceral physical
+    imagery alongside moments of transcendence and defiance. The emotional register
+    is psychologically complex — simultaneously fragile and fierce, mournful and ecstatic,
+    self-exposing and confrontational. Vocals are central, delivered in a falsetto-leaning,
+    intimate tone that can shift toward raw intensity. The overall aesthetic merges
+    confessional songwriting with experimental production sensibility, creating music
+    of pronounced emotional and textural contrast.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4239
+      present: 0.2607
+      future: 0.3154
+    spatial:
+      thing: 0.4247
+      place: 0.3149
+      person: 0.2603
+    ontological:
+      imagined: 0.35
+      forgotten: 0.298
+      known: 0.3519
+    confidence: 0.0243
   discogs_id: 1741195
   notes: ''
 Frank Ocean:
   slug: frank_ocean
   status: draft
-  description: 'Frank Ocean is a primarily vocal artist whose productions are dense yet intimate, layered with manipulated
-    vocal samples, pitch-shifted harmonics, and soft synthesizer beds beneath understated percussion. Studio treatment emphasizes
-    textural warmth—analog saturation, reverb tails, and fragmented sonic collage sit alongside moments of stark minimalism.
-    Lyrically, his work circles themes of desire, nostalgia, identity, memory, and longing, rendered through fragmented, impressionistic
-    imagery with a confessional yet elliptical tone. Timbre favors gentle falsetto and mid-register singing, often heavily
-    processed or doubled, creating an introspective quality. Emotionally, the register is quietly melancholic yet tender—psychologically
-    complex, suspended between vulnerability and detachment. Compositions frequently shift in texture mid-song, moving between
-    lush orchestration and sparse, near-skeletal arrangements, giving the work an introspective, stream-of-consciousness feel
-    that resists easy resolution.
+  description: 'Frank Ocean is a primarily vocal artist whose productions are dense
+    yet intimate, layered with manipulated vocal samples, pitch-shifted harmonics,
+    and soft synthesizer beds beneath understated percussion. Studio treatment emphasizes
+    textural warmth—analog saturation, reverb tails, and fragmented sonic collage
+    sit alongside moments of stark minimalism. Lyrically, his work circles themes
+    of desire, nostalgia, identity, memory, and longing, rendered through fragmented,
+    impressionistic imagery with a confessional yet elliptical tone. Timbre favors
+    gentle falsetto and mid-register singing, often heavily processed or doubled,
+    creating an introspective quality. Emotionally, the register is quietly melancholic
+    yet tender—psychologically complex, suspended between vulnerability and detachment.
+    Compositions frequently shift in texture mid-song, moving between lush orchestration
+    and sparse, near-skeletal arrangements, giving the work an introspective, stream-of-consciousness
+    feel that resists easy resolution.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4352
+      present: 0.2554
+      future: 0.3094
+    spatial:
+      thing: 0.436
+      place: 0.3092
+      person: 0.2548
+    ontological:
+      imagined: 0.3509
+      forgotten: 0.2935
+      known: 0.3556
+    confidence: 0.0273
   discogs_id: 2013868
   notes: ''
 Amanda Lear:
   slug: amanda_lear
   status: draft
-  description: 'Amanda Lear operates primarily as a vocal artist within a lush, synthetic sonic environment rooted in late-1970s
-    European disco and electronic pop. Production textures are dense and polished, layering orchestral strings against pulsing
-    synthesisers, four-on-the-floor percussion, and deep, warm bass lines. Her vocal delivery is notably low and spoken-adjacent,
-    hovering between singing and a theatrical, seductive monologue, giving recordings an almost cinematic quality. Studio
-    treatment typically applies heavy reverb and glossy compression, creating an expansive, slightly decadent atmosphere.
-    Lyrically, themes revolve around desire, power, persona, fantasy, and glamour — imagery is often nocturnal, urbane, and
-    self-mythologising. The tone carries a cool detachment undercut with latent intensity. Emotionally, the register is sophisticated
-    and aloof yet charged with sensuality, evoking an artificial paradise — controlled, sleek, and theatrically seductive
-    rather than rawly expressive.
+  description: 'Amanda Lear operates primarily as a vocal artist within a lush, synthetic
+    sonic environment rooted in late-1970s European disco and electronic pop. Production
+    textures are dense and polished, layering orchestral strings against pulsing synthesisers,
+    four-on-the-floor percussion, and deep, warm bass lines. Her vocal delivery is
+    notably low and spoken-adjacent, hovering between singing and a theatrical, seductive
+    monologue, giving recordings an almost cinematic quality. Studio treatment typically
+    applies heavy reverb and glossy compression, creating an expansive, slightly decadent
+    atmosphere. Lyrically, themes revolve around desire, power, persona, fantasy,
+    and glamour — imagery is often nocturnal, urbane, and self-mythologising. The
+    tone carries a cool detachment undercut with latent intensity. Emotionally, the
+    register is sophisticated and aloof yet charged with sensuality, evoking an artificial
+    paradise — controlled, sleek, and theatrically seductive rather than rawly expressive.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4144
+      present: 0.27
+      future: 0.3156
+    spatial:
+      thing: 0.4155
+      place: 0.315
+      person: 0.2694
+    ontological:
+      imagined: 0.3532
+      forgotten: 0.2999
+      known: 0.3469
+    confidence: 0.0225
   discogs_id: 51229
   notes: ''
 Nico (3):
   slug: nico_3
   status: draft
-  description: 'Nico''s vocal works are defined by a stark, cavernous sonic texture — sparse arrangements built around harmonium
-    drones, minimal percussion, and modal chord structures that resist conventional resolution. The production character leans
-    toward deliberate austerity, favouring raw, close-miked acoustics over polish, with density achieved through sustained
-    tones rather than layering. Lyrically, her material gravitates toward existential weight, mortality, spiritual desolation,
-    and occult or mythological imagery rendered in cold, detached language. Thematic darkness is treated with clinical distance
-    rather than sentimentality. The emotional register is glacial and sepulchral — evoking psychological states of dissociation,
-    alienation, and muted grief, rarely softening toward warmth. Her work is primarily vocal, with the voice itself — a deep,
-    heavily accented contralto — functioning as a primary textural instrument, its unusual timbre inseparable from the overall
+  description: 'Nico''s vocal works are defined by a stark, cavernous sonic texture
+    — sparse arrangements built around harmonium drones, minimal percussion, and modal
+    chord structures that resist conventional resolution. The production character
+    leans toward deliberate austerity, favouring raw, close-miked acoustics over polish,
+    with density achieved through sustained tones rather than layering. Lyrically,
+    her material gravitates toward existential weight, mortality, spiritual desolation,
+    and occult or mythological imagery rendered in cold, detached language. Thematic
+    darkness is treated with clinical distance rather than sentimentality. The emotional
+    register is glacial and sepulchral — evoking psychological states of dissociation,
+    alienation, and muted grief, rarely softening toward warmth. Her work is primarily
+    vocal, with the voice itself — a deep, heavily accented contralto — functioning
+    as a primary textural instrument, its unusual timbre inseparable from the overall
     compositional atmosphere.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4245
+      present: 0.2621
+      future: 0.3134
+    spatial:
+      thing: 0.4254
+      place: 0.3132
+      person: 0.2615
+    ontological:
+      imagined: 0.3366
+      forgotten: 0.3034
+      known: 0.3599
+    confidence: 0.0233
   discogs_id: 158676
   notes: ''
 DJ Koze:
   slug: dj_koze
   status: draft
-  description: 'DJ Koze operates in a dreamlike space where organic warmth and digital precision coexist. His productions
-    layer sun-bleached samples, languid synthesizer pads, and unhurried percussion into a dense yet breathing sonic fabric,
-    favoring warmth over clinical sharpness. Studio treatment emphasizes slow dissolution — elements fade, blur, and resurface
-    rather than snap into place, creating a hazy, humid textural depth. Vocal contributions appear frequently, sourced from
-    collaborators, and carry an intimate, almost confessional quality; thematically, they orbit longing, sensory pleasure,
-    transformation, and wistful introspection. Imagery tends toward the natural, the fleeting, and the quietly surreal. Emotionally,
-    the register hovers between melancholy and euphoria — a bittersweet suspension that resists resolution. The mood is contemplative
-    but bodied, rooted in dancefloor physicality while pulling consistently inward. Tempos remain measured, allowing texture
-    and atmosphere to bear the primary compositional weight.
+  description: 'DJ Koze operates in a dreamlike space where organic warmth and digital
+    precision coexist. His productions layer sun-bleached samples, languid synthesizer
+    pads, and unhurried percussion into a dense yet breathing sonic fabric, favoring
+    warmth over clinical sharpness. Studio treatment emphasizes slow dissolution —
+    elements fade, blur, and resurface rather than snap into place, creating a hazy,
+    humid textural depth. Vocal contributions appear frequently, sourced from collaborators,
+    and carry an intimate, almost confessional quality; thematically, they orbit longing,
+    sensory pleasure, transformation, and wistful introspection. Imagery tends toward
+    the natural, the fleeting, and the quietly surreal. Emotionally, the register
+    hovers between melancholy and euphoria — a bittersweet suspension that resists
+    resolution. The mood is contemplative but bodied, rooted in dancefloor physicality
+    while pulling consistently inward. Tempos remain measured, allowing texture and
+    atmosphere to bear the primary compositional weight.
 
     '
   style_tags: []
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4401
+      present: 0.2546
+      future: 0.3052
+    spatial:
+      thing: 0.441
+      place: 0.3052
+      person: 0.2538
+    ontological:
+      imagined: 0.3419
+      forgotten: 0.2929
+      known: 0.3652
+    confidence: 0.034
   discogs_id: 8260
   notes: ''
 The Jesus and Mary Chain:
   slug: the_jesus_and_mary_chain
   status: draft
-  description: 'The Jesus and Mary Chain layer dense, distorted guitar noise over deceptively simple pop structures, creating
-    a wall of feedback and hiss that functions as texture rather than chaos. Production is deliberately lo-fi and saturated,
-    with trebly, buzzing guitars burying melodic hooks beneath sheets of white noise. Rhythm sections are sparse and mechanical,
-    often driven by drum machines. The sound is simultaneously abrasive and dreamy, balancing harshness with underlying sweetness.
+  description: 'The Jesus and Mary Chain layer dense, distorted guitar noise over
+    deceptively simple pop structures, creating a wall of feedback and hiss that functions
+    as texture rather than chaos. Production is deliberately lo-fi and saturated,
+    with trebly, buzzing guitars burying melodic hooks beneath sheets of white noise.
+    Rhythm sections are sparse and mechanical, often driven by drum machines. The
+    sound is simultaneously abrasive and dreamy, balancing harshness with underlying
+    sweetness.
 
 
-    Vocals are central, delivered in a detached, near-monotone baritone that conveys emotional numbness rather than expressiveness.
-    Lyrical themes circle obsession, desire, alienation, self-destruction, and a romanticised darkness — imagery tends toward
-    the nocturnal, the transgressive, and the melancholic.
+    Vocals are central, delivered in a detached, near-monotone baritone that conveys
+    emotional numbness rather than expressiveness. Lyrical themes circle obsession,
+    desire, alienation, self-destruction, and a romanticised darkness — imagery tends
+    toward the nocturnal, the transgressive, and the melancholic.
 
 
-    The emotional register is psychologically cool yet internally intense — numbness masking yearning. The overall affect
-    suggests detachment as a defence mechanism against overwhelming feeling, blending nihilism with suppressed romanticism.
+    The emotional register is psychologically cool yet internally intense — numbness
+    masking yearning. The overall affect suggests detachment as a defence mechanism
+    against overwhelming feeling, blending nihilism with suppressed romanticism.
 
     '
   style_tags: *id001
-  chromatic_score: null
+  chromatic_score:
+    temporal:
+      past: 0.4321
+      present: 0.2604
+      future: 0.3074
+    spatial:
+      thing: 0.4333
+      place: 0.3071
+      person: 0.2596
+    ontological:
+      imagined: 0.3534
+      forgotten: 0.2929
+      known: 0.3537
+    confidence: 0.0298
   discogs_id: 243280
   notes: (canonical spelling — same entry as 'The Jesus And Mary Chain')
-
 Bruce Springsteen:
   slug: bruce_springsteen
   status: draft
-  description: |
-    Bruce Springsteen is a vocal-forward artist whose work centers on storytelling through plainspoken yet emotionally charged imagery—working-class landscapes, open highways, industrial towns, and characters caught between aspiration and resignation. His sonic palette blends muscular rock instrumentation with soulful undertones: prominent saxophone, layered guitars, organ, and propulsive rhythm sections create dense, arena-scaled textures. Production ranges from raw and live-feeling to polished and anthemic, often emphasizing dynamic contrast—sparse verses opening into expansive choruses. Lyrically, recurring motifs include escape, loyalty, disillusionment, love under pressure, and American mythology examined with both romanticism and grit. Emotionally, his register oscillates between defiant energy and brooding melancholy, frequently holding both simultaneously. His voice—raspy, earnest, and physically committed—functions as the primary instrument, carrying a psychological weight that blends communal solidarity with deep personal longing.
-  style_tags: []
-  # chromatic_hint:
-  #   temporal: past | present | future
-  #   spatial: thing | place | person
-  #   ontological: imagined | forgotten | known
-  chromatic_score: null
-  discogs_id: null
-  notes: ""
+  description: 'Bruce Springsteen is a vocal-forward artist whose work centers on
+    storytelling through plainspoken yet emotionally charged imagery—working-class
+    landscapes, open highways, industrial towns, and characters caught between aspiration
+    and resignation. His sonic palette blends muscular rock instrumentation with soulful
+    undertones: prominent saxophone, layered guitars, organ, and propulsive rhythm
+    sections create dense, arena-scaled textures. Production ranges from raw and live-feeling
+    to polished and anthemic, often emphasizing dynamic contrast—sparse verses opening
+    into expansive choruses. Lyrically, recurring motifs include escape, loyalty,
+    disillusionment, love under pressure, and American mythology examined with both
+    romanticism and grit. Emotionally, his register oscillates between defiant energy
+    and brooding melancholy, frequently holding both simultaneously. His voice—raspy,
+    earnest, and physically committed—functions as the primary instrument, carrying
+    a psychological weight that blends communal solidarity with deep personal longing.
 
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4401
+      present: 0.2538
+      future: 0.3061
+    spatial:
+      thing: 0.4412
+      place: 0.3059
+      person: 0.2529
+    ontological:
+      imagined: 0.3523
+      forgotten: 0.2912
+      known: 0.3565
+    confidence: 0.0305
+  discogs_id: null
+  notes: ''
 Lankum:
   slug: lankum
   status: draft
-  description: |
-    Lankum creates dense, drone-saturated folk music with a heavily layered sonic texture. Their production favours slow accumulation — instruments and voices building into overwhelming, almost suffocating walls of sound, with uilleann pipes, fiddle, and concertina generating sustained, reedy timbres beneath close-miked vocals. The approach is deliberately raw yet immersive, favouring long arcs of tension over conventional structure. Lyrically, they draw on traditional balladry, exploring death, suffering, poverty, moral corruption, and the grinding weight of ordinary life, rendered through stark, plainspoken imagery with roots in Irish and British folk traditions. The emotional register is dark, mournful, and fatalistic — occasionally tipping into something ritualistic or trance-inducing. Vocals are central, often unison or close harmony, sitting within rather than above the instrumental texture, creating a communal, incantatory quality throughout.
-  style_tags: []
-  # chromatic_hint:
-  #   temporal: past | present | future
-  #   spatial: thing | place | person
-  #   ontological: imagined | forgotten | known
-  chromatic_score: null
-  discogs_id: null
-  notes: ""
+  description: 'Lankum creates dense, drone-saturated folk music with a heavily layered
+    sonic texture. Their production favours slow accumulation — instruments and voices
+    building into overwhelming, almost suffocating walls of sound, with uilleann pipes,
+    fiddle, and concertina generating sustained, reedy timbres beneath close-miked
+    vocals. The approach is deliberately raw yet immersive, favouring long arcs of
+    tension over conventional structure. Lyrically, they draw on traditional balladry,
+    exploring death, suffering, poverty, moral corruption, and the grinding weight
+    of ordinary life, rendered through stark, plainspoken imagery with roots in Irish
+    and British folk traditions. The emotional register is dark, mournful, and fatalistic
+    — occasionally tipping into something ritualistic or trance-inducing. Vocals are
+    central, often unison or close harmony, sitting within rather than above the instrumental
+    texture, creating a communal, incantatory quality throughout.
 
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4229
+      present: 0.2603
+      future: 0.3169
+    spatial:
+      thing: 0.4239
+      place: 0.3163
+      person: 0.2598
+    ontological:
+      imagined: 0.3525
+      forgotten: 0.3017
+      known: 0.3458
+    confidence: 0.0224
+  discogs_id: null
+  notes: ''
 Phosphorescent:
   slug: phosphorescent
   status: draft
-  description: |
-    Phosphorescent blends intimate, weathered folk with slow-burning country and gospel, wrapped in a hazy, reverb-drenched production aesthetic. The sonic texture favors warm analog warmth — dusty guitars, pedal steel, understated percussion, and layered vocal harmonies that drift like smoke through open space. Production is simultaneously sparse and immersive, with deliberate lo-fi graininess softened by luminous, cathedral-like reverb. Lyrically, the work gravitates toward longing, spiritual searching, romantic dissolution, and the ache of impermanence, rendered through elemental imagery — night skies, rivers, light, wandering. The tone is confessional yet mythic, personal grief elevated into something ritualistic. Emotionally, the register is melancholic but not despairing — suffused with a bittersweet transcendence, a yearning that feels both exhausted and quietly luminous. The project is primarily vocal-led, with Matthew Houck's rough-hewn, emotionally exposed voice as the central instrument.
-  style_tags: []
-  # chromatic_hint:
-  #   temporal: past | present | future
-  #   spatial: thing | place | person
-  #   ontological: imagined | forgotten | known
-  chromatic_score: null
-  discogs_id: null
-  notes: ""
+  description: 'Phosphorescent blends intimate, weathered folk with slow-burning country
+    and gospel, wrapped in a hazy, reverb-drenched production aesthetic. The sonic
+    texture favors warm analog warmth — dusty guitars, pedal steel, understated percussion,
+    and layered vocal harmonies that drift like smoke through open space. Production
+    is simultaneously sparse and immersive, with deliberate lo-fi graininess softened
+    by luminous, cathedral-like reverb. Lyrically, the work gravitates toward longing,
+    spiritual searching, romantic dissolution, and the ache of impermanence, rendered
+    through elemental imagery — night skies, rivers, light, wandering. The tone is
+    confessional yet mythic, personal grief elevated into something ritualistic. Emotionally,
+    the register is melancholic but not despairing — suffused with a bittersweet transcendence,
+    a yearning that feels both exhausted and quietly luminous. The project is primarily
+    vocal-led, with Matthew Houck''s rough-hewn, emotionally exposed voice as the
+    central instrument.
 
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4193
+      present: 0.265
+      future: 0.3156
+    spatial:
+      thing: 0.4203
+      place: 0.3152
+      person: 0.2645
+    ontological:
+      imagined: 0.352
+      forgotten: 0.2991
+      known: 0.3489
+    confidence: 0.0282
+  discogs_id: null
+  notes: ''
 The National:
   slug: the_national
   status: draft
-  description: |
-    The National is a vocal-led ensemble with a distinctive baritone voice anchoring dense, layered arrangements. Sonically, production favors orchestral accretion — strings, horns, and treated guitars build gradually over spare rhythmic foundations, creating a warm yet pressurized studio texture. Dynamic shifts move between hushed intimacy and swelling, near-cathartic release without dramatic rupture. Lyrically, imagery draws from domestic interiors, urban alienation, and strained relationships, rendered through fragmented, oblique observation rather than direct narrative. Themes circle adult anxiety, middle-class discomfort, memory, and emotional paralysis. The tone is cerebral but emotionally porous — irony and vulnerability coexist without resolution. The emotional register occupies a sustained, melancholic tension: rarely outright despairing, rarely resolved, hovering in a grey-lit psychological space that feels simultaneously private and expansive. Rhythmic structures tend toward propulsive steadiness beneath the textural complexity.
-  style_tags: []
-  # chromatic_hint:
-  #   temporal: past | present | future
-  #   spatial: thing | place | person
-  #   ontological: imagined | forgotten | known
-  chromatic_score: null
-  discogs_id: null
-  notes: ""
+  description: 'The National is a vocal-led ensemble with a distinctive baritone voice
+    anchoring dense, layered arrangements. Sonically, production favors orchestral
+    accretion — strings, horns, and treated guitars build gradually over spare rhythmic
+    foundations, creating a warm yet pressurized studio texture. Dynamic shifts move
+    between hushed intimacy and swelling, near-cathartic release without dramatic
+    rupture. Lyrically, imagery draws from domestic interiors, urban alienation, and
+    strained relationships, rendered through fragmented, oblique observation rather
+    than direct narrative. Themes circle adult anxiety, middle-class discomfort, memory,
+    and emotional paralysis. The tone is cerebral but emotionally porous — irony and
+    vulnerability coexist without resolution. The emotional register occupies a sustained,
+    melancholic tension: rarely outright despairing, rarely resolved, hovering in
+    a grey-lit psychological space that feels simultaneously private and expansive.
+    Rhythmic structures tend toward propulsive steadiness beneath the textural complexity.
 
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4351
+      present: 0.2564
+      future: 0.3084
+    spatial:
+      thing: 0.4357
+      place: 0.3085
+      person: 0.2558
+    ontological:
+      imagined: 0.3444
+      forgotten: 0.2939
+      known: 0.3618
+    confidence: 0.0185
+  discogs_id: null
+  notes: ''
 boards of canada:
   slug: boards_of_canada
   status: draft
-  description: |
-    Boards of Canada craft densely layered electronic music built from warm, degraded analogue textures — tape hiss, detuned synthesisers, dusty samples, and softly decayed timbres that evoke aged film stock and half-remembered childhood. Production feels deliberately eroded, as though sounds have been buried underground and partially excavated. Low-frequency drones anchor hypnotic rhythmic patterns, while melodic fragments drift in and out of audibility. The work is primarily instrumental, though occasional vocal fragments — heavily processed, pitched, or obscured — surface as textural elements rather than lyrical carriers. Thematically, imagery clusters around nostalgia, nature, hidden knowledge, and temporal dislocation — a sense of something lost or just beyond reach. The emotional register is simultaneously comforting and unsettling: pastoral warmth undercut by unease, meditative calm shadowed by melancholy, innocence tinged with something faintly ominous.
-  style_tags: []
-  # chromatic_hint:
-  #   temporal: past | present | future
-  #   spatial: thing | place | person
-  #   ontological: imagined | forgotten | known
-  chromatic_score: null
-  discogs_id: null
-  notes: ""
+  description: 'Boards of Canada craft densely layered electronic music built from
+    warm, degraded analogue textures — tape hiss, detuned synthesisers, dusty samples,
+    and softly decayed timbres that evoke aged film stock and half-remembered childhood.
+    Production feels deliberately eroded, as though sounds have been buried underground
+    and partially excavated. Low-frequency drones anchor hypnotic rhythmic patterns,
+    while melodic fragments drift in and out of audibility. The work is primarily
+    instrumental, though occasional vocal fragments — heavily processed, pitched,
+    or obscured — surface as textural elements rather than lyrical carriers. Thematically,
+    imagery clusters around nostalgia, nature, hidden knowledge, and temporal dislocation
+    — a sense of something lost or just beyond reach. The emotional register is simultaneously
+    comforting and unsettling: pastoral warmth undercut by unease, meditative calm
+    shadowed by melancholy, innocence tinged with something faintly ominous.
 
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.452
+      present: 0.2472
+      future: 0.3007
+    spatial:
+      thing: 0.453
+      place: 0.3005
+      person: 0.2465
+    ontological:
+      imagined: 0.3514
+      forgotten: 0.2844
+      known: 0.3641
+    confidence: 0.0335
+  discogs_id: null
+  notes: ''
 arca:
   slug: arca
   status: draft
-  description: |
-    Arca's sonic world is built on fractured, mutating textures — hyper-compressed percussion, smeared bass frequencies, and synthetic flesh that feels simultaneously organic and alien. Production density shifts violently between cavernous negative space and overwhelming tactile noise, with meticulous layering of glitched, warped timbres that resist conventional rhythmic grids. Vocals are integrated as another textural element — stretched, pitch-shifted, and processed beyond naturalism — making the work essentially hybrid rather than purely instrumental. Thematically, the work circles transformation, bodily dissolution, identity as fluid and unstable, eros entangled with violence, and the posthuman body. Imagery tends toward visceral abstraction — flesh, machinery, rupture, metamorphosis. The emotional register is intensely psychological: simultaneously erotic and anxious, tender and confrontational, euphoric and dysphoric. There is a consistent atmosphere of threshold states — between genders, between human and machine, between pleasure and pain.
-  style_tags: []
-  # chromatic_hint:
-  #   temporal: past | present | future
-  #   spatial: thing | place | person
-  #   ontological: imagined | forgotten | known
-  chromatic_score: null
-  discogs_id: null
-  notes: ""
+  description: 'Arca''s sonic world is built on fractured, mutating textures — hyper-compressed
+    percussion, smeared bass frequencies, and synthetic flesh that feels simultaneously
+    organic and alien. Production density shifts violently between cavernous negative
+    space and overwhelming tactile noise, with meticulous layering of glitched, warped
+    timbres that resist conventional rhythmic grids. Vocals are integrated as another
+    textural element — stretched, pitch-shifted, and processed beyond naturalism —
+    making the work essentially hybrid rather than purely instrumental. Thematically,
+    the work circles transformation, bodily dissolution, identity as fluid and unstable,
+    eros entangled with violence, and the posthuman body. Imagery tends toward visceral
+    abstraction — flesh, machinery, rupture, metamorphosis. The emotional register
+    is intensely psychological: simultaneously erotic and anxious, tender and confrontational,
+    euphoric and dysphoric. There is a consistent atmosphere of threshold states —
+    between genders, between human and machine, between pleasure and pain.
 
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4075
+      present: 0.2674
+      future: 0.3251
+    spatial:
+      thing: 0.4082
+      place: 0.3244
+      person: 0.2674
+    ontological:
+      imagined: 0.337
+      forgotten: 0.3108
+      known: 0.3522
+    confidence: 0.0148
+  discogs_id: null
+  notes: ''
 autechre:
   slug: autechre
   status: draft
-  description: |
-    Autechre is primarily instrumental, eschewing vocals almost entirely in favour of pure sound design. Their sonic texture is dense, mechanical, and deeply synthetic — built from heavily processed rhythmic fragments, glitched percussion grids, and evolving modular or algorithmic timbres that resist conventional groove while maintaining internal logic. Production character is cold, precise, and spatially complex, with sounds occupying unusual frequency relationships and stereo positions. Low-end weight alternates with brittle, granular upper-register detail. Thematically, there is no lyrical content; instead, compositional themes suggest industrial abstraction, machine cognition, and the aesthetic of systems operating beyond human intention. The emotional register is detached yet immersive — not hostile, but clinical and alien, occasionally giving way to passages of unexpected warmth buried within layered synthesis. Psychological colour tends toward introspection, spatial disorientation, and a kind of meditative tension sustained across long formal structures.
-  style_tags: []
-  # chromatic_hint:
-  #   temporal: past | present | future
-  #   spatial: thing | place | person
-  #   ontological: imagined | forgotten | known
-  chromatic_score: null
-  discogs_id: null
-  notes: ""
+  description: 'Autechre is primarily instrumental, eschewing vocals almost entirely
+    in favour of pure sound design. Their sonic texture is dense, mechanical, and
+    deeply synthetic — built from heavily processed rhythmic fragments, glitched percussion
+    grids, and evolving modular or algorithmic timbres that resist conventional groove
+    while maintaining internal logic. Production character is cold, precise, and spatially
+    complex, with sounds occupying unusual frequency relationships and stereo positions.
+    Low-end weight alternates with brittle, granular upper-register detail. Thematically,
+    there is no lyrical content; instead, compositional themes suggest industrial
+    abstraction, machine cognition, and the aesthetic of systems operating beyond
+    human intention. The emotional register is detached yet immersive — not hostile,
+    but clinical and alien, occasionally giving way to passages of unexpected warmth
+    buried within layered synthesis. Psychological colour tends toward introspection,
+    spatial disorientation, and a kind of meditative tension sustained across long
+    formal structures.
 
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4588
+      present: 0.2407
+      future: 0.3006
+    spatial:
+      thing: 0.4595
+      place: 0.3006
+      person: 0.2399
+    ontological:
+      imagined: 0.3481
+      forgotten: 0.2865
+      known: 0.3653
+    confidence: 0.0278
+  discogs_id: null
+  notes: ''
 burial:
   slug: burial
   status: draft
-  description: |
-    Burial crafts music primarily through dense, textural layering — cracked vinyl hiss, pitched-down vocal fragments, sub-bass rumble, and stuttering percussion that mimics broken drum machines. The production aesthetic embraces lo-fi warmth against cold, cavernous space, creating an urban nocturnal atmosphere. Vocals appear as processed, ghostly samples — half-buried, genderless, emotionally raw — rather than conventional songwriting, placing the work closer to instrumental ambient music despite their presence. Thematically, the work orbits late-night solitude, longing, grief, and the melancholic romanticism of city darkness — rain-soaked streets, distant crowds, emotional isolation within proximity to others. Textures shift slowly, structures dissolve rather than resolve. The emotional register is consistently elegiac and introspective, carrying an ache that feels both personal and strangely collective — private emotion rendered through decayed, anonymous sonic materials.
-  style_tags: []
-  # chromatic_hint:
-  #   temporal: past | present | future
-  #   spatial: thing | place | person
-  #   ontological: imagined | forgotten | known
-  chromatic_score: null
-  discogs_id: null
-  notes: ""
+  description: 'Burial crafts music primarily through dense, textural layering — cracked
+    vinyl hiss, pitched-down vocal fragments, sub-bass rumble, and stuttering percussion
+    that mimics broken drum machines. The production aesthetic embraces lo-fi warmth
+    against cold, cavernous space, creating an urban nocturnal atmosphere. Vocals
+    appear as processed, ghostly samples — half-buried, genderless, emotionally raw
+    — rather than conventional songwriting, placing the work closer to instrumental
+    ambient music despite their presence. Thematically, the work orbits late-night
+    solitude, longing, grief, and the melancholic romanticism of city darkness — rain-soaked
+    streets, distant crowds, emotional isolation within proximity to others. Textures
+    shift slowly, structures dissolve rather than resolve. The emotional register
+    is consistently elegiac and introspective, carrying an ache that feels both personal
+    and strangely collective — private emotion rendered through decayed, anonymous
+    sonic materials.
 
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4339
+      present: 0.2575
+      future: 0.3086
+    spatial:
+      thing: 0.4348
+      place: 0.3084
+      person: 0.2568
+    ontological:
+      imagined: 0.3471
+      forgotten: 0.2949
+      known: 0.3581
+    confidence: 0.0239
+  discogs_id: null
+  notes: ''
 four tet:
   slug: four_tet
   status: draft
-  description: |
-    Four Tet operates primarily as an instrumental project, weaving intricate electronic compositions from densely layered acoustic and digital sources. His production style blends organic textures — chopped vocal fragments, plucked strings, field recordings, crackling vinyl warmth — against precisely sequenced percussion and shimmering synthesizer pads. Density fluctuates deliberately, shifting between sparse, breath-like passages and richly saturated sonic fields. The studio approach favours meticulous sample manipulation, where source material becomes unrecognisable yet retains an inherent human warmth. Thematically, the work gravitates toward interiority, cyclical patterns, and a kind of meditative attention — evoking domestic quietude, nocturnal spaces, and natural rhythms. Emotionally, the register is gently melancholic yet quietly euphoric, occupying a psychological space between introspection and release. A sense of nostalgia coexists with forward motion, producing music that feels simultaneously familiar and abstracted.
+  description: 'Four Tet operates primarily as an instrumental project, weaving intricate
+    electronic compositions from densely layered acoustic and digital sources. His
+    production style blends organic textures — chopped vocal fragments, plucked strings,
+    field recordings, crackling vinyl warmth — against precisely sequenced percussion
+    and shimmering synthesizer pads. Density fluctuates deliberately, shifting between
+    sparse, breath-like passages and richly saturated sonic fields. The studio approach
+    favours meticulous sample manipulation, where source material becomes unrecognisable
+    yet retains an inherent human warmth. Thematically, the work gravitates toward
+    interiority, cyclical patterns, and a kind of meditative attention — evoking domestic
+    quietude, nocturnal spaces, and natural rhythms. Emotionally, the register is
+    gently melancholic yet quietly euphoric, occupying a psychological space between
+    introspection and release. A sense of nostalgia coexists with forward motion,
+    producing music that feels simultaneously familiar and abstracted.
+
+    '
   style_tags: []
-  # chromatic_hint:
-  #   temporal: past | present | future
-  #   spatial: thing | place | person
-  #   ontological: imagined | forgotten | known
+  chromatic_score:
+    temporal:
+      past: 0.4439
+      present: 0.2503
+      future: 0.3058
+    spatial:
+      thing: 0.4447
+      place: 0.3056
+      person: 0.2497
+    ontological:
+      imagined: 0.3577
+      forgotten: 0.286
+      known: 0.3563
+    confidence: 0.0326
+  discogs_id: null
+  notes: ''
+Amon Düül II:
+  slug: amon_d_l_ii
+  status: draft
+  description: 'Amon Düül II occupies a dense, abrasive sonic space where distorted
+    guitars layer against hypnotic rhythmic cycles, creating a texture simultaneously
+    murky and hallucinatory. Production carries rawness alongside deliberate studio
+    manipulation — phased tones, echo-soaked passages, and sudden dynamic ruptures
+    are characteristic. The music balances vocal and instrumental modes freely, shifting
+    between sung passages and extended atmospheric or riff-driven stretches. Vocals
+    carry an incantatory quality, sometimes appearing in German and English, often
+    feeling ritualistic rather than conventionally melodic. Thematic content circles
+    around psychedelic imagery, mythological or occult suggestion, societal alienation,
+    and dreamlike surrealism, maintaining an ambiguous, fractured narrative tone.
+    The emotional register is unsettling and trance-inducing — paranoid yet euphoric,
+    dark yet propulsive. Dense rhythmic propulsion coexists with sprawling improvisational
+    passages, generating a claustrophobic intensity that occasionally opens into wide,
+    disorienting soundscapes.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4109
+      present: 0.2678
+      future: 0.3212
+    spatial:
+      thing: 0.4115
+      place: 0.3209
+      person: 0.2676
+    ontological:
+      imagined: 0.3438
+      forgotten: 0.3068
+      known: 0.3495
+    confidence: 0.0132
+  discogs_id: null
+  notes: ''
+Carole King:
+  slug: carole_king
+  status: draft
+  description: 'Carole King is primarily a vocal artist, her voice intimate and slightly
+    husky, conveying lived-in warmth rather than formal polish. Production tends toward
+    organic sparseness — piano-forward arrangements, gentle acoustic guitar, subtle
+    orchestration, and understated drums that prioritize breath and space over density.
+    Studio treatment is dry and close, placing the listener in near proximity to the
+    performer. Lyrically, she explores emotional vulnerability, interpersonal longing,
+    self-reflection, and the quiet upheavals of relationships and personal identity.
+    Imagery draws from everyday experience — natural cycles, seasonal change, domestic
+    intimacy — rendered in plain, conversational language that feels confessional
+    without becoming abstract. The emotional register is warm yet melancholic, oscillating
+    between tender reassurance and aching uncertainty. Songs carry a psychological
+    interiority; even upbeat moments carry undertones of wistfulness. The overall
+    tonal palette is soft-textured, earthy, and emotionally unguarded.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4239
+      present: 0.2634
+      future: 0.3128
+    spatial:
+      thing: 0.4248
+      place: 0.3123
+      person: 0.2629
+    ontological:
+      imagined: 0.3379
+      forgotten: 0.3006
+      known: 0.3615
+    confidence: 0.0255
+  discogs_id: null
+  notes: ''
+Aldous Harding:
+  slug: aldous_harding
+  status: draft
+  description: 'Aldous Harding is a primarily vocal artist whose work inhabits sparse,
+    chamber-folk territories with occasional pastoral or art-pop textures. Production
+    tends toward intimate sparsity — close-miked vocals, acoustic guitar, subtle piano,
+    minimal percussion — creating a fragile, airless density where silence carries
+    weight. Studio treatment often preserves breath and imperfection, lending an unsettling
+    intimacy. Lyrically, imagery is oblique and surrealist, drawing on domestic spaces,
+    animal figures, and interpersonal tension rendered through slanted, elliptical
+    language; narrative logic resists linearity. Themes circle around identity dissolution,
+    transformation, and veiled emotional states. The emotional register is psychologically
+    ambiguous — simultaneously tender and unsettling, playful yet menacing — occupying
+    a tonal space where warmth and strangeness coexist unresolved. Vocal delivery
+    shifts between whisper, theatrical affect, and sudden tonal displacement, functioning
+    as an expressive instrument that destabilizes expected emotional cues.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4205
+      present: 0.2632
+      future: 0.3163
+    spatial:
+      thing: 0.421
+      place: 0.3161
+      person: 0.2629
+    ontological:
+      imagined: 0.3387
+      forgotten: 0.303
+      known: 0.3584
+    confidence: 0.0139
+  discogs_id: null
+  notes: ''
+Arca:
+  slug: arca
+  status: draft
+  description: 'Arca works in a fractured, hyperkinetic electronic idiom defined by
+    mutilated textures, glitching percussion, and extreme dynamic contrast. Production
+    is dense and tactile — sounds appear warped, stretched, or violently compressed,
+    with synthetic and organic materials blurring together. Bass frequencies carry
+    visceral, almost biological weight. Vocals appear regularly, ranging from operatic
+    soprano flights to processed whispers and distorted spoken tones, creating a fluid,
+    androgynous vocal presence. Thematically, the work circles around bodily transformation,
+    desire, vulnerability, duality, and dissolution of identity — imagery tends toward
+    the fleshy, the spectral, and the liminal. The emotional register is simultaneously
+    ecstatic and anguished, oscillating between tenderness and aggression, intimacy
+    and alienation. There is a consistent psychological tension between beauty and
+    rupture, with moments of stark melodic clarity erupting from otherwise chaotic
+    sonic environments.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4099
+      present: 0.2706
+      future: 0.3195
+    spatial:
+      thing: 0.4107
+      place: 0.3192
+      person: 0.2701
+    ontological:
+      imagined: 0.3327
+      forgotten: 0.3094
+      known: 0.3579
+    confidence: 0.0181
+  discogs_id: null
+  notes: ''
+Alva Noto:
+  slug: alva_noto
+  status: draft
+  description: 'Alva Noto works primarily in the instrumental domain, constructing
+    music from granular synthesis, digital noise, sine tones, and precisely sculpted
+    clicks and cuts. The production character is clinical and sparse, favoring extreme
+    dynamic contrast between near-silence and sharp percussive bursts. Textures are
+    often microscopic, built from fragmented data-like sonic particles arranged with
+    mathematical deliberation. Density shifts slowly, creating long arcs of subtle
+    transformation rather than conventional melodic development. Rhythmic structures,
+    when present, emerge from stochastic patterning rather than traditional pulse.
+    Thematically, the work engages with technology, signal transmission, and the boundary
+    between noise and information — imagery that is abstract and post-industrial in
+    character. The emotional register is cool, contemplative, and quietly austere,
+    evoking states of focused stillness or detached observation. There is an underlying
+    psychological tension between order and entropy, precision and dissolution.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4417
+      present: 0.2494
+      future: 0.3088
+    spatial:
+      thing: 0.4425
+      place: 0.3085
+      person: 0.249
+    ontological:
+      imagined: 0.3425
+      forgotten: 0.2934
+      known: 0.3641
+    confidence: 0.0288
+  discogs_id: null
+  notes: ''
+Aphex Twin:
+  slug: aphex_twin
+  status: draft
+  description: 'Aphex Twin operates almost exclusively in the instrumental domain,
+    with rare, heavily processed vocal fragments dissolved into texture rather than
+    foregrounded as lyrical elements. The sonic palette is dense and meticulously
+    layered: crisp, hyperactive percussion patterns sit alongside glacial synthesizer
+    pads, acid bass lines, and hand-crafted timbres that feel simultaneously clinical
+    and organic. Production carries a workshop quality — sounds appear custom-built,
+    granularly manipulated, and spatially precise. Rhythmic structures range from
+    intricate, asymmetric breakbeats to near-static ambient drift. Thematically, the
+    work evokes liminality — childhood memory warped by time, dreamlike unease, mechanical
+    systems behaving with eerie biological warmth. The emotional register shifts between
+    serene introspection and disorienting anxiety, often within a single piece. A
+    persistent psychological tension exists between beauty and menace, calm and aggression,
+    the familiar and the deeply unsettling.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4411
+      present: 0.253
+      future: 0.3059
+    spatial:
+      thing: 0.442
+      place: 0.3057
+      person: 0.2523
+    ontological:
+      imagined: 0.3541
+      forgotten: 0.2885
+      known: 0.3574
+    confidence: 0.0289
+  discogs_id: null
+  notes: ''
+Iron & Wine:
+  slug: iron_wine
+  status: draft
+  description: 'Iron & Wine is primarily a vocal project, with Sam Beam''s warm baritone
+    or soft falsetto anchoring intimate, folk-rooted arrangements. Production ranges
+    from spare, lo-fi acoustic recordings to lush, layered arrangements incorporating
+    fingerpicked guitar, woodwinds, strings, and subtle percussion. Sonically, textures
+    tend toward softness and warmth, with deliberate restraint even in denser arrangements.
+    Lyrically, the work draws heavily on rural and domestic imagery — nature, family,
+    bodies, decay, and quiet devotion — rendered through fragmented, impressionistic
+    language that favors the concrete detail over direct statement. Thematic territory
+    encompasses mortality, longing, faith, and the passage of time, treated with ambivalence
+    rather than resolution. The emotional register is contemplative and melancholic,
+    occasionally tinged with tenderness or subdued sensuality, maintaining a hushed
+    psychological intimacy throughout. Mood rarely escalates to urgency; stillness
+    is a defining quality.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4261
+      present: 0.2612
+      future: 0.3127
+    spatial:
+      thing: 0.427
+      place: 0.3124
+      person: 0.2606
+    ontological:
+      imagined: 0.3477
+      forgotten: 0.2976
+      known: 0.3547
+    confidence: 0.0217
+  discogs_id: null
+  notes: ''
+Fleet Foxes:
+  slug: fleet_foxes
+  status: draft
+  description: 'Fleet Foxes build their sound around dense, interlocking vocal harmonies
+    layered into rich choral textures, supported by acoustic guitar, piano, and occasional
+    orchestral or baroque-folk instrumentation. Production is warm and slightly reverberant,
+    favoring organic timbres and a spacious, unhurried quality. The arrangements shift
+    between intimate acoustic passages and expansive, hymn-like swells of layered
+    voices.
+
+
+    Lyrically, the work draws heavily on pastoral and natural imagery — forests, rivers,
+    seasonal cycles, celestial bodies — alongside meditation on memory, impermanence,
+    and human smallness within larger natural and temporal forces. Tone is contemplative
+    and archaic-feeling without being nostalgic in a sentimental sense.
+
+
+    The emotional register is predominantly melancholic yet luminous — a kind of aching
+    stillness, hovering between wonder and loss. Despite rich instrumentation, the
+    work is fundamentally vocal in orientation, with the human voice functioning as
+    the primary expressive and structural anchor.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4178
+      present: 0.2638
+      future: 0.3184
+    spatial:
+      thing: 0.4186
+      place: 0.3178
+      person: 0.2635
+    ontological:
+      imagined: 0.3468
+      forgotten: 0.3029
+      known: 0.3503
+    confidence: 0.0203
+  discogs_id: null
+  notes: ''
+Gillian Welch:
+  slug: gillian_welch
+  status: draft
+  description: 'Gillian Welch works primarily as a vocalist, with sparse acoustic
+    guitar accompaniment forming the core sonic texture. Production is deliberately
+    minimal — dry, close-miked, low-density arrangements that foreground breath and
+    string resonance, creating an intimate, almost archival timbre reminiscent of
+    early recorded sound. A second guitar often weaves countermelody rather than adding
+    harmonic mass.
+
+
+    Lyrically, her work inhabits rural American imagery — decay, labor, poverty, longing,
+    and quiet endurance — filtered through a timeless, regionless past. Themes circle
+    mortality, hardship, and small dignities, rendered in plain, concrete language
+    with a mythic undertone.
+
+
+    The emotional register is melancholic without sentimentality, austere yet warm,
+    suggesting grief held at a controlled distance. There is a stillness and unhurried
+    fatalism running throughout — a mood of watching rather than reacting, contemplative
+    and shadowed but never melodramatic.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4369
+      present: 0.253
+      future: 0.31
+    spatial:
+      thing: 0.4378
+      place: 0.3097
+      person: 0.2525
+    ontological:
+      imagined: 0.3417
+      forgotten: 0.2965
+      known: 0.3618
+    confidence: 0.028
+  discogs_id: null
+  notes: ''
+Bon Iver:
+  slug: bon_iver
+  status: draft
+  description: 'Bon Iver occupies a heavily processed, layered sonic world where acoustic
+    intimacy collides with electronic abstraction. Vocals are central but heavily
+    treated — pitch-shifted, chopped, harmonically stacked, and blurred into near-instrumental
+    textures. Production favors dense, reverb-saturated environments that feel both
+    expansive and claustrophobic simultaneously. Instrumentation shifts across works
+    from sparse folk guitar and falsetto to complex orchestral and synthesizer constructions
+    with stuttering digital artifacts.
+
+
+    Lyrically, language is fractured and associative rather than narrative, employing
+    geographic imagery, seasonal and natural symbolism, and abstracted emotional states.
+    Meaning emerges obliquely through sonic weight rather than literal statement.
+    Themes circle isolation, longing, transformation, and liminal psychological states.
+
+
+    The emotional register is melancholic but not despairing — introspective, suspended,
+    and muted, inhabiting a grey-blue psychological colour somewhere between grief
+    and quiet acceptance. The work is primarily vocal, though voice functions simultaneously
+    as instrument.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4135
+      present: 0.2683
+      future: 0.3182
+    spatial:
+      thing: 0.4142
+      place: 0.3179
+      person: 0.2679
+    ontological:
+      imagined: 0.3475
+      forgotten: 0.3022
+      known: 0.3503
+    confidence: 0.0153
+  discogs_id: null
+  notes: ''
+Sun Kil Moon:
+  slug: sun_kil_moon
+  status: draft
+  description: 'Sun Kil Moon centres on fingerpicked acoustic guitar with warm, close-miked
+    intimacy, occasionally layered with understated electric textures, sparse percussion,
+    and subtle ambient drift. Production favours an unpolished directness — dry room
+    sound, minimal compression — creating a sense of documentary immediacy rather
+    than studio polish. Vocals are primary and central: a low, conversational delivery
+    that sits close to speech, threading long, prose-like lines through unhurried
+    melodic contours. Lyrically, the work excavates mundane autobiography, mortality,
+    grief, friendship, and the accumulated weight of ordinary experience, rendered
+    through hyperspecific sensory detail — named people, particular places, recurring
+    objects — that accumulates into something ritualistic and elegiac. Thematic tone
+    oscillates between tenderness and bleak reckoning, shot through with dark humour
+    and unsettling frankness. The emotional register is heavy, ruminative, and psychologically
+    exposed, resisting resolution.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4402
+      present: 0.2525
+      future: 0.3073
+    spatial:
+      thing: 0.4411
+      place: 0.3072
+      person: 0.2517
+    ontological:
+      imagined: 0.3496
+      forgotten: 0.2933
+      known: 0.357
+    confidence: 0.0273
+  discogs_id: null
+  notes: ''
+Gregory Alan Isakov:
+  slug: gregory_alan_isakov
+  status: draft
+  description: 'Gregory Alan Isakov occupies a hushed, intimate sonic space where
+    acoustic guitar, sparse percussion, and understated strings create layered yet
+    never cluttered textures. Production leans toward warmth and organic softness
+    — subtle reverb, gentle room presence, and careful dynamic restraint give recordings
+    an almost candlelit density. His work is primarily vocal, with melody serving
+    as an emotional anchor against restrained instrumentation.
+
+
+    Lyrically, imagery draws from natural landscapes — celestial bodies, open fields,
+    seasons, water — woven into meditations on longing, distance, transience, and
+    quiet introspection. Language tends toward the oblique and imagistic rather than
+    narrative or confessional.
+
+
+    The emotional register is melancholic but not despairing — a sustained, contemplative
+    ache with occasional flickering warmth. The psychological colour is predominantly
+    nocturnal and solitary, evoking stillness, reflection, and the bittersweet weight
+    of memory and impermanence.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4266
+      present: 0.2586
+      future: 0.3148
+    spatial:
+      thing: 0.4274
+      place: 0.3145
+      person: 0.2581
+    ontological:
+      imagined: 0.3456
+      forgotten: 0.2989
+      known: 0.3555
+    confidence: 0.021
+  discogs_id: null
+  notes: ''
+Anaïs Mitchell:
+  slug: ana_s_mitchell
+  status: draft
+  description: 'Anaïs Mitchell works primarily as a vocalist and lyricist, her music
+    rooted in folk and chamber-folk traditions with intimate, often sparse production.
+    Acoustic guitar and piano anchor arrangements that occasionally expand into full
+    orchestral or theatrical textures, blending folk instrumentation with subtle theatrical
+    grandeur. Her sonic palette favors warmth and wood-grain timbre, with close-miked
+    vocals sitting intimately in the mix. Lyrically, she draws on myth, folklore,
+    classical antiquity, and American vernacular tradition, weaving allegorical narratives
+    that explore power, desire, grief, and social inequality through heightened poetic
+    imagery. Her tone oscillates between tender vulnerability and sharp dramatic tension,
+    often inhabiting multiple character perspectives within a single work. The emotional
+    register carries psychological weight — melancholic, morally complex, occasionally
+    darkly playful — with a storytelling urgency that feels simultaneously ancient
+    and urgently contemporary.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4182
+      present: 0.2686
+      future: 0.3132
+    spatial:
+      thing: 0.4191
+      place: 0.3131
+      person: 0.2678
+    ontological:
+      imagined: 0.3498
+      forgotten: 0.2992
+      known: 0.351
+    confidence: 0.0183
+  discogs_id: null
+  notes: ''
+Fever Ray:
+  slug: fever_ray
+  status: draft
+  description: 'Fever Ray constructs dense, otherworldly soundscapes built from heavily
+    processed vocals, stuttering electronic pulses, tribal percussion, and thick synthesizer
+    layers. The production feels simultaneously ancient and clinical — cavernous reverb,
+    ritualistic rhythmic patterns, and distorted organic textures create an atmosphere
+    of cold ceremonialism. Vocals are central but heavily manipulated through pitch-shifting
+    and effects, blurring gender and humanity, functioning as another textural instrument
+    rather than a conventional melodic vehicle. Lyrically, the work circles themes
+    of domesticity made strange, bodily experience, motherhood, identity dissolution,
+    and the uncanny interior life — rendered in spare, fragmented imagery with a hypnotic,
+    incantatory quality. The emotional register is profoundly unsettling yet intimate:
+    gothic dread coexists with vulnerability, isolation with longing. The overall
+    psychological colour is twilight — suspended between waking and dreaming, familiar
+    and deeply alien.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4095
+      present: 0.2721
+      future: 0.3184
+    spatial:
+      thing: 0.4104
+      place: 0.318
+      person: 0.2716
+    ontological:
+      imagined: 0.3491
+      forgotten: 0.3037
+      known: 0.3471
+    confidence: 0.0181
+  discogs_id: null
+  notes: ''
+Death Grips:
+  slug: death_grips
+  status: draft
+  description: 'Death Grips operates as a vocal-forward project with aggressive, abrasive
+    production anchoring every element. Sonically, the texture is dense and confrontational
+    — industrial percussion hammers with distorted, heavily compressed drum machines
+    layered beneath noise collages, glitched electronics, and raw, overdriven bass
+    frequencies. Production deliberately embraces clipping, saturation, and sonic
+    violence, creating a claustrophobic yet energized density. Vocals are delivered
+    in a relentless, percussive bark, functioning almost rhythmically, interlocked
+    tightly with the beat architecture. Lyrically, themes orbit paranoia, systemic
+    alienation, nihilism, power dynamics, bodily intensity, and fractured identity
+    — imagery tends toward the visceral, fragmented, and hallucinatory. Tone is confrontational
+    and unresolved, resisting sentimentality entirely. The emotional register is one
+    of controlled mania — anxiety, aggression, and dissociation coexist with a propulsive,
+    almost ecstatic momentum, generating psychological tension that feels simultaneously
+    threatening and liberating.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.3935
+      present: 0.2774
+      future: 0.3291
+    spatial:
+      thing: 0.3941
+      place: 0.3289
+      person: 0.2771
+    ontological:
+      imagined: 0.3275
+      forgotten: 0.3208
+      known: 0.3517
+    confidence: 0.008
+  discogs_id: null
+  notes: ''
+Grouper:
+  slug: grouper
+  status: draft
+  description: 'Grouper''s work is defined by heavily treated vocals submerged beneath
+    layers of reverb, tape hiss, and ambient drone, creating a sound of extreme textural
+    density that simultaneously feels intimate and oceanic. The production approach
+    privileges degradation and distance — voices emerge as instruments dissolving
+    into field recordings, acoustic guitar, and slow electronic wash. Lyrics circle
+    themes of grief, memory, longing, nature, and psychological dissolution, employing
+    sparse, imagistic language that evokes fog, water, absence, and interior states
+    of mourning or searching. The emotional register is profoundly melancholic, contemplative,
+    and introspective, occupying a space between waking and sleep, presence and disappearance.
+    The work is primarily vocal-centered, though vocals function as textural elements
+    rather than conventional melodic foreground. Overall atmosphere tends toward stillness,
+    suspension, and a kind of sacred or ritualistic quietude, the music operating
+    at the threshold of audibility.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4242
+      present: 0.2579
+      future: 0.3179
+    spatial:
+      thing: 0.425
+      place: 0.3172
+      person: 0.2577
+    ontological:
+      imagined: 0.3408
+      forgotten: 0.3023
+      known: 0.3569
+    confidence: 0.0214
+  discogs_id: null
+  notes: ''
+Zola Jesus:
+  slug: zola_jesus
+  status: draft
+  description: 'Zola Jesus is a vocal-forward artist whose work layers operatic soprano
+    voice against dense, gothic electronic production. Sonically, the texture combines
+    dark synthwave foundations, industrial percussion, and orchestral swells, creating
+    a claustrophobic yet expansive sonic architecture. The studio approach favors
+    heavy reverb and compression, giving vocals a monumental, cathedral-like resonance
+    within machine-driven arrangements.
+
+
+    Lyrically, the work gravitates toward existential isolation, bodily experience,
+    grief, transformation, and the tension between vulnerability and endurance. Imagery
+    tends toward the elemental — darkness, flesh, survival, dissolution — rendered
+    in abstract, poetic language with a confessional intensity.
+
+
+    The emotional register is consistently bleak yet cathartic, inhabiting a psychological
+    space between desolation and defiance. Affect is heavy and immersive, prioritizing
+    emotional weight over melodic lightness. The overall mood suggests ritual mourning
+    transmuted into something survivable.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4099
+      present: 0.2695
+      future: 0.3206
+    spatial:
+      thing: 0.4108
+      place: 0.3203
+      person: 0.2689
+    ontological:
+      imagined: 0.3423
+      forgotten: 0.3083
+      known: 0.3495
+    confidence: 0.022
+  discogs_id: null
+  notes: ''
+Burial:
+  slug: burial
+  status: draft
+  description: 'Burial operates primarily in the instrumental-ambient domain, with
+    sparse, fragmented vocal samples processed beyond recognition into texture rather
+    than narrative. Production is characterised by extreme layering: dusty vinyl crackle,
+    sub-bass pressure, deteriorated drum machine patterns with shuffled, irregular
+    swing, and environmental field recordings dissolved into dense sonic murk. Timbres
+    are deliberately degraded — signals appear worn, waterlogged, and nocturnal. Lyrically,
+    vocal fragments suggest themes of urban loneliness, late-night transit, lost connection,
+    and yearning without resolution; imagery gravitates toward empty streets, rain,
+    artificial light, and dissolved memory. The emotional register is melancholic
+    and dissociative — grief held at distance, longing without clear object, intimacy
+    corroded by isolation. Mood is consistently nocturnal and introspective, carrying
+    a psychological quality of suspended grief and hollow warmth. Studio approach
+    prioritises texture over clarity, treating distortion and degradation as compositional
+    tools.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4113
+      present: 0.2682
+      future: 0.3205
+    spatial:
+      thing: 0.4118
+      place: 0.3203
+      person: 0.2679
+    ontological:
+      imagined: 0.3282
+      forgotten: 0.3114
+      known: 0.3604
+    confidence: 0.0101
+  discogs_id: null
+  notes: ''
+Nils Frahm:
+  slug: nils_frahm
+  status: draft
+  description: 'Nils Frahm works predominantly in instrumental music, blending acoustic
+    piano with synthesizers, analog electronics, and layered textures. His production
+    approach favors close-miked intimacy — audible key mechanisms, pedal breath, room
+    resonance — creating a tactile, human warmth alongside pristine studio clarity.
+    Sonic density ranges from sparse, meditative single-note passages to dense, rhythmically
+    propulsive sequences where minimalist repetition builds gradually into immersive
+    crescendos. Thematically, his work inhabits liminal spaces: stillness and motion,
+    solitude and expansiveness, the mechanical and the organic. Imagery evokes late-night
+    contemplation, vast interior landscapes, and quiet momentum. Emotionally, the
+    register moves fluidly between melancholy and euphoria, introspection and release,
+    often sustaining ambiguity rather than resolving toward clear sentiment. Rhythmic
+    pulse frequently underpins otherwise atmospheric textures, lending urgency to
+    meditative material and grounding abstract sonic environments in physical, visceral
+    feeling.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4744
+      present: 0.2312
+      future: 0.2945
+    spatial:
+      thing: 0.4752
+      place: 0.2943
+      person: 0.2305
+    ontological:
+      imagined: 0.3522
+      forgotten: 0.2784
+      known: 0.3694
+    confidence: 0.0575
+  discogs_id: null
+  notes: ''
+Holly Herndon:
+  slug: holly_herndon
+  status: draft
+  description: 'Holly Herndon works primarily as a vocalist, weaving her voice through
+    dense, algorithmically-processed layers that blur the boundary between organic
+    and synthetic. Her production aesthetic favours granular textures, fragmented
+    vocal clusters, and harsh digital artifacts sitting alongside intimate choral
+    warmth. Studio construction is highly sculptural — sounds accumulate in cellular,
+    grid-like patterns rather than traditional song architecture. Thematically, her
+    work orbits technology, embodiment, surveillance, networked identity, and the
+    politics of digital infrastructure, often treating the human body as a site of
+    techno-political negotiation. Imagery tends toward the systemic and abstract,
+    framing everyday computational experience as ideologically charged territory.
+    Emotionally, the register oscillates between clinical detachment and sudden vulnerability
+    — cold, architectural passages dissolve into moments of communal tenderness. There
+    is persistent psychological tension between alienation and intimacy, distance
+    and warmth, machine logic and human fragility.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4218
+      present: 0.2621
+      future: 0.3161
+    spatial:
+      thing: 0.4227
+      place: 0.3157
+      person: 0.2616
+    ontological:
+      imagined: 0.3422
+      forgotten: 0.3015
+      known: 0.3563
+    confidence: 0.0227
+  discogs_id: null
+  notes: ''
+Actress:
+  slug: actress
+  status: draft
+  description: 'Actress (Darren Cunningham) crafts primarily instrumental electronic
+    music rooted in fragmented, decayed textures. His production character favours
+    lo-fi grit layered beneath synthetic warmth — corroded drum machine patterns,
+    smeared harmonic residue, and deliberately degraded samples create a sense of
+    sonic deterioration. Density shifts between cavernous minimalism and claustrophobic
+    layering, with space weaponised as compositional material. Studio treatments emphasise
+    imperfection: distortion, pitch drift, and warped synthesis suggest analogue decomposition
+    rather than digital precision.
+
+
+    Thematically, his work engages with interiority, urban alienation, and states
+    of altered or dissociated consciousness. Imagery, where implied through titles
+    and sonic atmosphere, tends toward the liminal — thresholds, absence, collapse.
+
+
+    The emotional register is cold yet strangely intimate, evoking dislocation, detachment,
+    and melancholic suspension. Mood sits between contemplative unease and trance-like
+    drift, psychological rather than dancefloor-oriented in temperament.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.475
+      present: 0.2303
+      future: 0.2947
+    spatial:
+      thing: 0.4758
+      place: 0.2946
+      person: 0.2296
+    ontological:
+      imagined: 0.3489
+      forgotten: 0.277
+      known: 0.3741
+    confidence: 0.0615
+  discogs_id: null
+  notes: ''
+Anais Mitchell:
+  slug: anais_mitchell
+  status: draft
+  description: 'Anaïs Mitchell writes primarily vocal folk and theatrical folk music,
+    her voice carrying an intimate, slightly weathered quality that sits close in
+    the mix. Production tends toward sparse, folk-rooted arrangements—acoustic guitar,
+    fiddle, upright bass—occasionally expanding into full theatrical orchestration
+    with brass, strings, and choral textures. Lyrically, she draws on mythological
+    and allegorical frameworks, reimagining classical or folkloric narratives through
+    a contemporary American vernacular. Imagery tends toward the domestic and the
+    elemental: bargains, thresholds, seasons, and moral reckonings. Thematically,
+    her work circles around power, sacrifice, grief, and survival, often filtered
+    through female interiority. The emotional register is haunted and tender, occupying
+    a psychological space between longing and resolve—melancholic without being passive.
+    Dialogue and character voice are central compositional devices, giving her work
+    a narrative, dramatic density even in smaller song formats.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4227
+      present: 0.263
+      future: 0.3143
+    spatial:
+      thing: 0.4235
+      place: 0.3141
+      person: 0.2624
+    ontological:
+      imagined: 0.343
+      forgotten: 0.3022
+      known: 0.3548
+    confidence: 0.0174
+  discogs_id: null
+  notes: ''
+Nick Cave:
+  slug: nick_cave
+  status: draft
+  description: 'Nick Cave is a vocal-driven artist whose work centres on the human
+    voice as primary instrument. Sonically, his productions range from sparse, cavernous
+    arrangements — dominated by upright piano, mournful strings, and hollowed-out
+    reverb — to dense, abrasive guitar-driven textures with aggressive rhythmic momentum.
+    The studio aesthetic tends toward deliberate, theatrical space, where silence
+    and decay are treated as compositional elements. Lyrically, his work draws heavily
+    on biblical mythology, mortality, violence, erotic longing, grief, and redemption,
+    rendered through Southern Gothic and apocalyptic imagery. Narrative storytelling
+    is central, often adopting character voices and confession-like monologue structures.
+    The emotional register is consistently intense — oscillating between raw desolation,
+    barely contained rage, and transcendent tenderness. A brooding, ceremonial quality
+    pervades even quieter passages, giving the work a ritualistic psychological weight.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4197
+      present: 0.2643
+      future: 0.316
+    spatial:
+      thing: 0.4206
+      place: 0.3156
+      person: 0.2637
+    ontological:
+      imagined: 0.3424
+      forgotten: 0.3033
+      known: 0.3544
+    confidence: 0.0218
+  discogs_id: null
+  notes: ''
+Joanna Newsom:
+  slug: joanna_newsom
+  status: draft
+  description: 'Joanna Newsom is primarily a vocal artist, her harp-centred arrangements
+    forming a distinctive sonic foundation. Texturally, her recordings blend acoustic
+    harp, orchestral strings, woodwinds, and chamber instrumentation into dense yet
+    delicate webs, often with dry, intimate production that preserves natural resonance
+    and human imperfection. Her voice is idiosyncratic — high, reedy, and slightly
+    nasal, conveying a quality that is simultaneously childlike and ancient.
+
+
+    Lyrically, she works in extended, labyrinthine structures, drawing on pastoral
+    imagery, mythological allusion, natural cycles, mortality, time, memory, and the
+    fragility of human connection. Her narratives are layered and elliptical, favouring
+    metaphor over directness.
+
+
+    Emotionally, her work occupies a liminal register: tender yet unsettled, wistful
+    yet intellectually rigorous, oscillating between wonder and grief. There is a
+    persistent undercurrent of longing and impermanence beneath ornate, almost archaic
+    linguistic surfaces.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4187
+      present: 0.2637
+      future: 0.3176
+    spatial:
+      thing: 0.4198
+      place: 0.3169
+      person: 0.2633
+    ontological:
+      imagined: 0.3478
+      forgotten: 0.3018
+      known: 0.3504
+    confidence: 0.0277
+  discogs_id: null
+  notes: ''
+Andrew Bird:
+  slug: andrew_bird
+  status: draft
+  description: 'Andrew Bird is primarily a vocal artist who integrates elaborate instrumental
+    layering, particularly violin, whistling, and looped guitar, into a densely textured
+    folk-chamber sound. Production tends toward warm acoustics with deliberate, artisanal
+    clarity — intimate yet architecturally complex, often built around live looping
+    that creates an organic, slightly unpredictable density. Lyrically, Bird favors
+    scientific and naturalistic imagery — ornithology, biology, entropy, language
+    itself — woven through philosophical and existential contemplation, delivered
+    with dry wit and intellectual distance. Themes frequently orbit systems of meaning,
+    decay, and the limits of communication. Emotionally, the register is cerebral
+    yet quietly melancholic, maintaining a contemplative affect that occasionally
+    opens into wistfulness or restrained wonder. The tone is rarely confessional,
+    preferring allegory and oblique abstraction. Whistling functions both melodically
+    and texturally, becoming a signature timbral element alongside pizzicato strings
+    and fingerpicked acoustic passages.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4294
+      present: 0.2591
+      future: 0.3115
+    spatial:
+      thing: 0.4303
+      place: 0.3113
+      person: 0.2584
+    ontological:
+      imagined: 0.3457
+      forgotten: 0.2989
+      known: 0.3554
+    confidence: 0.0191
+  discogs_id: null
+  notes: ''
+Sam Amidon:
+  slug: sam_amidon
+  status: draft
+  description: 'Sam Amidon works primarily as a vocalist, though instrumentation plays
+    an equally weighted role. His sonic texture is sparse and intimate — finger-picked
+    acoustic guitar, fiddle, banjo, and occasional subtle electronic or orchestral
+    layering create a production character that feels simultaneously archaic and quietly
+    modern. Studio arrangements tend toward restraint, leaving significant negative
+    space. Lyrically, he draws on traditional American folk and ballad sources, reshaping
+    fragmentary narratives involving death, travel, loss, and rural life into something
+    dreamlike and slightly dislocated. Imagery tends toward the concrete yet strange
+    — animals, journeys, unnamed figures — delivered with a tonal ambiguity that resists
+    straightforward sentimentality. The emotional register is hushed and liminal,
+    hovering between melancholy and calm acceptance, with an undertone of mild uncanniness.
+    His vocal delivery is understated, conversational, and deliberately unpolished,
+    reinforcing a psychological colour of quiet estrangement and gentle mystery.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4254
+      present: 0.2623
+      future: 0.3123
+    spatial:
+      thing: 0.4265
+      place: 0.312
+      person: 0.2615
+    ontological:
+      imagined: 0.3491
+      forgotten: 0.2981
+      known: 0.3528
+    confidence: 0.0252
+  discogs_id: null
+  notes: ''
+FKA twigs:
+  slug: fka_twigs
+  status: draft
+  description: 'FKA twigs works primarily as a vocalist, though her productions foreground
+    texture as heavily as melody. Sonically, her music inhabits sparse, sub-bass-heavy
+    electronic architecture — hollow percussion, breathy vocal layering, glitchy cuts,
+    and intimate close-miked intimacy sitting against cavernous negative space. Production
+    is meticulous and sculptural, blending R&B, avant-pop, and industrial minimalism
+    with delicate restraint. Lyrically, she draws on devotion, bodily vulnerability,
+    spiritual surrender, and erotic power — imagery tends toward the sacred and carnal
+    simultaneously, exploring control, submission, and transformation as intertwined
+    states. Her tone oscillates between whispered confession and incantatory ritual.
+    Emotionally, the register is quietly intense — aching longing coexists with cool
+    self-possession, producing a psychological atmosphere that feels simultaneously
+    exposed and armoured, tender and unsettling. Silence and space function as compositional
+    elements equal in weight to sound.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4303
+      present: 0.2593
+      future: 0.3104
+    spatial:
+      thing: 0.4314
+      place: 0.3101
+      person: 0.2585
+    ontological:
+      imagined: 0.3448
+      forgotten: 0.2961
+      known: 0.359
+    confidence: 0.0314
+  discogs_id: null
+  notes: ''
+Anohni:
+  slug: anohni
+  status: draft
+  description: 'Anohni is a vocal-led artist whose work blends orchestral chamber
+    arrangements with sparse electronic production, creating music of stark, ceremonial
+    weight. Textures shift between intimate acoustic warmth and cold synthetic surfaces,
+    often layered with deliberate density that feels ritualistic. Themes circle around
+    ecological grief, political mourning, surveillance, bodily vulnerability, and
+    spiritual longing, rendered through imagery that is simultaneously tender and
+    accusatory. The lyrical tone carries a confessional directness, often addressing
+    collective culpability and systemic violence through a first-person lens that
+    implicates both speaker and listener. Emotionally, the register is one of sustained
+    lament—sorrowful yet unsentimental, suffused with a luminous, almost devotional
+    ache. Production approaches vary between lush orchestration and stark minimalism,
+    but always subordinate sonic gesture to emotional transparency. The voice remains
+    the gravitational centre throughout, bare and ceremonial in quality.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4336
+      present: 0.256
+      future: 0.3104
+    spatial:
+      thing: 0.4347
+      place: 0.31
+      person: 0.2553
+    ontological:
+      imagined: 0.355
+      forgotten: 0.2947
+      known: 0.3503
+    confidence: 0.0307
+  discogs_id: null
+  notes: ''
+Klaus Schulze:
+  slug: klaus_schulze
+  status: draft
+  description: 'Klaus Schulze works almost exclusively in the instrumental domain,
+    constructing vast, slowly evolving electronic soundscapes where sequencer arpeggios
+    pulse beneath layered synthesizer pads of immense depth and warmth. His production
+    favors long decay times, reverb-drenched timbres, and a dense, almost orchestral
+    density achieved through analog synthesis. Textures shift glacially, with melodic
+    cells cycling hypnotically while harmonic clouds drift overhead. Thematically,
+    his compositions evoke cosmic vastness, inner contemplation, and timeless mythological
+    or metaphysical territories — spaces that feel both ancient and futuristic. The
+    emotional register is predominantly meditative, introspective, and awe-inducing,
+    carrying a solemn grandeur that occasionally opens into euphoric swells. Rhythmic
+    structures, when present, are mechanical yet organic, providing hypnotic momentum
+    rather than conventional pulse. The overall sonic world is immersive, monolithic,
+    and sustained — designed to induce altered states of perception and deep, expansive
+    listening.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4364
+      present: 0.2535
+      future: 0.31
+    spatial:
+      thing: 0.4371
+      place: 0.3099
+      person: 0.253
+    ontological:
+      imagined: 0.3441
+      forgotten: 0.2955
+      known: 0.3604
+    confidence: 0.0252
+  discogs_id: null
+  notes: ''
+Coil:
+  slug: coil
+  status: draft
+  description: 'Coil occupies a dense, ritualistic sonic space where industrial electronics,
+    musique concrète, and occult-inflected ambient converge. Production textures are
+    layered and alchemical — corroded synth drones, manipulated field recordings,
+    processed voices, and abrasive low-frequency rumble coexist with moments of crystalline
+    fragility. Studio work favours deliberate sonic decomposition and reconstruction,
+    creating an organic yet deeply unnatural character.
+
+
+    Lyrics and thematic imagery circle sexuality, death, transformation, bodily dissolution,
+    magical systems, altered states, and liminal spiritual experience. Tone moves
+    between incantatory and confessional, coded and visceral. Language tends toward
+    dense symbolism rather than conventional narrative.
+
+
+    Emotionally, the register spans glacial dread, ecstatic dissolution, funerary
+    solemnity, and dark eroticism — sometimes simultaneously. There is persistent
+    psychological ambiguity, hovering between the sacred and the abject.
+
+
+    Both vocal and instrumental dimensions carry equal weight; voice functions as
+    texture and ritual instrument rather than melodic vehicle.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4193
+      present: 0.2625
+      future: 0.3182
+    spatial:
+      thing: 0.4201
+      place: 0.3176
+      person: 0.2623
+    ontological:
+      imagined: 0.3356
+      forgotten: 0.3049
+      known: 0.3596
+    confidence: 0.0137
+  discogs_id: null
+  notes: ''
+Lustmord:
+  slug: lustmord
+  status: draft
+  description: 'Lustmord operates in the realm of dark ambient and industrial sound
+    design, crafting compositions that are almost exclusively instrumental. The sonic
+    texture is extraordinarily dense and subterranean — cavernous low-frequency drones,
+    processed field recordings, and metallic resonances layered into vast, suffocating
+    architectures. Production favors extreme depth and spatial immersion, with sounds
+    appearing to emerge from unidentifiable distances or enclosed underground spaces.
+    When occasional vocal elements appear, they are heavily processed into abstracted,
+    ritualistic tones rather than discernible language. Thematically, the work gravitates
+    toward darkness, void, entropy, and primordial or cosmic dread — suggesting spaces
+    beneath consciousness or beyond human scale. The emotional register is one of
+    sustained existential unease, slow dread, and dissociation. There is no resolution
+    or warmth; the psychological colour remains uniformly bleak, hypnotic, and oppressive
+    throughout, evoking annihilation and deep geological or cosmological timescales.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4184
+      present: 0.2666
+      future: 0.315
+    spatial:
+      thing: 0.4194
+      place: 0.3146
+      person: 0.2659
+    ontological:
+      imagined: 0.3372
+      forgotten: 0.3051
+      known: 0.3577
+    confidence: 0.0243
+  discogs_id: null
+  notes: ''
+Robert Rich:
+  slug: robert_rich
+  status: draft
+  description: 'Robert Rich works primarily in instrumental ambient and dark ambient
+    territory, occasionally incorporating wordless or minimal vocal elements. His
+    sonic textures are dense and layered, built from slow-moving synthesizer pads,
+    processed acoustic instruments, ethnic woodwinds, tuned percussion, and intricate
+    rhythmic underpinnings derived from hand drums and sequenced patterns. Production
+    is meticulous and immersive, favoring deep low-frequency presence alongside crystalline
+    high-frequency detail, creating a sense of vast interior space. Thematic tendencies
+    orbit biological consciousness, dream states, primordial landscapes, and the boundary
+    between organic and synthetic existence. Imagery evokes subterranean environments,
+    cellular processes, ancient ritual, and the threshold of sleep. The emotional
+    register is characteristically somber, contemplative, and hypnotic — psychologically
+    inducing a liminal, suspended state that blurs wakefulness and unconsciousness.
+    Rhythmic elements, when present, feel ceremonial rather than propulsive, reinforcing
+    an atmosphere of slow temporal drift and meditative unease.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4175
+      present: 0.2667
+      future: 0.3158
+    spatial:
+      thing: 0.4184
+      place: 0.3155
+      person: 0.2661
+    ontological:
+      imagined: 0.3372
+      forgotten: 0.3048
+      known: 0.3581
+    confidence: 0.0177
+  discogs_id: null
+  notes: ''
+Cluster:
+  slug: cluster
+  status: draft
+  description: 'Cluster occupies a primarily instrumental sonic world built from dense,
+    exploratory electronic textures. Their production character favours analogue warmth
+    mixed with abrasive, unpredictable noise — oscillators drift, circuitry hums,
+    and feedback loops create tactile, almost physical sound masses. Studio treatments
+    emphasise spontaneity, with rough edges and live-feeling manipulation preserved
+    rather than polished away. Structurally, pieces tend toward open-form improvisation,
+    where repetition and gradual timbral mutation replace conventional development.
+    Melodic content, when present, is fragmentary and submerged within layered drones
+    or rhythmic mechanical pulses. Lyricism is essentially absent; meaning emerges
+    through sound architecture alone. Emotionally, the register shifts between meditative
+    stillness and disorienting unease — passages of hypnotic calm interrupted by harsh,
+    destabilising bursts. The psychological colour is ambiguous, simultaneously industrial
+    and organic, suggesting both machine process and natural decay. Density alternates
+    between sparse minimalism and thick, enveloping sonic saturation.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4609
+      present: 0.2397
+      future: 0.2994
+    spatial:
+      thing: 0.4616
+      place: 0.2994
+      person: 0.239
+    ontological:
+      imagined: 0.3558
+      forgotten: 0.2823
+      known: 0.3619
+    confidence: 0.0326
+  discogs_id: null
+  notes: ''
+Drexciya:
+  slug: drexciya
+  status: draft
+  description: 'Drexciya is primarily instrumental, rooted in Detroit techno and electro.
+    Productions carry a dense, aquatic sonic texture — submerged bass frequencies,
+    percussive machine rhythms, and synthesizer pulses that evoke pressurized underwater
+    environments. The studio approach favors analog hardware, yielding a raw yet tightly
+    sequenced aesthetic with high rhythmic density and minimal space. Vocal elements
+    appear sparingly, typically processed or abstracted into texture rather than melody.
+    Thematically, the work orbits mythology, Afrofuturism, oceanic descent, and speculative
+    cosmology — constructing an elaborate imagined civilization of beings adapted
+    to underwater existence. Imagery draws on transformation, survival, and hidden
+    worlds beneath visible reality. The emotional register is cold and immersive,
+    projecting tension alongside purposeful momentum — neither melancholic nor celebratory,
+    but urgent and otherworldly. A consistent psychological undertone of displacement
+    and resilience permeates the compositional environment.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4042
+      present: 0.275
+      future: 0.3208
+    spatial:
+      thing: 0.4049
+      place: 0.3208
+      person: 0.2743
+    ontological:
+      imagined: 0.3328
+      forgotten: 0.3119
+      known: 0.3553
+    confidence: 0.0133
+  discogs_id: null
+  notes: ''
+Oval:
+  slug: oval
+  status: draft
+  description: 'Oval operates in a predominantly instrumental domain, crafting music
+    built from fragmented, glitching digital textures derived from manipulated compact
+    disc errors and software processes. The sonic palette is densely layered yet paradoxically
+    weightless — corroded loops, stuttering tones, and granular noise accumulate into
+    shifting, porous surfaces rather than conventional melodic or rhythmic structures.
+    Production is deconstructive, treating the studio process itself as subject matter,
+    with artifacts of digital breakdown elevated to compositional material. Thematically,
+    the work implies ideas of malfunction, system failure, and the aesthetics of error
+    without employing overt narrative or imagery, as vocals are largely absent. The
+    emotional register sits in a cool, disorienting ambiguity — neither warmly ambient
+    nor aggressively harsh — evoking a kind of detached introspection, somewhere between
+    meditative drift and mild cognitive unsettlement, as if observing a familiar process
+    dissolving into unrecognizable fragments.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4489
+      present: 0.2484
+      future: 0.3026
+    spatial:
+      thing: 0.4498
+      place: 0.3024
+      person: 0.2478
+    ontological:
+      imagined: 0.3523
+      forgotten: 0.2855
+      known: 0.3621
+    confidence: 0.04
+  discogs_id: null
+  notes: ''
+Vladislav Delay:
+  slug: vladislav_delay
+  status: draft
+  description: 'Vladislav Delay works almost exclusively in the instrumental domain,
+    forging dense, tactile sound environments rooted in abstract techno and microsound
+    aesthetics. His production character is defined by heavily processed rhythmic
+    textures where percussive elements dissolve into granular fog, sub-bass pressure,
+    and crackling surface noise. Layered feedback loops, pitch-shifted debris, and
+    deliberately degraded audio material create a sense of structural erosion rather
+    than conventional musical architecture. Density shifts between suffocating thickness
+    and sparse, breath-like negative space, generating tension through restraint and
+    weight rather than melodic movement. Thematically, the work aligns with natural
+    phenomena, spatial ambiguity, and material decay — though these remain implicit,
+    evoked through sonic metaphor rather than language. The emotional register is
+    austere, contemplative, and frequently unsettling, carrying a cold Nordic psychological
+    colour — immersive yet distancing, suggesting isolation, compression, and slow
+    transformation.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4386
+      present: 0.2509
+      future: 0.3105
+    spatial:
+      thing: 0.4391
+      place: 0.3104
+      person: 0.2505
+    ontological:
+      imagined: 0.3382
+      forgotten: 0.2961
+      known: 0.3658
+    confidence: 0.0181
+  discogs_id: null
+  notes: ''
+Stars of the Lid:
+  slug: stars_of_the_lid
+  status: draft
+  description: 'Stars of the Lid crafts primarily instrumental orchestral ambient
+    music built from dense, slowly evolving layers of treated strings, guitars, brass,
+    and synthesizers. Production is cavernous and reverb-saturated, with sounds blurring
+    into sustained washes that dissolve boundaries between acoustic and electronic
+    sources. Textures accumulate glacially, often swelling toward overwhelming climactic
+    densities before receding into near-silence. The studio approach favors immense
+    spatial depth, with low-frequency weight anchoring shimmering upper registers.
+    Thematically, the music evokes vastness, mortality, grief, longing, and transcendence
+    — imagery of open landscapes, cosmic scale, and internal psychological states
+    predominates. Vocal elements, when present, are treated as textural components
+    rather than narrative vehicles, rendered wordless or heavily processed. The emotional
+    register is simultaneously mournful and consoling, inhabiting a suspended, liminal
+    affect — sorrowful yet oddly peaceful, as though grief and acceptance occupy the
+    same unresolved moment.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4317
+      present: 0.2559
+      future: 0.3125
+    spatial:
+      thing: 0.4325
+      place: 0.312
+      person: 0.2555
+    ontological:
+      imagined: 0.3382
+      forgotten: 0.2992
+      known: 0.3626
+    confidence: 0.0261
+  discogs_id: null
+  notes: ''
+William Basinski:
+  slug: william_basinski
+  status: draft
+  description: 'William Basinski works almost exclusively in instrumental ambient
+    and musique concrète forms, building compositions from decayed, looping tape fragments
+    and degraded analogue recordings. His sonic palette is dense with warm hiss, flutter,
+    and granular erosion — textures that feel simultaneously archaic and weightless.
+    Production foregrounds entropy itself: source material dissolves, smears, or drops
+    out incrementally, making deterioration a structural element rather than a flaw.
+    Thematically, his work circles loss, impermanence, and the fragility of memory
+    — imagery often evokes abandoned spaces, fading light, and the passage of geological
+    or historical time. The emotional register is profoundly melancholic yet contemplative,
+    carrying a muted, elegiac stillness that resists catharsis. There is no vocal
+    presence; meaning emerges entirely through timbre, duration, and the subtle drama
+    of material decay. Density shifts slowly, rewarding extended, immersive listening
+    with gradual tonal and textural transformation.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4328
+      present: 0.2576
+      future: 0.3096
+    spatial:
+      thing: 0.4339
+      place: 0.3091
+      person: 0.257
+    ontological:
+      imagined: 0.3461
+      forgotten: 0.2954
+      known: 0.3584
+    confidence: 0.0361
+  discogs_id: null
+  notes: ''
+Huerco S.:
+  slug: huerco_s
+  status: draft
+  description: 'Huerco S. works primarily in instrumental electronic music, crafting
+    dense, heavily processed soundscapes that blur the boundaries between ambient,
+    techno, and experimental music. Textures are thick and granular, built from degraded
+    loops, saturated low-end frequencies, and heavily filtered synthesizer tones that
+    feel submerged or corroded. The production approach favors lo-fi warmth, tape
+    saturation, and a sense of material decay — sounds appear to be eroding in real
+    time. Rhythmic elements, when present, are murky and diffuse, dissolving into
+    textural fog rather than asserting clear pulse. There are no conventional vocals
+    or lyrics; communication is entirely sonic and atmospheric. Thematically, the
+    work evokes isolation, geological timescales, entropy, and a kind of pastoral
+    desolation. The emotional register is introspective and melancholic, suggesting
+    vast empty spaces — industrial ruins, flat landscapes, or slow environmental degradation
+    — conveying stillness threaded with unease.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4262
+      present: 0.2621
+      future: 0.3117
+    spatial:
+      thing: 0.4272
+      place: 0.3113
+      person: 0.2615
+    ontological:
+      imagined: 0.3482
+      forgotten: 0.2972
+      known: 0.3546
+    confidence: 0.0271
+  discogs_id: null
+  notes: ''
+Loscil:
+  slug: loscil
+  status: draft
+  description: 'Loscil works primarily in instrumental ambient and electronic music,
+    building immersive soundscapes through layered synthesis, processed field recordings,
+    and slow-evolving drones. The production aesthetic favors low-frequency warmth,
+    granular textures, and deliberate harmonic ambiguity, with individual sounds emerging
+    from and dissolving back into dense sonic fog. Rhythmic elements, when present,
+    are subdued — often drawn from manipulated acoustic or industrial sources, providing
+    subtle pulse rather than propulsion. Thematically, the music gravitates toward
+    aquatic and maritime imagery, urban stillness, and liminal environmental states,
+    evoking spaces between waking and sleep, depth and surface. The emotional register
+    is introspective and melancholic, occupying a cool, contemplative psychological
+    space — meditative without being passive, melancholic without urgency. Silence
+    and negative space function as compositional tools, allowing textures to breathe
+    and accumulate meaning gradually over extended durations.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4307
+      present: 0.2586
+      future: 0.3107
+    spatial:
+      thing: 0.4316
+      place: 0.3105
+      person: 0.2578
+    ontological:
+      imagined: 0.3445
+      forgotten: 0.2971
+      known: 0.3584
+    confidence: 0.0318
+  discogs_id: null
+  notes: ''
+Hiroshi Yoshimura:
+  slug: hiroshi_yoshimura
+  status: draft
+  description: 'Hiroshi Yoshimura works primarily in instrumental ambient music, constructing
+    immersive sonic environments through sparse, carefully spaced timbres. His production
+    favors natural acoustic textures — water, wind, rustling foliage — woven alongside
+    gentle synthesizer tones and soft electronic pads, creating low-density soundscapes
+    with significant use of silence and negative space. Studio processing tends toward
+    clean, uncluttered reverb that mimics spatial depth rather than artificiality.
+    Thematically, his work centers on natural phenomena, domestic tranquility, and
+    the quiet rhythms of environmental observation — rain, seasons, interior light,
+    open water. The emotional register is contemplative and restful, evoking a state
+    of attentive stillness rather than melancholy or tension. Psychological coloring
+    leans toward a serene, almost meditative neutrality that invites passive listening.
+    Dynamics remain consistently gentle, with gradual textural shifts replacing conventional
+    melodic development.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4298
+      present: 0.2569
+      future: 0.3133
+    spatial:
+      thing: 0.4304
+      place: 0.3132
+      person: 0.2564
+    ontological:
+      imagined: 0.3404
+      forgotten: 0.2995
+      known: 0.36
+    confidence: 0.0192
+  discogs_id: null
+  notes: ''
+Leyland Kirby:
+  slug: leyland_kirby
+  status: draft
+  description: 'Leyland Kirby works primarily in instrumental electronic music, with
+    occasional fragmented or degraded vocal samples dissolved into texture rather
+    than foregrounded as melody. His production aesthetic centres on heavily processed,
+    decayed audio — wax-cylinder warmth, vinyl surface noise, tape flutter, and deliberate
+    signal deterioration create a sense of material disintegrating over time. Textures
+    are dense yet paradoxically spacious, layering slow harmonic drones, ghost-like
+    melodic remnants, and ambient hiss into immersive, suffocating atmospheres. Thematically,
+    his work circles obsessively around memory, loss, cognitive dissolution, and the
+    unreliability of the past — imagery of fog, erasure, and incompleteness permeates
+    the conceptual framework. The emotional register is profoundly melancholic, elegiac,
+    and psychologically unsettling, evoking dissociation and grief without sentimentality.
+    Time itself feels distorted or collapsed. The overall mood is one of sustained,
+    contemplative dread softened by a kind of mournful beauty.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4393
+      present: 0.2521
+      future: 0.3086
+    spatial:
+      thing: 0.4403
+      place: 0.3081
+      person: 0.2516
+    ontological:
+      imagined: 0.3495
+      forgotten: 0.2928
+      known: 0.3577
+    confidence: 0.0286
+  discogs_id: null
+  notes: ''
+Jóhann Jóhannsson:
+  slug: j_hann_j_hannsson
+  status: draft
+  description: 'Jóhann Jóhannsson works primarily in the instrumental domain, weaving
+    orchestral strings, brass, and woodwinds with processed electronics, field recordings,
+    and subtle digital manipulation. His sonic textures tend toward slow, layered
+    density — sounds accumulate gradually, with reverb-soaked timbres dissolving into
+    one another, creating an atmosphere between the organic and the synthetic. Production
+    character is cinematic yet intimate, favouring quiet dynamics and unhurried pacing.
+    Thematically, his work gravitates toward themes of memory, loss, technological
+    alienation, the passage of time, and the relationship between human experience
+    and industrial or mechanical systems. Imagery suggests vast, cold landscapes alongside
+    interior psychological spaces. The emotional register is predominantly melancholic,
+    contemplative, and quietly unsettling — mourning without drama, tension without
+    resolution. Sparse melodic figures emerge from dense harmonic environments, evoking
+    fragility and impermanence. The overall psychological colour is introspective,
+    sombre, and hauntingly still.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4272
+      present: 0.2583
+      future: 0.3144
+    spatial:
+      thing: 0.4282
+      place: 0.3139
+      person: 0.2579
+    ontological:
+      imagined: 0.3401
+      forgotten: 0.3013
+      known: 0.3586
+    confidence: 0.0246
+  discogs_id: null
+  notes: ''
+Eliane Radigue:
+  slug: eliane_radigue
+  status: draft
+  description: 'Radigue works exclusively in the instrumental domain, constructing
+    immersive drone-based compositions through analog synthesizer (primarily the ARP
+    2500) and, later, acoustic instruments. Her sonic texture is extraordinarily slow-moving,
+    built from layered sine-wave oscillations, beating frequencies, and near-imperceptible
+    microtonal shifts that create a sense of living, breathing sound-mass. Density
+    is sparse yet enveloping, with production characterized by extended duration,
+    minimal attack and decay, and an absence of rhythmic pulse. Thematically, her
+    work gravitates toward contemplative and metaphysical territory — cycles, transience,
+    inner stillness, and states of consciousness informed by Tibetan Buddhist thought.
+    The emotional register is profoundly meditative, evoking suspension and dissolution
+    rather than tension or resolution. Psychological colour tends toward the vast
+    and quietly luminous, inducing a heightened attentiveness to minute sonic change
+    within apparent stasis.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4366
+      present: 0.2547
+      future: 0.3086
+    spatial:
+      thing: 0.4375
+      place: 0.3085
+      person: 0.2539
+    ontological:
+      imagined: 0.3323
+      forgotten: 0.2999
+      known: 0.3679
+    confidence: 0.025
+  discogs_id: null
+  notes: ''
+Don Caballero:
+  slug: don_caballero
+  status: draft
+  description: 'Don Caballero is a primarily instrumental band. Their sonic texture
+    is dense and interlocking, built around polyrhythmic, mathematically precise guitar
+    work that avoids traditional chord-based harmony in favour of independent melodic
+    lines moving against each other. Production tends toward a clean, dry clarity
+    that exposes the technical architecture rather than obscuring it. Bass and drums
+    carry enormous structural weight, with the kit functioning almost as a lead voice
+    — complex, aggressive, and constantly shifting meter. Guitar timbres range from
+    glassy and transparent to abrasive, often without distortion in conventional rock
+    terms. There are no lyrics to speak of; the music communicates entirely through
+    rhythmic tension and release. Emotionally, the register is taut and cerebral,
+    carrying an undercurrent of controlled aggression and restless momentum, occasionally
+    opening into spacious, meditative passages before collapsing back into dense rhythmic
+    counterpoint. The psychological colour is focused, pressurised, and relentlessly
+    kinetic.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4325
+      present: 0.2583
+      future: 0.3092
+    spatial:
+      thing: 0.4336
+      place: 0.3089
+      person: 0.2575
+    ontological:
+      imagined: 0.3521
+      forgotten: 0.2945
+      known: 0.3535
+    confidence: 0.0225
+  discogs_id: null
+  notes: ''
+Godspeed You! Black Emperor:
+  slug: godspeed_you_black_emperor
+  status: draft
+  description: 'Godspeed You! Black Emperor operates primarily as an instrumental
+    ensemble, occasionally incorporating found-voice spoken word fragments rather
+    than conventional vocals. Their sonic texture is dense and slowly evolving, built
+    from layered guitars, strings, bass, drums, and tape-sourced field recordings,
+    producing a warm yet abrasive orchestral weight. Production carries an intentionally
+    raw, analog quality — rough edges preserved, silence used structurally. Compositions
+    move in long arcs, building from sparse, almost static openings through gradual
+    crescendos toward overwhelming, distortion-saturated climaxes before collapsing
+    back into quiet. Thematically, the work circles around decay, collapse, and survival
+    within failing civic and industrial landscapes — urban ruin, marginal communities,
+    systemic entropy. Imagery tends toward the abandoned, the nocturnal, and the documentary.
+    The emotional register is predominantly mournful and apocalyptic, carrying a sustained
+    tension between grief and defiant endurance, with a psychological colour that
+    feels both vast and suffocating.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4252
+      present: 0.2583
+      future: 0.3166
+    spatial:
+      thing: 0.4261
+      place: 0.3161
+      person: 0.2578
+    ontological:
+      imagined: 0.346
+      forgotten: 0.301
+      known: 0.3531
+    confidence: 0.026
+  discogs_id: null
+  notes: ''
+Univers Zero:
+  slug: univers_zero
+  status: draft
+  description: 'Univers Zero is primarily an instrumental ensemble working in a dense,
+    chamber-darkened sound world where acoustic and electric textures collide with
+    deliberate severity. Production favors an austere, close-miked clarity that exposes
+    the grain of each instrument — bassoon, oboe, cello, electric guitar, and percussion
+    interlock in tightly notated, often dissonant counterpoint. The sonic density
+    ranges from sparse, threatening quietude to crushing tutti passages, with rhythms
+    that are mechanically precise yet organically unsettling. Thematic tendencies
+    draw from gothic and expressionist imagery: darkness, ritual, decay, and existential
+    dread rendered without sentimentality. The emotional register is relentlessly
+    grim and psychologically oppressive, evoking claustrophobia and cold menace rather
+    than catharsis. Influences from Bartók, Stravinsky, and medieval modal harmony
+    are absorbed into a post-rock compositional framework, producing music that feels
+    simultaneously ancient and industrial in atmosphere.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4143
+      present: 0.2684
+      future: 0.3173
+    spatial:
+      thing: 0.4151
+      place: 0.3171
+      person: 0.2678
+    ontological:
+      imagined: 0.3436
+      forgotten: 0.3048
+      known: 0.3516
+    confidence: 0.0147
+  discogs_id: null
+  notes: ''
+This Heat:
+  slug: this_heat
+  status: draft
+  description: 'This Heat occupies a dense, abrasive sonic territory where industrial
+    clatter, tape manipulation, and post-punk rhythms collide. Productions feel deliberately
+    fractured — layered with found sound, distorted repetition, and stark dynamic
+    shifts between silence and noise. Studio space is treated as compositional material;
+    recordings carry an analogue rawness and deliberate disorientation.
+
+
+    Vocals are present but often processed, chanted, or deployed collectively, functioning
+    somewhere between speech, incantation, and song. Instrumental passages carry equal
+    weight, creating a balance between vocal and non-vocal modes.
+
+
+    Lyrically, themes orbit systemic collapse, political anxiety, environmental dread,
+    and the fragility of social structures. Imagery tends toward the blunt and concrete
+    rather than the poetic or ornamental, delivered with an urgent, declaratory tone.
+
+
+    The emotional register is tense, claustrophobic, and unsettled — carrying persistent
+    undercurrents of alarm and cold existential unease without resolving into catharsis.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4185
+      present: 0.2641
+      future: 0.3174
+    spatial:
+      thing: 0.4192
+      place: 0.317
+      person: 0.2638
+    ontological:
+      imagined: 0.3405
+      forgotten: 0.3037
+      known: 0.3558
+    confidence: 0.0195
+  discogs_id: null
+  notes: ''
+Murcof:
+  slug: murcof
+  status: draft
+  description: 'Murcof operates primarily in the instrumental domain, weaving processed
+    classical samples — strings, piano, choral fragments — into sparse, glacially
+    paced electronic architectures. The production favors wide dynamic contrast, with
+    silences treated as structural elements alongside deep sub-bass pulses and delicately
+    granular textures. Layering is restrained yet precise, creating a sense of vast,
+    cold space. Thematically, the work gravitates toward mortality, ritual, transcendence,
+    and the liminal — drawing on pre-Columbian imagery and a sense of ancient, ceremonial
+    gravity without relying on overt narrative. The emotional register is contemplative
+    and austere, carrying a melancholic weight that occasionally opens into something
+    luminous or devotional. Density shifts slowly, building tension through accumulation
+    rather than rhythmic urgency. The overall psychological colour is introspective
+    and solemn, evoking desolate landscapes and interior stillness.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4276
+      present: 0.2591
+      future: 0.3133
+    spatial:
+      thing: 0.4284
+      place: 0.313
+      person: 0.2586
+    ontological:
+      imagined: 0.3379
+      forgotten: 0.3019
+      known: 0.3602
+    confidence: 0.0287
+  discogs_id: null
+  notes: ''
+Emptyset:
+  slug: emptyset
+  status: draft
+  description: 'Emptyset operates primarily as an instrumental project, blending industrial
+    techno with processed acoustic and architectural sound sources. Their production
+    character is dense and physically imposing — heavily distorted bass frequencies,
+    degraded percussive textures, and granular manipulation create a sense of material
+    decay and structural collapse. Studio treatments emphasize concrete resonance,
+    feedback, and mechanical noise, giving compositions a raw, almost geological weight.
+    Dynamic contrasts move between suffocating pressure and sudden sparse silence.
+    Thematically, their work orbits entropy, industrial systems, and the sonic properties
+    of physical spaces and materials — exploring tension between organic and mechanical
+    processes. The emotional register is austere and confrontational, evoking psychological
+    states of unease, endurance, and submission to overwhelming force. There is minimal
+    vocal presence; when voice appears, it is processed beyond intelligibility into
+    texture rather than communication.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4276
+      present: 0.2571
+      future: 0.3153
+    spatial:
+      thing: 0.4282
+      place: 0.3151
+      person: 0.2567
+    ontological:
+      imagined: 0.3492
+      forgotten: 0.2969
+      known: 0.3539
+    confidence: 0.0155
+  discogs_id: null
+  notes: ''
+Hildegard Westerkamp:
+  slug: hildegard_westerkamp
+  status: draft
+  description: 'Westerkamp works exclusively in instrumental electroacoustic and soundscape
+    composition, eschewing vocals entirely. Her sonic palette foregrounds field recordings
+    — urban ambiences, natural environments, indoor acoustic spaces — layered with
+    subtle electronic processing: slow filtering, pitch transposition, granular-like
+    stretching, and gentle tape-style manipulation that preserves source recognizability
+    while dissolving boundaries between document and composition. Textures tend toward
+    sparse, spacious densities with sudden intimate close-ups of sound, creating a
+    microphone-as-ear quality. Thematically, her work engages with place, ecological
+    listening, urban noise, and the relationship between interior psychological states
+    and exterior acoustic environments. The emotional register is contemplative, occasionally
+    unsettling, often meditative — inviting concentrated attention rather than passive
+    reception. There is a persistent undercurrent of fragility and quiet urgency,
+    particularly around themes of environmental vulnerability and the act of deep
+    listening itself as a form of awareness.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4468
+      present: 0.2468
+      future: 0.3064
+    spatial:
+      thing: 0.4477
+      place: 0.3062
+      person: 0.2461
+    ontological:
+      imagined: 0.346
+      forgotten: 0.2926
+      known: 0.3614
+    confidence: 0.027
+  discogs_id: null
+  notes: ''
+Francisco López:
+  slug: francisco_l_pez
+  status: draft
+  description: null
+  style_tags: []
   chromatic_score: null
   discogs_id: null
-  notes: ""
+  notes: Unknown artist — fill description manually
+Alvin Lucier:
+  slug: alvin_lucier
+  status: draft
+  description: 'Lucier''s sonic world is defined by radical simplicity and slow transformation.
+    His work is predominantly instrumental and process-driven, built from pure tones,
+    sine waves, room acoustics, and acoustic phenomena such as beating frequencies
+    and resonance. Textures are sparse and clinical, often arising from a single sound
+    source interacting with physical space rather than conventional studio layering.
+    Production character is raw and documentary, foregrounding the environment itself
+    as a compositional element. Thematically, his work orbits perception, the physics
+    of sound, spatial architecture, and the boundary between signal and noise. There
+    is no conventional lyricism; the physical phenomenon is the subject. Emotionally,
+    the register is meditative, austere, and contemplative — inducing a heightened
+    attentiveness rather than conventional feeling. Time is stretched, change is incremental,
+    and the listener''s awareness of acoustic reality becomes the primary psychological
+    experience.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4258
+      present: 0.2584
+      future: 0.3158
+    spatial:
+      thing: 0.4269
+      place: 0.3152
+      person: 0.258
+    ontological:
+      imagined: 0.3432
+      forgotten: 0.3021
+      known: 0.3547
+    confidence: 0.0251
+  discogs_id: null
+  notes: ''
+Jana Winderen:
+  slug: jana_winderen
+  status: draft
+  description: 'Jana Winderen works exclusively in instrumental sound art and field
+    recording. Her sonic texture is dense, immersive, and layered — raw environmental
+    recordings (underwater acoustics, insect swarms, arctic ambience) are processed
+    and sculpted into continuous, breathing soundscapes. Production is spatially expansive,
+    favouring high-fidelity capture of non-human sonic worlds, with subtle electronic
+    manipulation that preserves organic grain and unpredictability. Frequencies span
+    extremes — deep sub-bass rumble coexisting with ultrasonic shimmer — creating
+    a sense of vast, pressurised space. Thematically, her work circles around hidden
+    natural systems: the interior life of oceans, subterranean ecosystems, and the
+    acoustic behaviours of creatures beyond ordinary human perception. The tone is
+    non-narrative and contemplative, evoking geological timescales and ecological
+    depth. Emotionally, the register oscillates between wonder and unease — meditative
+    yet subtly unsettling, suggesting a world indifferent to human presence.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4269
+      present: 0.2593
+      future: 0.3138
+    spatial:
+      thing: 0.4277
+      place: 0.3135
+      person: 0.2588
+    ontological:
+      imagined: 0.3436
+      forgotten: 0.2993
+      known: 0.3571
+    confidence: 0.0251
+  discogs_id: null
+  notes: ''
+Luc Ferrari:
+  slug: luc_ferrari
+  status: draft
+  description: 'Luc Ferrari''s sonic world is built on musique concrète and electroacoustic
+    principles, blending field recordings with electronic manipulation to create richly
+    layered, documentary-like textures. His production approach favors transparency
+    and intimacy, allowing environmental sounds — urban ambience, nature, human voices
+    in conversation — to retain their raw, unprocessed quality alongside more abstract
+    electronic elements. The density shifts fluidly between sparse, isolated sonic
+    events and densely woven soundscapes. Thematically, his work gravitates toward
+    the everyday, the erotic, the political, and the mundane, treating overheard reality
+    as compositional material. The imagery is grounded, sensual, and occasionally
+    voyeuristic, with a strong sense of place and human presence. Emotionally, the
+    register oscillates between warmth, irony, melancholy, and quiet curiosity. His
+    output is predominantly instrumental and electronic, though spoken and recorded
+    voices frequently function as sonic and narrative elements rather than traditional
+    vocal performance.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4291
+      present: 0.2599
+      future: 0.311
+    spatial:
+      thing: 0.4302
+      place: 0.3106
+      person: 0.2592
+    ontological:
+      imagined: 0.3443
+      forgotten: 0.2974
+      known: 0.3582
+    confidence: 0.0286
+  discogs_id: null
+  notes: ''
+Lau Nau:
+  slug: lau_nau
+  status: draft
+  description: 'Lau Nau (Laura Naukkarinen) works primarily as a vocal artist, her
+    voice often layered into soft, overlapping clouds that blur the boundary between
+    instrument and song. Productions are intimate and low-density, favouring delicate
+    acoustic textures — guitar, zither-like tones, light percussion — wrapped in subtle
+    reverb and tape warmth. Arrangements remain sparse, allowing silence and breath
+    to function as compositional elements. Thematically, her work gravitates toward
+    nature, remoteness, and quiet interiority, drawing on imagery of forests, water,
+    and seasonal change. Finnish appears as a language whose phonetic texture integrates
+    smoothly with the sonic palette. The emotional register is contemplative, hushed,
+    and slightly melancholic, evoking solitude without distress — a kind of cool,
+    Nordic stillness. Studio choices emphasise organic imperfection over polish, lending
+    recordings a handmade, almost field-recorded quality despite their careful construction.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4389
+      present: 0.2536
+      future: 0.3076
+    spatial:
+      thing: 0.4398
+      place: 0.3073
+      person: 0.2529
+    ontological:
+      imagined: 0.3464
+      forgotten: 0.2925
+      known: 0.3612
+    confidence: 0.0315
+  discogs_id: null
+  notes: ''
+Hildur Guðnadóttir:
+  slug: hildur_gu_nad_ttir
+  status: draft
+  description: 'Hildur Guðnadóttir works primarily in the instrumental domain, with
+    occasional wordless vocal textures woven into dense orchestral and electronic
+    frameworks. Her sonic palette favors extended cello techniques — bowing, scraping,
+    resonant drones — layered with processed strings, field recordings, and subtle
+    electronic manipulation to create immersive, dark tonal environments. Production
+    tends toward spatial depth, with sounds given room to decay and breathe, emphasizing
+    silence as structural material. Thematically, her work gravitates toward psychological
+    interiority, fragmentation, and the threshold between order and dissolution, often
+    evoking interior architecture — corridors, enclosed spaces, inward collapse. The
+    emotional register is consistently somber, suspended, and pressurized — neither
+    fully resolved nor chaotic, but held in a state of controlled dread or grief.
+    Textures shift slowly, building accumulative weight rather than melodic development,
+    creating a cinematic, inward-facing emotional experience.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4448
+      present: 0.2471
+      future: 0.3081
+    spatial:
+      thing: 0.4456
+      place: 0.3078
+      person: 0.2466
+    ontological:
+      imagined: 0.3413
+      forgotten: 0.2945
+      known: 0.3642
+    confidence: 0.0262
+  discogs_id: null
+  notes: ''
+Hauschka:
+  slug: hauschka
+  status: draft
+  description: 'Hauschka works primarily in instrumental composition, blending prepared
+    piano with electronic percussion, found sounds, and rhythmic mechanical textures.
+    His sonic palette favours a dense yet playful interplay between acoustic and synthetic
+    elements — piano strings altered with objects produce metallic, muted, or rattling
+    timbres that sit alongside pulsing drum machine patterns and ambient noise. Production
+    tends toward a dry, intimate quality with deliberate imperfection, emphasising
+    the physical character of sound-making. Thematically, his work evokes urban energy,
+    repetitive motion, and controlled chaos — imagery of machinery, crowded spaces,
+    and systematic patterns underlies much of the compositional logic. Emotionally,
+    the register shifts between kinetic momentum and introspective stillness, carrying
+    a restless yet disciplined psychological colour. The music balances intellectual
+    structure with tactile warmth, suggesting both mathematical precision and spontaneous
+    experimentation.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4317
+      present: 0.2553
+      future: 0.313
+    spatial:
+      thing: 0.4323
+      place: 0.3127
+      person: 0.255
+    ontological:
+      imagined: 0.3466
+      forgotten: 0.2954
+      known: 0.358
+    confidence: 0.0205
+  discogs_id: null
+  notes: ''
+Félicia Atkinson:
+  slug: f_licia_atkinson
+  status: draft
+  description: 'Félicia Atkinson works in a space between vocal and instrumental music,
+    with voice often functioning as texture rather than narrative delivery — murmured,
+    half-spoken, and deeply intimate. Her productions layer field recordings, sparse
+    piano, gentle electronics, and ambient drones into compositions of low density
+    and careful silence. The studio approach feels intentionally fragile, with sounds
+    left unpolished and space treated as compositional material. Thematically, her
+    work circles nature, perception, interior states, and a kind of philosophical
+    attentiveness to the everyday — imagery tends toward landscape, quietude, and
+    sensory minutiae. The emotional register is contemplative and tender, carrying
+    a mood of gentle melancholy softened by curiosity. There is a distinctly poetic,
+    almost aphoristic quality to her textual contributions, favouring suggestion over
+    statement. The overall affect is hushed, meditative, and dreamlike — music that
+    exists near the threshold of audibility.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4372
+      present: 0.2491
+      future: 0.3137
+    spatial:
+      thing: 0.438
+      place: 0.3133
+      person: 0.2488
+    ontological:
+      imagined: 0.3487
+      forgotten: 0.2943
+      known: 0.357
+    confidence: 0.0307
+  discogs_id: null
+  notes: ''
+Moondog:
+  slug: moondog
+  status: draft
+  description: 'Moondog''s sonic world is sparse yet intricate, built from homemade
+    percussion instruments, wooden blocks, and unconventional tuned surfaces that
+    produce dry, resonant, almost ritualistic timbres. His production carries an acoustic
+    intimacy — minimal reverb, close-miked textures, rhythmic patterns rooted in polyrhythmic
+    counterpoint. The density oscillates between stark solo percussion and surprisingly
+    lush canons or rounds featuring voices and strings. He works in both instrumental
+    and vocal modes; choral rounds are a recurring signature, with voices treated
+    as interlocking structural voices rather than expressive soloists. Lyrically,
+    his themes lean toward nature, cosmology, primitive spirituality, and mythological
+    abstraction, rendered in a detached, incantatory tone. Emotionally, the music
+    occupies a meditative, slightly austere register — ceremonial without being solemn,
+    ancient-feeling without nostalgia. There is a consistent undercurrent of rhythmic
+    hypnosis and geometric calm.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4218
+      present: 0.2625
+      future: 0.3158
+    spatial:
+      thing: 0.4224
+      place: 0.3155
+      person: 0.262
+    ontological:
+      imagined: 0.3356
+      forgotten: 0.3049
+      known: 0.3594
+    confidence: 0.02
+  discogs_id: null
+  notes: ''
+Nico Muhly:
+  slug: nico_muhly
+  status: draft
+  description: 'Nico Muhly works primarily in instrumental and choral-adjacent classical
+    contemporary idioms, blending acoustic chamber textures with subtle electronic
+    processing. His sonic palette favors layered strings, organ, and voices treated
+    with gentle reverb and spatial depth, creating a luminous, cathedral-inflected
+    density. Production tends toward transparency — individual timbres remain identifiable
+    within carefully woven counterpoint. Thematically, his work draws on liturgical
+    tradition, language, annotation, and mapping — recurring preoccupations with text
+    as visual artifact and meaning as layered or fragmented. The emotional register
+    is contemplative and introspective, often suspending resolution to cultivate a
+    sense of hovering unease beneath surface serenity. Modal harmonies and minimalist
+    repetition generate slow psychological accumulation, shifting between vulnerability
+    and restraint. When vocal, singers are treated as instrumental voices within an
+    ensemble architecture rather than as foregrounded soloists. Stillness and precision
+    coexist with an underlying emotional tension.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.442
+      present: 0.2482
+      future: 0.3099
+    spatial:
+      thing: 0.4426
+      place: 0.3098
+      person: 0.2476
+    ontological:
+      imagined: 0.3448
+      forgotten: 0.2941
+      known: 0.3611
+    confidence: 0.0208
+  discogs_id: null
+  notes: ''
+Scott Walker:
+  slug: scott_walker
+  status: draft
+  description: 'Scott Walker is primarily a vocalist, with a rich, operatic baritone
+    as the central instrument. Production is dense and cinematic, drawing on orchestral
+    arrangements — sweeping strings, brass, and dissonant chamber textures — contrasted
+    against stark, isolating silence and abrupt sonic intrusions. Later work employs
+    avant-garde studio techniques: percussive body sounds, atonal clusters, and deeply
+    processed timbres that create unsettling, fragmented soundscapes. Lyrically, themes
+    orbit existential dread, alienation, war, bodily mortality, and surrealist imagery
+    drawn from European modernist sensibilities — figures displaced in hostile, often
+    bureaucratic or political landscapes. Tone oscillates between grandiose formality
+    and claustrophobic unease, resisting narrative resolution. The emotional register
+    is cold yet operatically intense — detached intellectualism fused with visceral
+    psychological disturbance. There is a persistent tension between beauty and grotesquerie,
+    with compositional structures that deliberately subvert listener expectation and
+    conventional musical comfort.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4069
+      present: 0.2732
+      future: 0.3198
+    spatial:
+      thing: 0.4076
+      place: 0.3196
+      person: 0.2728
+    ontological:
+      imagined: 0.3378
+      forgotten: 0.3088
+      known: 0.3535
+    confidence: 0.0106
+  discogs_id: null
+  notes: ''
+Arvo Pärt:
+  slug: arvo_p_rt
+  status: draft
+  description: 'Pärt works primarily in both instrumental and choral-vocal idioms,
+    often blending sacred choral writing with chamber and orchestral forces. His sonic
+    texture is sparse and luminous — single melodic lines move against sustained,
+    drone-like harmonies, creating a crystalline, reverberant quality. Production
+    typically preserves long decay and ambient silence, treating space itself as compositional
+    material. Thematically, his work draws on liturgical and contemplative imagery:
+    prayer, stillness, grief, and transcendence rendered through minimal motivic gestures.
+    The harmonic language hovers between modal tonality and gentle dissonance, resolving
+    slowly and deliberately. Emotionally, the register is austere yet tender — meditative,
+    sorrowful, occasionally radiant — evoking introspection and a sense of suspended
+    time. Density remains consistently low, with individual timbral strands — bell
+    tones, bowed strings, unaccompanied voices — granted maximum clarity and isolation
+    within the texture.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4142
+      present: 0.263
+      future: 0.3227
+    spatial:
+      thing: 0.4148
+      place: 0.3223
+      person: 0.2628
+    ontological:
+      imagined: 0.333
+      forgotten: 0.3111
+      known: 0.3559
+    confidence: 0.0151
+  discogs_id: null
+  notes: ''
+Nick Drake:
+  slug: nick_drake
+  status: draft
+  description: 'Nick Drake''s music occupies an intimate, acoustic space defined by
+    fingerpicked guitar in open or alternate tunings, creating a resonant, harmonically
+    ambiguous foundation. Production is sparse and close-miked, placing voice and
+    instrument in an almost uncomfortably near proximity, with occasional string arrangements
+    adding cool, melancholic texture without crowding the silence. He is primarily
+    a vocal artist, his voice soft, low, and unhurried, blending seamlessly with the
+    guitar rather than asserting itself above it. Lyrically, his work gravitates toward
+    nature imagery — seasons, rivers, light — as vehicles for introspection, alienation,
+    and longing. Time, transience, and a quiet sense of disconnection from the world
+    permeate his themes. The emotional register is predominantly melancholic and hushed,
+    carrying an undercurrent of vulnerability and psychological isolation, though
+    without melodrama. Texturally, the music feels nocturnal and autumnal, weighted
+    with stillness.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4242
+      present: 0.2626
+      future: 0.3132
+    spatial:
+      thing: 0.4255
+      place: 0.3125
+      person: 0.262
+    ontological:
+      imagined: 0.3427
+      forgotten: 0.302
+      known: 0.3553
+    confidence: 0.0361
+  discogs_id: null
+  notes: ''
+Damien Rice:
+  slug: damien_rice
+  status: draft
+  description: 'Damien Rice is primarily a vocal artist, foregrounding intimate, unadorned
+    voice as the central expressive instrument. Productions are sparse and organic
+    — acoustic guitar, cello, piano, and subtle percussion layered with deliberate
+    restraint, creating a textural fragility where silence functions as compositional
+    material. Dynamic range is extreme, moving from near-whispered vulnerability to
+    raw, fractured intensity within single pieces. Female vocal counterpoint appears
+    frequently, creating harmonic tension and emotional dialogue. Lyrically, imagery
+    tends toward domesticity and the body — rooms, water, hands, breath — used to
+    frame themes of romantic collapse, longing, guilt, and unresolved attachment.
+    Tone is confessional and psychologically exposed, resisting resolution or consolation.
+    The emotional register occupies a specific zone: grief that has not yet calcified
+    into acceptance, tenderness coexisting with anguish. Studio choices prioritise
+    the impression of captured intimacy over polish, with audible room tone and performance
+    imperfection treated as expressive rather than corrective.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4207
+      present: 0.2616
+      future: 0.3177
+    spatial:
+      thing: 0.4213
+      place: 0.3173
+      person: 0.2614
+    ontological:
+      imagined: 0.3275
+      forgotten: 0.3072
+      known: 0.3653
+    confidence: 0.0129
+  discogs_id: null
+  notes: ''
+Adrianne Lenker:
+  slug: adrianne_lenker
+  status: draft
+  description: 'Adrianne Lenker works primarily as a vocalist and guitarist, with
+    voice as the central expressive instrument. Her sonic texture is intimate and
+    sparse — close-mic''d acoustic guitar, breath and room noise left audible, minimal
+    production layering that preserves rawness and imperfection. Studio recordings
+    often feel field-recorded or deliberately unpolished. Lyrically, she favors sensory,
+    nature-saturated imagery — soil, light, water, bodies, seasons — woven into meditations
+    on impermanence, grief, longing, and tender human connection. Themes circle loss
+    and presence simultaneously, often without resolving tension. Her tone is confessional
+    but oblique, emotionally vulnerable without becoming sentimental. The emotional
+    register sits in a liminal space between sorrow and quiet wonder — melancholic
+    but not despairing, luminous but grounded. Melodic phrasing is conversational,
+    following speech rhythms. Harmonic choices tend toward open tunings and modal
+    color, creating a timeless, rootless-yet-rooted atmospheric quality.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4153
+      present: 0.2681
+      future: 0.3166
+    spatial:
+      thing: 0.4162
+      place: 0.3162
+      person: 0.2676
+    ontological:
+      imagined: 0.3394
+      forgotten: 0.3049
+      known: 0.3556
+    confidence: 0.0188
+  discogs_id: null
+  notes: ''
+The Antlers:
+  slug: the_antlers
+  status: draft
+  description: 'The Antlers craft densely layered indie rock and art-pop with an ethereal,
+    almost translucent production character. Vocals—central and expressive—float above
+    beds of reverb-drenched guitar, sparse piano, and softly pulsing drums, creating
+    an intimate yet expansive sonic space. Studio textures lean toward ambient warmth,
+    with careful dynamic contrast between near-silence and swelling orchestration.
+    Lyrically, their work gravitates toward grief, illness, codependence, psychological
+    rupture, and the ambiguity between care and harm, rendered through domestic and
+    clinical imagery. Metaphor carries significant weight; the tone is confessional
+    yet oblique, resisting direct narrative resolution. Emotionally, the register
+    occupies a fragile, aching vulnerability—haunted, tender, and suspended between
+    despair and cautious hope. Songs often build through accumulation rather than
+    conventional structure, allowing mood to dissolve and reconstitute. The work is
+    primarily vocal-led, though instrumental passages carry strong melodic and emotional
+    weight.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4284
+      present: 0.2592
+      future: 0.3124
+    spatial:
+      thing: 0.4292
+      place: 0.3121
+      person: 0.2587
+    ontological:
+      imagined: 0.3594
+      forgotten: 0.2923
+      known: 0.3484
+    confidence: 0.023
+  discogs_id: null
+  notes: ''
+Carla dal Forno:
+  slug: carla_dal_forno
+  status: draft
+  description: 'Carla dal Forno works primarily as a vocalist, layering hushed, intimate
+    singing over minimal electronic and post-punk frameworks. Her productions favour
+    sparse, low-density arrangements built from drum machines, bass guitar, and subdued
+    synthesiser textures, creating a deliberately lo-fi, close-miked intimacy. Reverb
+    and subtle decay extend sounds without overwhelming the skeletal structures, giving
+    recordings a submerged, interior quality. Lyrically, her work tends toward introspective
+    observation — quiet domestic scenes, interpersonal distance, drifting attention,
+    and ambiguous emotional states rendered in plain, understated language. Thematically,
+    alienation and stillness recur, framed without melodrama. The emotional register
+    is cool and melancholic, occupying a psychological space of detached longing and
+    restrained tension rather than overt expressiveness. Influences from minimal wave,
+    dub, and kosmische music surface in the repetitive, hypnotic pacing, while the
+    vocal delivery remains conversational and deliberately unadorned.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4381
+      present: 0.2548
+      future: 0.3071
+    spatial:
+      thing: 0.439
+      place: 0.3071
+      person: 0.2539
+    ontological:
+      imagined: 0.349
+      forgotten: 0.2933
+      known: 0.3577
+    confidence: 0.0251
+  discogs_id: null
+  notes: ''
+Death Cab for Cutie:
+  slug: death_cab_for_cutie
+  status: draft
+  description: 'Death Cab for Cutie is a vocal-led indie rock project built around
+    clean, precise guitar work layered over understated rhythmic foundations. Production
+    tends toward spacious clarity, favoring warmth and deliberate restraint over density,
+    with textural elements—organ, piano, soft electronic accents—introduced carefully
+    to deepen emotional weight without cluttering the sonic field. Dynamics shift
+    gradually, moving between hushed introspection and measured crescendos. Lyrically,
+    the work centers on impermanence, distance, mortality, romantic dissolution, and
+    the passage of time, rendered through specific domestic and geographic imagery
+    that grounds abstract feeling in concrete detail. The tone is quietly ruminative,
+    rarely confrontational, preferring melancholic acceptance over anguish. The emotional
+    register is predominantly autumnal—reflective, tender, tinged with longing and
+    resignation. Vocal delivery is gentle and earnest, closely integrated with the
+    melodic architecture rather than positioned as a theatrical centerpiece.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4454
+      present: 0.2493
+      future: 0.3052
+    spatial:
+      thing: 0.4464
+      place: 0.3051
+      person: 0.2485
+    ontological:
+      imagined: 0.3489
+      forgotten: 0.2895
+      known: 0.3616
+    confidence: 0.036
+  discogs_id: null
+  notes: ''
+Nico:
+  slug: nico
+  status: draft
+  description: 'Nico''s sound is defined by cavernous, drone-heavy production with
+    sparse arrangements centring harmonium, minimal percussion, and desolate string
+    or guitar textures. The sonic density is low, creating vast empty space around
+    each element. Her voice is a deep, flat contralto — expressionless yet hypnotic,
+    delivered with deliberate emotional detachment that functions as its own tonal
+    instrument. Studio approaches favour raw, unpolished atmospheres, avoiding warmth
+    or conventional polish.
+
+
+    Lyrically, themes orbit mortality, existential isolation, myth, darkness, and
+    spiritual desolation. Imagery draws from Gothic, pagan, and European romantic
+    traditions — cold landscapes, night, decay, and the void. Tone is ceremonial and
+    bleak without melodrama.
+
+
+    The emotional register is one of sustained, hollow dread — not anguish, but numbness
+    and cosmic indifference. The work is primarily vocal, though the voice operates
+    more as ritualistic instrument than expressive performance.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4078
+      present: 0.2748
+      future: 0.3174
+    spatial:
+      thing: 0.4086
+      place: 0.3171
+      person: 0.2742
+    ontological:
+      imagined: 0.3513
+      forgotten: 0.3031
+      known: 0.3456
+    confidence: 0.0128
+  discogs_id: null
+  notes: ''
+Microphones:
+  slug: microphones
+  status: draft
+  description: 'The Microphones (Phil Elverum) blend lo-fi home recording with cavernous,
+    mythic-scale sonics — intimate bedroom textures collide with overwhelming density,
+    creating a paradox of smallness and vastness. Production favors tape hiss, distortion,
+    sudden dynamic swells, and raw acoustic instruments layered with noise and field
+    recordings. Drums hit with physical weight while vocals remain hushed and close-miked,
+    creating spatial disorientation.
+
+
+    Lyrically, themes circle around nature as existential force — mountains, ocean,
+    wind, and fog serve as mirrors for interior states. Imagery tends toward elemental
+    and bodily: breath, bones, light, darkness. Tone is earnest and unflinching, approaching
+    mortality, longing, and dissolution without irony.
+
+
+    Emotionally, the register occupies grief, awe, and fragile tenderness simultaneously
+    — a psychological palette of melancholic wonder, occasionally tipping into dread.
+    Both vocal and instrumental elements carry equal expressive weight, functioning
+    as unified compositional texture rather than distinct layers.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4383
+      present: 0.2519
+      future: 0.3098
+    spatial:
+      thing: 0.4391
+      place: 0.3095
+      person: 0.2514
+    ontological:
+      imagined: 0.3451
+      forgotten: 0.2946
+      known: 0.3603
+    confidence: 0.0216
+  discogs_id: null
+  notes: ''
+Éliane Radigue:
+  slug: liane_radigue
+  status: draft
+  description: 'Radigue works almost exclusively in instrumental electronic music,
+    constructing immersive, slowly evolving drones built from analog synthesizer feedback,
+    tape manipulation, and ARP 2500 oscillation. Sonic textures are extraordinarily
+    dense yet transparent — layered harmonic partials drift and beat against each
+    other with glacial patience, creating a sense of continuous cellular motion within
+    apparent stillness. Production favors extreme low frequencies and near-inaudible
+    upper harmonics, demanding close, sustained listening. Dynamic range is narrow
+    but internally rich, with microtonal fluctuations forming the primary melodic
+    gesture.
+
+
+    Thematically, the work gravitates toward dissolution, cyclical transformation,
+    impermanence, and contemplative interiority — imagery aligned with Tibetan Buddhist
+    cosmological frameworks, without literal programmatic depiction. Tones feel ritualistic
+    and timeless rather than narrative or structural in a Western classical sense.
+    The emotional register is meditative, suspended, and quietly awe-adjacent — inducing
+    states of focused stillness and heightened perceptual sensitivity rather than
+    dramatic emotional arc.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.429
+      present: 0.258
+      future: 0.313
+    spatial:
+      thing: 0.4295
+      place: 0.313
+      person: 0.2575
+    ontological:
+      imagined: 0.3344
+      forgotten: 0.3023
+      known: 0.3633
+    confidence: 0.0136
+  discogs_id: null
+  notes: ''
+Talk Talk:
+  slug: talk_talk
+  status: draft
+  description: 'Talk Talk occupies a space between art rock and ambient minimalism,
+    characterised by sparse, breathing arrangements where silence functions as actively
+    as sound. Production is organic and unhurried — acoustic and electric instruments
+    decay naturally, with piano, woodwinds, and treated guitar existing in wide, reverberant
+    space. Density shifts dramatically, from near-empty passages to dense, improvised
+    clusters. The approach is primarily vocal, with the voice delivered in an intimate,
+    searching, emotionally raw manner, often surrounded by textural instrumentation
+    rather than conventional accompaniment. Lyrically, themes circle around spiritual
+    searching, human fragility, nature, and inner stillness, rendered through elliptical,
+    imagistic language that resists literal interpretation. The emotional register
+    is contemplative, hushed, and occasionally anguished — psychologically introspective,
+    evoking solitude and unresolved yearning. The overall atmosphere suggests quiet
+    revelation rather than resolution, prioritising mood and texture over conventional
+    song structure.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4359
+      present: 0.2535
+      future: 0.3107
+    spatial:
+      thing: 0.4366
+      place: 0.3103
+      person: 0.2531
+    ontological:
+      imagined: 0.3474
+      forgotten: 0.2941
+      known: 0.3585
+    confidence: 0.0235
+  discogs_id: null
+  notes: ''
+Harold Budd:
+  slug: harold_budd
+  status: draft
+  description: 'Harold Budd works almost exclusively in instrumental territory, occasionally
+    incorporating wordless or near-absent voice as pure texture. His sonic palette
+    is defined by slow-decay piano tones, heavily reverberant and drenched in ambient
+    space, sitting within vast, luminous synthesizer washes. Production character
+    favors extreme openness — sounds are allowed to breathe and dissolve rather than
+    sustain sharply, creating an impression of rooms without walls. Density remains
+    consistently low, with significant silence functioning as compositional material.
+    Thematically, his work orbits dreamlike, interior landscapes — twilight imagery,
+    stillness, sacred or contemplative spaces, and the boundary between waking and
+    sleep. Textures suggest warmth without sentimentality, melancholy without distress.
+    The emotional register is introspective and meditative, carrying a quality of
+    suspended time — muted wonder, hushed reverence, and a soft, enveloping melancholy
+    that never resolves into darkness or overt drama.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4372
+      present: 0.2526
+      future: 0.3102
+    spatial:
+      thing: 0.438
+      place: 0.31
+      person: 0.2521
+    ontological:
+      imagined: 0.3367
+      forgotten: 0.299
+      known: 0.3643
+    confidence: 0.0257
+  discogs_id: null
+  notes: ''
+Kate Bush:
+  slug: kate_bush
+  status: draft
+  description: 'Kate Bush works primarily as a vocalist, with her voice serving as
+    the central instrument — ranging from intimate whispers to dramatic, operatic
+    leaps across multiple registers. Sonically, her productions blend acoustic and
+    orchestral textures with synthesizers, creating dense, layered environments that
+    feel simultaneously intimate and vast. Studio construction is meticulous and theatrical,
+    favouring atmospheric depth over conventional pop clarity. Thematically, her work
+    explores mythology, folklore, literary references, nature, the supernatural, and
+    the interior landscape of human psychology — particularly femininity, desire,
+    grief, and transcendence. Imagery tends toward the elemental and symbolic, grounded
+    in the physical yet reaching toward the metaphysical. The emotional register is
+    intense and mercurial — shifting between vulnerability and ferocity, tenderness
+    and wildness. There is a persistent sense of altered states, dreamlike logic,
+    and emotional extremity, delivered with conviction that blurs the line between
+    performance and genuine possession.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4048
+      present: 0.2742
+      future: 0.321
+    spatial:
+      thing: 0.4059
+      place: 0.3203
+      person: 0.2738
+    ontological:
+      imagined: 0.3395
+      forgotten: 0.3085
+      known: 0.352
+    confidence: 0.0196
+  discogs_id: null
+  notes: ''
+Damien Jurado:
+  slug: damien_jurado
+  status: draft
+  description: 'Damien Jurado is a vocal-led artist working in folk, indie folk, and
+    lo-fi singer-songwriter traditions. Sonically, his recordings range from intimate
+    acoustic sparseness to layered, reverb-drenched psychedelic folk production, often
+    featuring hushed guitars, subtle percussion, and warm ambient textures with a
+    deliberately understated studio character. His production approach favors space
+    and restraint, allowing silence to function as compositional material. Lyrically,
+    his work gravitates toward fractured domestic narratives, rural and small-town
+    imagery, spiritual searching, loss, memory, and moral ambiguity, rendered through
+    plain-spoken yet elliptical language. Themes of isolation, faith, and quiet desperation
+    recur throughout. The emotional register is consistently introspective and melancholic,
+    carrying an undertow of unresolved tension and psychological ambiguity. His vocal
+    delivery is gentle and conversational, reinforcing an atmosphere of confessional
+    intimacy, while harmonic and melodic choices lean toward open-ended resolution.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4221
+      present: 0.2644
+      future: 0.3135
+    spatial:
+      thing: 0.423
+      place: 0.3131
+      person: 0.2639
+    ontological:
+      imagined: 0.3437
+      forgotten: 0.2997
+      known: 0.3566
+    confidence: 0.0146
+  discogs_id: null
+  notes: ''
+'Songs: Ohia':
+  slug: songs_ohia
+  status: draft
+  description: 'Songs: Ohia operates primarily as a vocal-driven project, anchored
+    by a deep, worn baritone that sits close in the mix with an intimate, confessional
+    presence. Production tends toward sparse, dry arrangements — acoustic guitar,
+    occasional organ, subtle percussion — with deliberate lo-fi warmth and room-tone
+    ambience rather than sonic polish. Textures range from stark minimalism to layered,
+    slow-burning drone, with electric guitar sometimes introducing trembling, distorted
+    weight. Lyrically, the work circles themes of spiritual searching, devotion, grief,
+    rural isolation, and fractured identity, using plain yet resonant imagery drawn
+    from landscapes, seasons, and interpersonal loss. The tone is unflinching and
+    austere, resisting sentimentality while remaining emotionally direct. The emotional
+    register is predominantly mournful and contemplative, carrying a psychological
+    heaviness balanced by occasional moments of restrained tenderness — an affect
+    of exhausted sincerity navigating guilt, faith, and longing.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4359
+      present: 0.2544
+      future: 0.3097
+    spatial:
+      thing: 0.4367
+      place: 0.3096
+      person: 0.2537
+    ontological:
+      imagined: 0.3429
+      forgotten: 0.2959
+      known: 0.3612
+    confidence: 0.0236
+  discogs_id: null
+  notes: ''
+Magnolia Electric Co.:
+  slug: magnolia_electric_co
+  status: draft
+  description: 'Magnolia Electric Co. centers on Jason Molina''s weathered baritone
+    as its primary instrument, set against arrangements that blend country, folk,
+    and slow-core rock. Production tends toward warm, spacious, and slightly worn
+    — analog-feeling recordings where pedal steel, electric guitar, and sparse rhythm
+    sections create an open, dusky sonic landscape. Density shifts between intimate
+    acoustic passages and fuller band swells, but never feels overproduced. Lyrically,
+    imagery draws heavily from night, vast open landscapes, railroads, celestial bodies,
+    and solitude — language that is plain yet freighted with metaphorical weight.
+    Thematically, displacement, longing, spiritual searching, and the persistence
+    of grief recur throughout. The emotional register is persistently mournful and
+    contemplative, carrying a sense of exhausted endurance rather than acute despair
+    — a low, sustained darkness with occasional moments of stark, open-sky transcendence.
+    The work is firmly vocal-led.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4383
+      present: 0.2527
+      future: 0.309
+    spatial:
+      thing: 0.4391
+      place: 0.3089
+      person: 0.252
+    ontological:
+      imagined: 0.3513
+      forgotten: 0.2923
+      known: 0.3564
+    confidence: 0.0215
+  discogs_id: null
+  notes: ''
+Hayden:
+  slug: hayden
+  status: draft
+  description: Petra Haden is a primarily vocal artist whose signature approach involves
+    layered, unaccompanied or lightly accompanied a cappella arrangements. Her sonic
+    texture is intimate and densely stacked, built from multitracked vocal overdubs
+    that simulate instrumental timbres — strings, horns, and rhythm sections rendered
+    entirely through voice. The production character tends toward intimate, close-miked
+    warmth with a handcrafted, analog-adjacent quality. Thematically, she gravitates
+    toward cover interpretations that reframe familiar material through stripped emotional
+    lenses, emphasizing vulnerability, solitude, and childlike wonder. Her imagery
+    is often nostalgic and introspective, dwelling in quiet domestic or inner-landscape
+    spaces. The emotional register is predominantly tender and melancholic, with occasional
+    playful lightness breaking through. Psychologically, her work carries a sense
+    of careful attention and stillness, as though sound itself is being examined under
+    soft light. The overall mood is hushed, contemplative, and warmly fragile.
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4289
+      present: 0.2592
+      future: 0.3119
+    spatial:
+      thing: 0.4298
+      place: 0.3117
+      person: 0.2585
+    ontological:
+      imagined: 0.3462
+      forgotten: 0.2974
+      known: 0.3564
+    confidence: 0.0244
+  discogs_id: null
+  notes: Artist is Petra Haden
+Palace Music:
+  slug: palace_music
+  status: draft
+  description: 'Will Oldham works primarily as a vocalist, with guitar-centered arrangements
+    kept sparse and deliberately unpolished. Production leans toward low-fidelity
+    intimacy — ambient room noise, subtle reverb, fragile recording quality that foregrounds
+    imperfection. Instrumentation is minimal: acoustic guitar, occasional banjo, sparse
+    percussion, understated harmonies. Density remains consistently thin, leaving
+    significant sonic space.
+
+
+    Lyrically, imagery draws from rural American landscapes, spiritual ambivalence,
+    mortality, bodily experience, and fractured relationships. Themes move between
+    folk-gospel tradition and existential unease, often using plain vernacular language
+    alongside unexpected abstraction. Tone is confessional without being sentimental.
+
+
+    Emotionally, the register occupies a muted, weathered melancholy — grief held
+    at arm''s length, longing without resolution, occasional flashes of dark humor.
+    The psychological colour is consistently interior and introspective, suggesting
+    isolation and spiritual searching. Warmth and bleakness coexist without resolving
+    into either comfort or despair.'
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4126
+      present: 0.268
+      future: 0.3194
+    spatial:
+      thing: 0.4134
+      place: 0.319
+      person: 0.2676
+    ontological:
+      imagined: 0.3401
+      forgotten: 0.3061
+      known: 0.3538
+    confidence: 0.0159
+  discogs_id: null
+  notes: Artist is Will Oldham (Palace Music / Palace Brothers)
+Mark Hollis:
+  slug: mark_hollis
+  status: draft
+  description: 'Mark Hollis works primarily as a vocal artist, though his late work
+    tends toward spare, near-instrumental minimalism where voice functions as one
+    texture among many. Production is characterised by extreme dynamic contrast —
+    sudden silences, isolated acoustic instruments, and deliberate imperfection: breath,
+    room ambience, the decay of a piano note treated as compositional material. Density
+    is radically low; space and absence carry structural weight. Timbres are organic
+    and fragile — acoustic piano, woodwinds, fretless bass — recorded with an intimate,
+    almost archival dryness. Lyrically, themes orbit transience, spiritual searching,
+    natural imagery, and quiet existential contemplation, rendered in fragmentary,
+    impressionistic language rather than direct statement. The emotional register
+    is introspective, hushed, and luminous — carrying a quality of grief held alongside
+    acceptance, stillness rather than resolution. Mood gravitates toward the sacred
+    and the melancholic without sentimentality.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4296
+      present: 0.2573
+      future: 0.3131
+    spatial:
+      thing: 0.4303
+      place: 0.3128
+      person: 0.2569
+    ontological:
+      imagined: 0.3453
+      forgotten: 0.2983
+      known: 0.3564
+    confidence: 0.0172
+  discogs_id: null
+  notes: ''
+Demdike Stare:
+  slug: demdike_stare
+  status: draft
+  description: 'Demdike Stare operates primarily as an instrumental project, weaving
+    dense, hypnotic textures from degraded tape sources, manipulated samples, and
+    slow-burning rhythmic structures. Their production aesthetic embraces granular
+    decay — sounds surface as if eroded by time, coated in hiss, murk, and low-frequency
+    pressure. Layers accumulate gradually, creating a claustrophobic density where
+    industrial pulse, kosmische drift, and dub spatial depth converge. The timbral
+    palette favors corroded analogue warmth over digital clarity, with bassweight
+    and vinyl deterioration as expressive tools. Thematically, the work gravitates
+    toward occult geography, ritual darkness, and the psychogeography of remote or
+    forgotten places — suggesting folklore, folk horror, and liminal zones between
+    the mundane and the uncanny. The emotional register is persistently unsettling,
+    inducing a slow dread that is contemplative rather than aggressive — immersive,
+    ceremonial, and psychologically oppressive in its patience.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4209
+      present: 0.2623
+      future: 0.3168
+    spatial:
+      thing: 0.4215
+      place: 0.3166
+      person: 0.2619
+    ontological:
+      imagined: 0.3322
+      forgotten: 0.3064
+      known: 0.3614
+    confidence: 0.0157
+  discogs_id: null
+  notes: ''
+Fennesz:
+  slug: fennesz
+  status: draft
+  description: 'Fennesz works predominantly in instrumental electronic music, weaving
+    heavily processed guitar through dense layers of digital noise, granular synthesis,
+    and ambient drift. The production character is immersive and textural — surfaces
+    crackle with glitch artifacts, distortion blooms organically, and melodic fragments
+    dissolve into washes of static and feedback. Timbres oscillate between warmth
+    and abrasion, creating a sensation of beauty under erosion. Density varies from
+    sparse, breathable passages to overwhelming sonic saturation, often within a single
+    piece. Thematically, the music evokes coastal or elemental imagery — water, light,
+    decay, and vastness — with a sense of longing and temporal suspension. The emotional
+    register is melancholic yet luminous, evoking nostalgia filtered through abstraction,
+    tenderness obscured by distortion. There is a persistent tension between clarity
+    and dissolution, intimacy and immensity, suggesting emotional states that resist
+    direct articulation.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4287
+      present: 0.2564
+      future: 0.3149
+    spatial:
+      thing: 0.4294
+      place: 0.3145
+      person: 0.256
+    ontological:
+      imagined: 0.3475
+      forgotten: 0.2971
+      known: 0.3554
+    confidence: 0.0231
+  discogs_id: null
+  notes: ''
+Gavin Bryars:
+  slug: gavin_bryars
+  status: draft
+  description: 'Gavin Bryars works primarily in the instrumental and chamber-vocal
+    realm, blending composed notation with slow-moving, meditative textures. His sonic
+    palette favours sparse string writing, gentle brass, and intimate vocal lines
+    that drift through glacial harmonic fields. Production tends toward warmth and
+    acoustic clarity, avoiding electronic saturation while occasionally incorporating
+    subtle studio ambience. Thematically, his work gravitates toward loss, memory,
+    spiritual contemplation, and the passage of time, often drawing on sacred or liturgical
+    imagery without strict religious orthodoxy. Repeated melodic fragments cycle with
+    minimal variation, creating a hypnotic, suspended quality. The emotional register
+    is consistently introspective and elegiac — hushed sorrow coexisting with a kind
+    of luminous acceptance. Silence and restraint are treated as active compositional
+    elements. The overall psychological colour suggests stillness, fragility, and
+    a muted but persistent longing.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4476
+      present: 0.249
+      future: 0.3034
+    spatial:
+      thing: 0.4485
+      place: 0.3033
+      person: 0.2482
+    ontological:
+      imagined: 0.3519
+      forgotten: 0.2875
+      known: 0.3606
+    confidence: 0.0333
+  discogs_id: null
+  notes: ''
+Current 93:
+  slug: current_93
+  status: draft
+  description: 'Current 93 is primarily a vocal project, with David Tibet''s distinctive
+    spoken-word and chanted delivery central to the work. Sonically, the palette shifts
+    between sparse acoustic folk—fingerpicked guitar, mournful strings, drone—and
+    dense, unsettling noise and dark ambient textures. Production tends toward intimate,
+    raw staging, preserving fragility and ritual atmosphere. Layered voices, hurdy-gurdy,
+    and processed sounds create a sense of ceremonial depth. Thematically, the work
+    draws on apocalyptic mysticism, Blakean visionary imagery, sacred and profane
+    symbolism, childhood innocence set against spiritual catastrophe, and obsessive
+    recurring mythological figures and proper nouns. Tone oscillates between lamentation,
+    ecstatic revelation, and quiet desolation. The emotional register is consistently
+    intense—grief, yearning, and transcendence coexist uneasily. A pervasive sense
+    of immanent endings and eternal recurrence colours the psychological atmosphere
+    throughout.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4267
+      present: 0.2614
+      future: 0.3118
+    spatial:
+      thing: 0.4277
+      place: 0.3114
+      person: 0.2608
+    ontological:
+      imagined: 0.3446
+      forgotten: 0.2981
+      known: 0.3573
+    confidence: 0.0194
+  discogs_id: null
+  notes: ''
+Penderecki:
+  slug: penderecki
+  status: draft
+  description: 'Penderecki''s orchestral and choral writing is defined by dense, turbulent
+    sonic masses — clusters of strings producing microtonal glissandi, percussive
+    bowing techniques, and aggressive col legno attacks that dissolve traditional
+    pitch into raw textural noise. His sonority is dark, saturated, and monolithic,
+    often swelling into overwhelming walls of dissonant sound before collapsing into
+    eerie silence. Thematically, his work gravitates toward suffering, mortality,
+    lamentation, and the sacred — invoking imagery of catastrophe, grief, and spiritual
+    reckoning through vast architectural forms. The emotional register is predominantly
+    oppressive and harrowing, with occasional passages of anguished beauty or sombre
+    solemnity. Later works incorporate more Romantic warmth and tonal resolution,
+    softening the psychological extremity into a brooding, elegiac melancholy. His
+    output is predominantly instrumental and choral-orchestral, with the human voice
+    used as a textural force rather than a lyrical vehicle.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4437
+      present: 0.2494
+      future: 0.3069
+    spatial:
+      thing: 0.4447
+      place: 0.3064
+      person: 0.2489
+    ontological:
+      imagined: 0.3583
+      forgotten: 0.2892
+      known: 0.3525
+    confidence: 0.0296
+  discogs_id: null
+  notes: ''
+Nurse With Wound:
+  slug: nurse_with_wound
+  status: draft
+  description: 'Nurse With Wound operates primarily as an instrumental project, though
+    disembodied vocal fragments, found speech, and manipulated voices surface as textural
+    elements rather than narrative carriers. Sonically, the work favours dense, heavily
+    processed collage — layered field recordings, degraded tape loops, industrial
+    clatter, and surrealist juxtapositions of found sound sit alongside passages of
+    unsettling quietude. Production carries a deliberately abrasive, handmade quality;
+    sounds are allowed to corrode and bleed. Thematically, the aesthetic draws on
+    surrealist imagery, the uncanny, ritualistic darkness, and psychological dislocation
+    — an atmosphere of dreamlike menace permeates the work. The emotional register
+    is deeply unsettled: paranoid, hallucinatory, at times grotesque, occasionally
+    drifting into hypnotic calm before fracturing again. Timbral contrasts are extreme,
+    shifting between harsh noise, eerie ambience, and absurdist sonic comedy, creating
+    a persistent sense of psychological unease and dissociation.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4262
+      present: 0.2594
+      future: 0.3144
+    spatial:
+      thing: 0.427
+      place: 0.314
+      person: 0.259
+    ontological:
+      imagined: 0.3444
+      forgotten: 0.2997
+      known: 0.3559
+    confidence: 0.0218
+  discogs_id: null
+  notes: ''
+Antony and the Johnsons:
+  slug: antony_and_the_johnsons
+  status: draft
+  description: 'Antony and the Johnsons centres on a commanding, androgynous countertenor
+    voice set against sparse, intimate orchestral arrangements — strings, piano, and
+    occasional woodwinds layered with restrained density. Production tends toward
+    warm, close-miked intimacy, foregrounding breath and tonal vulnerability rather
+    than studio polish. Lyrically, the work explores transformation, gender identity,
+    bodily fragility, grief, and spiritual yearning, often employing imagery drawn
+    from nature, decay, and transcendence. The tone is confessional yet ceremonial,
+    occupying a liminal space between lament and ecstasy. Emotionally, the register
+    is consistently tender and raw, moving through sorrow, longing, and occasional
+    cathartic release without resolving toward comfort. The music is primarily vocal,
+    with the voice functioning as the primary melodic and expressive instrument, while
+    the ensemble provides a hushed, reverential cushion beneath it. Silence and dynamic
+    restraint are integral textural elements throughout.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4243
+      present: 0.2625
+      future: 0.3133
+    spatial:
+      thing: 0.4252
+      place: 0.313
+      person: 0.2617
+    ontological:
+      imagined: 0.341
+      forgotten: 0.3017
+      known: 0.3574
+    confidence: 0.0222
+  discogs_id: null
+  notes: ''
+This Mortal Coil:
+  slug: this_mortal_coil
+  status: draft
+  description: 'This Mortal Coil occupies a vocal-led, deeply atmospheric space where
+    layered female and male voices drift across spare, reverb-drenched arrangements.
+    Production is dense yet spacious—instruments submerged in echo, strings ghostly
+    and ambient, percussion minimal or entirely absent. Textures blend acoustic and
+    electronic elements, favouring cello, oboe, treated guitar, and synthesiser washes
+    that dissolve into one another without clear attack or release. Lyrically, the
+    work circles themes of grief, longing, spiritual dissolution, mortality, and transcendence,
+    using restrained, often archaic imagery that feels liturgical and mournful. Emotionally,
+    the register is sustained sorrow edged with beauty—melancholy that is contemplative
+    rather than dramatic, intimate rather than theatrical. There is a ritualistic
+    stillness to the sound, as though each piece occupies suspended, sacred time.
+    The overall effect is cinematic, nocturnal, and devotional, conveying fragility
+    and existential weight simultaneously.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4392
+      present: 0.2512
+      future: 0.3096
+    spatial:
+      thing: 0.4401
+      place: 0.3092
+      person: 0.2507
+    ontological:
+      imagined: 0.3443
+      forgotten: 0.2934
+      known: 0.3624
+    confidence: 0.0311
+  discogs_id: null
+  notes: ''
+The Magnetic Fields:
+  slug: the_magnetic_fields
+  status: draft
+  description: 'The Magnetic Fields blend lo-fi intimacy with theatrical artifice,
+    layering synthesizers, drum machines, ukulele, acoustic guitar, and chamber strings
+    in sparse-to-lush arrangements that shift dramatically across albums. Production
+    oscillates between deliberately cheap and carefully ornate, often within the same
+    record. Vocals are central, typically delivered in a deadpan, detached baritone
+    or cool feminine tones, contrasting stark sincerity against ironic distance. Lyrically,
+    themes encompass romantic longing, heartbreak, obsession, and existential weariness,
+    filtered through wit, wordplay, and literary allusion. Imagery draws from urban
+    melancholy, queer experience, and theatrical artifice, maintaining an arch, sardonic
+    tone that masks genuine emotional vulnerability. The emotional register is bittersweet
+    and coolly melancholic, balancing self-aware irony with unexpected tenderness.
+    The overall aesthetic functions as a kind of sophisticated emotional paradox —
+    detachment deployed as a vehicle for intimacy.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4354
+      present: 0.2565
+      future: 0.3082
+    spatial:
+      thing: 0.4363
+      place: 0.3078
+      person: 0.2559
+    ontological:
+      imagined: 0.3578
+      forgotten: 0.2886
+      known: 0.3536
+    confidence: 0.0283
+  discogs_id: null
+  notes: ''
+Van Dyke Parks:
+  slug: van_dyke_parks
+  status: draft
+  description: 'Van Dyck Parks composes richly layered vocal works where lush orchestration
+    — strings, brass, calliope-inflected keyboards, and intricate acoustic guitar
+    — creates a densely ornate, Americana-carnival sonic palette. Production tends
+    toward the elaborate and theatrical, with multiple textural planes coexisting
+    simultaneously. Lyrically, imagery draws from Southern Americana, Creole mythology,
+    colonial history, and pastoral nostalgia, rendered through elliptical, allusive
+    language that prioritizes sound and association over literal narrative. Thematic
+    preoccupations include cultural memory, American mythology, and the tension between
+    innocence and decay. The emotional register oscillates between whimsy and melancholy,
+    with an underlying ironic distance that gives even celebratory passages a bittersweet,
+    elegiac quality. Works feel simultaneously childlike and sophisticated, evoking
+    a dreamlike state of nostalgic disorientation. Though orchestral arrangements
+    are central, the human voice carries primary melodic and narrative weight throughout.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.414
+      present: 0.2699
+      future: 0.3161
+    spatial:
+      thing: 0.4151
+      place: 0.3154
+      person: 0.2695
+    ontological:
+      imagined: 0.3398
+      forgotten: 0.3047
+      known: 0.3554
+    confidence: 0.0219
+  discogs_id: null
+  notes: ''
+Julianna Barwick:
+  slug: julianna_barwick
+  status: draft
+  description: 'Julianna Barwick works primarily as a vocal artist, though her voice
+    functions as an instrument rather than a vehicle for conventional song. Her productions
+    are built from layered, looped vocal lines — wordless or near-wordless — stacked
+    into dense, luminous halos of sound. The studio approach emphasizes reverb-saturated
+    space, creating an enveloping, cathedral-like depth. Sparse piano, soft synthesizer
+    pads, and minimal percussion occasionally anchor the vocal clouds without dominating
+    them. Texturally, her music occupies a slow, suspended field — unhurried, breathable,
+    immersive. Thematically, her work evokes interior stillness, contemplative solitude,
+    memory held at a distance, and a diffuse sense of longing or quiet awe. There
+    is little narrative or imagery in a concrete sense; instead, mood and atmosphere
+    carry meaning. The emotional register is introspective, meditative, and gently
+    elegiac — hovering between melancholy and transcendence without resolving into
+    either.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4433
+      present: 0.2523
+      future: 0.3044
+    spatial:
+      thing: 0.4444
+      place: 0.304
+      person: 0.2516
+    ontological:
+      imagined: 0.3447
+      forgotten: 0.2916
+      known: 0.3637
+    confidence: 0.0463
+  discogs_id: null
+  notes: ''
+Liz Harris:
+  slug: liz_harris
+  status: draft
+  description: 'Liz Harris, recording as Grouper, works in a heavily processed, low-fidelity
+    sonic environment where vocals, guitar, and ambient texture collapse into one
+    another through layers of reverb, tape hiss, and drone. The production character
+    is deliberately murky and intimate, dissolving conventional melodic definition
+    into atmospheric wash. Her work is primarily vocal, though voice functions more
+    as timbral element than narrative vehicle. Lyrically, imagery gravitates toward
+    domestic space, natural light, grief, absence, and psychological liminality —
+    states of waiting, half-remembering, and emotional dissolution. Thematic tone
+    is consistently elegiac and introspective, with an almost devotional stillness.
+    The emotional register spans quiet desolation to fragile tenderness, evoking interiority
+    and isolation without melodrama. Density shifts between sparse, nearly empty passages
+    and dense reverberant clouds, creating a sense of enormous psychological space
+    compressed into delicate, hushed sound.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4426
+      present: 0.249
+      future: 0.3085
+    spatial:
+      thing: 0.4434
+      place: 0.3081
+      person: 0.2485
+    ontological:
+      imagined: 0.3545
+      forgotten: 0.2899
+      known: 0.3556
+    confidence: 0.0251
+  discogs_id: null
+  notes: ''
+Townes Van Zandt:
+  slug: townes_van_zandt
+  status: draft
+  description: 'Townes Van Zandt operates primarily as a vocal artist, his voice carrying
+    a worn, intimate timbre — hushed yet emotionally exposed, rarely ornamented. Production
+    is characteristically sparse: acoustic guitar forms the central sonic bed, often
+    recorded with minimal studio layering, preserving room ambience and breath. Density
+    is deliberately low, creating space around each phrase.
+
+
+    Lyrically, his work gravitates toward themes of transience, longing, existential
+    solitude, poverty, and wandering. Imagery draws from the American Southwest and
+    Southern landscapes — highways, cold rooms, rivers, nightfall — rendered in plain,
+    precise language with occasional surreal or mythic inflections. Tone remains unsentimental
+    despite heavy emotional content.
+
+
+    The emotional register is melancholic and contemplative, occupying a psychological
+    space of quiet devastation and resigned acceptance. Darkness is present but restrained,
+    never melodramatic. A persistent undercurrent of tenderness counterbalances the
+    bleakness, giving the work a muted, aching warmth.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4173
+      present: 0.2672
+      future: 0.3154
+    spatial:
+      thing: 0.4184
+      place: 0.3151
+      person: 0.2666
+    ontological:
+      imagined: 0.3449
+      forgotten: 0.3035
+      known: 0.3516
+    confidence: 0.0248
+  discogs_id: null
+  notes: ''
+Helmut Lachenmann:
+  slug: helmut_lachenmann
+  status: draft
+  description: 'Lachenmann is primarily an instrumental composer whose work centers
+    on what he termed "musique concrète instrumentale" — extracting noise-based, unconventional
+    sounds from acoustic instruments through extended techniques. Sonic texture is
+    dense, granular, and percussive; string instruments produce col legno scraping,
+    breath-like pressures, and near-silent rustling, while winds and brass yield multiphonics
+    and key-click rhythms. The overall timbral character is arid, abrasive, and deliberately
+    anti-lyrical, rejecting conventional tone production in favor of friction, resistance,
+    and material sound.
+
+
+    Thematically, the work engages with concepts of perception, physicality, and the
+    deconstruction of musical convention — sound is presented as labor, energy, and
+    raw matter rather than expression.
+
+
+    The emotional register is austere, alienating, and intellectually confrontational,
+    yet carries an underlying fragility. Moments of extreme quietude create psychological
+    tension. The affect is contemplative and unsettling, probing the boundaries between
+    music and noise.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4254
+      present: 0.2564
+      future: 0.3182
+    spatial:
+      thing: 0.4263
+      place: 0.3175
+      person: 0.2563
+    ontological:
+      imagined: 0.3397
+      forgotten: 0.3024
+      known: 0.358
+    confidence: 0.0176
+  discogs_id: null
+  notes: ''
+Meredith Monk:
+  slug: meredith_monk
+  status: draft
+  description: 'Meredith Monk works primarily as a vocalist, treating the human voice
+    as a complete sonic instrument divorced from conventional language. Her textures
+    are sparse and ritualistic, layering wordless vocalizations, extended techniques,
+    ululations, glottal stops, and breath into intricate polyphonic webs. Production
+    is typically intimate and acoustic, favoring natural resonance over electronic
+    processing, with minimal accompaniment — sparse piano, small chamber ensembles,
+    or pure a cappella arrangements. Thematically, her work orbits archetypal human
+    experience: memory, myth, landscape, ceremony, and collective identity, using
+    abstracted or invented languages to evoke pre-verbal emotional states. The emotional
+    register is simultaneously ancient and childlike, contemplative and urgent, oscillating
+    between solemnity and playful innocence. There is a meditative, ceremonial quality
+    throughout — music that functions closer to ritual than performance, creating
+    an atmosphere of suspended time and quiet psychological depth.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4216
+      present: 0.2626
+      future: 0.3158
+    spatial:
+      thing: 0.4224
+      place: 0.3154
+      person: 0.2622
+    ontological:
+      imagined: 0.339
+      forgotten: 0.3031
+      known: 0.3579
+    confidence: 0.0186
+  discogs_id: null
+  notes: ''
+Pauline Oliveros:
+  slug: pauline_oliveros
+  status: draft
+  description: 'Pauline Oliveros worked primarily in instrumental and electronic realms,
+    though voice occasionally appeared as one texture among many. Her sonic palette
+    favored sustained, slowly evolving drones, deep resonant tones, and accordion-based
+    timbres layered with electronic processing, reverb, and delay to create vast,
+    enveloping acoustic spaces. Production character emphasizes immersive depth over
+    clarity, with overlapping harmonic partials blurring into dense, meditative washes.
+    Thematically, her work orbits listening itself as subject — attentiveness, inner
+    stillness, ecological sound awareness, and the threshold between silence and tone.
+    Imagery is elemental and spatial rather than narrative. The emotional register
+    is contemplative, unhurried, and profoundly interior — evoking trance-like receptivity
+    and a dissolution of ordinary time-consciousness. Textures move at glacial pace,
+    rewarding sustained attention. The psychological colour is simultaneously expansive
+    and introspective, suggesting vast open terrain encountered from a place of deep
+    calm.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4249
+      present: 0.2632
+      future: 0.3119
+    spatial:
+      thing: 0.4259
+      place: 0.3117
+      person: 0.2625
+    ontological:
+      imagined: 0.3422
+      forgotten: 0.2996
+      known: 0.3582
+    confidence: 0.0237
+  discogs_id: null
+  notes: ''
+Georg Friedrich Haas:
+  slug: georg_friedrich_haas
+  status: draft
+  description: 'Georg Friedrich Haas works primarily in instrumental contemporary
+    classical music, employing microtonal and spectral harmonic systems as core compositional
+    tools. His sonic texture is characteristically dense and slowly evolving, built
+    from clusters of microtonally tuned pitches that create shimmering, beating acoustic
+    phenomena. Timbre is central rather than incidental — string ensembles, chamber
+    groups, and solo instruments are treated as resonating bodies whose overtones
+    interpenetrate and blur. Thematic tendencies lean toward darkness and interiority,
+    exploring liminal harmonic spaces between consonance and dissonance, light and
+    shadow, stability and dissolution. The emotional register is predominantly introspective,
+    suspended, and quietly unsettling — evoking states of ambiguity, threshold experience,
+    and psychological depth without resolution. Production favors acoustic clarity
+    over manipulation, allowing the natural acoustic beating of microtonal intervals
+    to generate inherent movement. Works unfold in long temporal arches, resisting
+    momentum in favor of immersive stasis.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4222
+      present: 0.2605
+      future: 0.3173
+    spatial:
+      thing: 0.4229
+      place: 0.3169
+      person: 0.2603
+    ontological:
+      imagined: 0.3381
+      forgotten: 0.3046
+      known: 0.3572
+    confidence: 0.0138
+  discogs_id: null
+  notes: ''
+Feldman Morton:
+  slug: feldman_morton
+  status: draft
+  description: 'Morton Feldman''s music inhabits a world of extreme quietude and suspended
+    time, favouring sparse, low-dynamic textures where individual sounds emerge and
+    dissolve with deliberate isolation. His sonic palette draws on subtle instrumental
+    combinations — often piano, strings, winds, and percussion — producing a delicate,
+    almost translucent density where silence functions as structural material. The
+    music unfolds in non-developmental, non-teleological forms, resisting climax or
+    resolution in favour of slowly shifting sonic fields. Thematically, his work gravitates
+    toward stillness, loss, memorial, and the aesthetic of abstract expressionist
+    visual art, with imagery suggesting fragility and impermanence. The emotional
+    register is contemplative, hushed, and psychologically introspective — occasionally
+    unsettling in its refusal of conventional momentum. Feldman''s output is exclusively
+    instrumental or, when voices appear, treats text as pure sonic material rather
+    than expressive narrative vehicle. Works often extend across unusually long durations,
+    cultivating deep meditative immersion.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4314
+      present: 0.2565
+      future: 0.3121
+    spatial:
+      thing: 0.4322
+      place: 0.3116
+      person: 0.2561
+    ontological:
+      imagined: 0.3387
+      forgotten: 0.2989
+      known: 0.3623
+    confidence: 0.0263
+  discogs_id: null
+  notes: ''
+Johann Johannsson:
+  slug: johann_johannsson
+  status: draft
+  description: 'Jóhann Jóhannsson works primarily in instrumental music, blending
+    orchestral strings, brass, and woodwinds with subtle electronic processing, field
+    recordings, and ambient texture. His production favors gradual layering, where
+    acoustic and synthetic elements merge into dense, slowly evolving soundscapes
+    with a warm yet austere tonal quality. Rhythmic elements are sparse and minimalist,
+    often derived from repetitive string or brass ostinatos. Thematically, his work
+    explores industrialism, time, memory, and the fragility of human experience, frequently
+    evoking desolate landscapes and existential contemplation. The emotional register
+    is melancholic and introspective, carrying an undercurrent of quiet grief or longing
+    balanced against moments of austere beauty. Dynamic contrasts shift deliberately
+    between hushed intimacy and swelling orchestral density, creating a psychological
+    tension between stillness and forward momentum. The overall sonic character feels
+    both cinematic and deeply private.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4349
+      present: 0.2558
+      future: 0.3093
+    spatial:
+      thing: 0.436
+      place: 0.309
+      person: 0.2551
+    ontological:
+      imagined: 0.352
+      forgotten: 0.2932
+      known: 0.3548
+    confidence: 0.0352
+  discogs_id: null
+  notes: ''
+Wintersleep:
+  slug: wintersleep
+  status: draft
+  description: 'Wintersleep operates in a dense, layered sonic space where distorted
+    and clean guitars interweave with driving rhythms, producing a textured, slightly
+    hazy rock sound. Production leans toward warmth and organic fullness, with walls
+    of guitar occasionally dissolving into spare, atmospheric passages. The band is
+    primarily vocal, with melodic but often introspective vocals riding above restless
+    instrumental beds. Lyrically, themes circle around existential uncertainty, mortality,
+    isolation, consciousness, and the friction between the interior self and the external
+    world. Imagery tends toward the elemental — darkness, light, sleep, waking — lending
+    a mythic, slightly surreal quality to otherwise grounded emotional territory.
+    The emotional register is melancholic yet propulsive, balancing resignation with
+    urgency. There is a persistent psychological tension between stillness and momentum,
+    giving the music a brooding, contemplative affect that occasionally erupts into
+    raw kinetic energy.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4405
+      present: 0.251
+      future: 0.3085
+    spatial:
+      thing: 0.4415
+      place: 0.3081
+      person: 0.2504
+    ontological:
+      imagined: 0.3565
+      forgotten: 0.2897
+      known: 0.3538
+    confidence: 0.0397
+  discogs_id: null
+  notes: ''
+Sparklehorse:
+  slug: sparklehorse
+  status: draft
+  description: 'Sparklehorse occupies a primarily vocal space, with weathered, intimate
+    vocals sitting low in densely layered, lo-fi textures. Production favors deliberate
+    imperfection — tape hiss, distortion, fragile acoustic instruments interwoven
+    with electronic noise, found sounds, and manipulated samples. Arrangements shift
+    between sparse folk intimacy and walls of abrasive, corroded sound. Lyrically,
+    imagery draws heavily from rural Southern American landscapes, childhood memory,
+    decay, animals, spirituality, grief, and psychological fragmentation. Themes circle
+    mortality, loss, mental dissolution, and faint redemptive longing without resolution.
+    The tonal register is melancholic, dreamlike, and unsettling — occupying a liminal
+    space between tenderness and dread. Songs frequently feel half-submerged, as if
+    heard through static or memory distortion. The emotional palette is muted, bruised,
+    and internally focused, with moments of unexpected warmth breaking through pervasive
+    darkness.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4099
+      present: 0.2703
+      future: 0.3197
+    spatial:
+      thing: 0.4107
+      place: 0.3194
+      person: 0.2699
+    ontological:
+      imagined: 0.3328
+      forgotten: 0.3099
+      known: 0.3573
+    confidence: 0.017
+  discogs_id: null
+  notes: ''
+Ólafur Arnalds:
+  slug: lafur_arnalds
+  status: draft
+  description: 'Ólafur Arnalds works primarily in instrumental composition, occasionally
+    incorporating wordless vocals or sparse sung fragments as textural elements rather
+    than lyrical vehicles. His sonic palette blends processed strings, delicate piano,
+    and modular synthesizers, layering acoustic warmth against granular or glitchy
+    digital decay. Production is intimate and spacious simultaneously, using subtle
+    tape noise, gentle reverb, and rhythmic patterns generated by self-playing piano
+    systems. Texturally, pieces often breathe slowly, with restrained density that
+    allows silence to function as a compositional element. Thematically, the work
+    evokes introspection, transience, grief, and quiet resolution — emotional territories
+    associated with memory, loss, and gradual acceptance. Imagery implied through
+    the music tends toward the natural and ephemeral: fog, fading light, stillness.
+    The emotional register is melancholic but rarely desolate, maintaining a sense
+    of suspended hope or calm underneath the sadness.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4419
+      present: 0.2515
+      future: 0.3066
+    spatial:
+      thing: 0.4428
+      place: 0.3065
+      person: 0.2507
+    ontological:
+      imagined: 0.358
+      forgotten: 0.2889
+      known: 0.3532
+    confidence: 0.028
+  discogs_id: null
+  notes: ''
+Tim Hecker:
+  slug: tim_hecker
+  status: draft
+  description: 'Tim Hecker works predominantly in the instrumental domain, constructing
+    densely layered soundscapes from degraded organ tones, heavily processed guitar,
+    synthesizers, and granular noise. His production approach favors erosion and saturation
+    — sounds are smeared, corroded, and submerged beneath reverberant hazes, creating
+    a sense of material decay. Textures shift slowly through tidal swells and abrupt
+    silences, building claustrophobic pressure before dissolving into sparse, ghostly
+    residue. Thematically, the work circles around deterioration, spiritual absence,
+    and the boundary between sacred and collapsed structures — cathedral acoustics
+    corrupted by entropy. The emotional register is consistently somber and searching,
+    evoking isolation, grief, and an unresolved yearning that resists resolution.
+    There is an atmosphere of ruins — something monumental slowly losing coherence.
+    Psychological colour tends toward the dissociative, positioning the listener inside
+    a space that feels both vast and suffocating simultaneously.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4335
+      present: 0.2581
+      future: 0.3083
+    spatial:
+      thing: 0.4344
+      place: 0.3082
+      person: 0.2574
+    ontological:
+      imagined: 0.3364
+      forgotten: 0.2974
+      known: 0.3661
+    confidence: 0.0345
+  discogs_id: null
+  notes: ''
+Temples:
+  slug: temples
+  status: draft
+  description: 'Temples craft densely layered psychedelic rock with a warm, vintage
+    production character rooted in analogue warmth, reverb-soaked guitars, and lush
+    orchestral flourishes. The sonic texture blends shimmering sitar-adjacent tonalities,
+    phased rhythms, and melodic bass lines beneath a thick harmonic canopy. Production
+    favours a polished yet antiquated quality, evoking mid-to-late 1960s studio aesthetics
+    through modern precision. Vocals are central — rich, harmonically stacked, and
+    melodic — often carrying a dreamy, incantatory quality. Lyrically, their work
+    gravitates toward cosmic introspection, metaphysical searching, altered perception,
+    and the tension between inner and outer worlds, using imagery drawn from nature,
+    light, and consciousness. The emotional register is hypnotic and contemplative,
+    occasionally euphoric, with an underlying melancholy threading through the warmth.
+    The overall psychological colour is immersive and slightly otherworldly, inviting
+    inward retreat rather than outward energy.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4237
+      present: 0.2636
+      future: 0.3127
+    spatial:
+      thing: 0.4247
+      place: 0.3124
+      person: 0.2629
+    ontological:
+      imagined: 0.3467
+      forgotten: 0.299
+      known: 0.3543
+    confidence: 0.0224
+  discogs_id: null
+  notes: ''
+Unknown Mortal Orchestra:
+  slug: unknown_mortal_orchestra
+  status: draft
+  description: 'Unknown Mortal Orchestra crafts densely layered, psychedelic rock
+    with a warm, lo-fi production aesthetic — tape saturation, subtle distortion,
+    and analog warmth permeate the mix. Drum tones are punchy yet hazy; guitars shimmer
+    with tremolo and wah effects; bass lines move with melodic independence. The sonic
+    texture blends funk-inflected grooves beneath dreamy, reverb-soaked surfaces,
+    creating a feeling of intimate distance.
+
+
+    Lyrically, the work gravitates toward introspection, desire, fractured relationships,
+    and altered perception — imagery tends toward the sensory and oblique rather than
+    literal narrative. Themes of longing, disorientation, and self-examination recur
+    with a confessional yet cryptic tone.
+
+
+    The emotional register is simultaneously warm and unsettled — melancholic yet
+    groovy, tender yet psychologically hazy. Songs feel personal and internalized.
+
+
+    The project is primarily vocal-led, with Ruban Nielson''s falsetto-adjacent voice
+    serving as the melodic and emotional anchor.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4051
+      present: 0.2741
+      future: 0.3208
+    spatial:
+      thing: 0.406
+      place: 0.3204
+      person: 0.2736
+    ontological:
+      imagined: 0.3419
+      forgotten: 0.3081
+      known: 0.3499
+    confidence: 0.0187
+  discogs_id: null
+  notes: ''
+Mac DeMarco:
+  slug: mac_demarco
+  status: draft
+  description: 'Mac DeMarco''s sound centres on a warm, lo-fi aesthetic built from
+    chorus-drenched, slightly detuned guitars producing a distinctively wobbly, tape-saturated
+    timbre. Production remains deliberately intimate and low-density, favouring sparse
+    arrangements with languid drum grooves, muted bass lines, and soft vocal layering.
+    The studio approach embraces audible imperfection, creating a bedroom-recording
+    warmth even in more polished contexts. Lyrically, themes orbit domesticity, romantic
+    ambivalence, mundane daily existence, and quiet introspection, rendered through
+    plainspoken imagery and deadpan understatement. Emotional register is characteristically
+    hazy and ambivalent — sitting between contentment and mild melancholy, projecting
+    a relaxed, almost stoned detachment tinged with genuine tenderness. The tone avoids
+    drama, leaning into passivity and gentle irony. DeMarco is primarily a vocal artist,
+    with his laconic, slightly nasal tenor central to the identity of the work.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4448
+      present: 0.2494
+      future: 0.3059
+    spatial:
+      thing: 0.4457
+      place: 0.3058
+      person: 0.2486
+    ontological:
+      imagined: 0.3475
+      forgotten: 0.2916
+      known: 0.3609
+    confidence: 0.0314
+  discogs_id: null
+  notes: ''
+Blood Orange:
+  slug: blood_orange
+  status: draft
+  description: 'Blood Orange occupies a dense, layered sonic space where neo-soul,
+    R&B, and post-punk atmospheres blur into something simultaneously intimate and
+    disorienting. Production is characteristically warm yet fractured — analog softness
+    interrupted by glitchy edits, lo-fi tape saturation, unexpected silences, and
+    richly textured string or synth arrangements that feel emotionally weighted rather
+    than decorative. Vocals are central, delivered in a soft, often falsetto register
+    that feels confessional and restrained, sitting low in the mix as though half-submerged.
+    Lyrically, themes orbit around identity, belonging, queer experience, vulnerability,
+    and longing, rendered through fragmented imagery and understated directness. Emotionally,
+    the register is melancholic and introspective, carrying an undercurrent of tenderness
+    and unresolved yearning — grief processed quietly rather than dramatically. Moods
+    shift between warmth and dislocation, community and isolation, often within a
+    single track.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4223
+      present: 0.2635
+      future: 0.3143
+    spatial:
+      thing: 0.4233
+      place: 0.3137
+      person: 0.263
+    ontological:
+      imagined: 0.3476
+      forgotten: 0.2994
+      known: 0.3529
+    confidence: 0.0288
+  discogs_id: null
+  notes: ''
+Khruangbin:
+  slug: khruangbin
+  status: draft
+  description: 'Khruangbin occupies a gauzy, low-lit sonic space built around warm,
+    reverb-saturated guitar tones, rubbery palm-muted bass lines, and restrained,
+    brushed drumming. Production is sparse and intimate, favoring subtle room ambience
+    over overt layering. The overall textural density remains deliberately thin, creating
+    a sense of distance and drift. Vocals, when present, are treated as another instrument
+    — buried lightly in the mix, breathy, and melodically minimal, often employing
+    syllabic or phonetically ambiguous phrasing that resists literal interpretation.
+    Thematically, imagery evokes travel, longing, and a kind of placeless reverie,
+    drawing loosely on global music traditions without anchoring to a specific geography.
+    The emotional register is meditative and nostalgic, carrying a warm but melancholic
+    undertow — introspective rather than melancholic. The band is primarily instrumental
+    in character, with vocal elements serving textural rather than narrative functions.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4394
+      present: 0.2534
+      future: 0.3072
+    spatial:
+      thing: 0.4405
+      place: 0.3069
+      person: 0.2526
+    ontological:
+      imagined: 0.3493
+      forgotten: 0.2953
+      known: 0.3553
+    confidence: 0.0347
+  discogs_id: null
+  notes: ''
+Coldplay:
+  slug: coldplay
+  status: draft
+  description: 'Coldplay''s sound centres on layered, atmospheric rock production
+    with shimmering guitar arpeggios, expansive synthesizer pads, and a clean, open
+    sonic density that balances intimacy with arena-scale grandeur. Production favours
+    bright, reverb-drenched timbres, melodic piano motifs, and dynamic shifts from
+    sparse verses to anthemic choruses. The band is primarily vocal-led, with Chris
+    Martin''s light-toned, mid-range tenor anchoring melodic hooks over rhythmically
+    steady, uncluttered arrangements. Lyrically, themes orbit longing, hope, transience,
+    love, and quiet existential searching, rendered through celestial and natural
+    imagery — stars, light, oceans — with a tone that is earnest and unguarded. The
+    emotional register is consistently bittersweet and uplifting simultaneously, occupying
+    a psychological space of tender vulnerability edged with optimism. Later work
+    incorporates brighter pop textures and electronic elements, increasing rhythmic
+    energy while retaining the core melancholic warmth.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4364
+      present: 0.2574
+      future: 0.3062
+    spatial:
+      thing: 0.4373
+      place: 0.3063
+      person: 0.2564
+    ontological:
+      imagined: 0.3563
+      forgotten: 0.2891
+      known: 0.3546
+    confidence: 0.0254
+  discogs_id: null
+  notes: ''
+Blur:
+  slug: blur
+  status: draft
+  description: 'Blur occupies a distinctly British sonic space, blending distorted,
+    jangly guitars with lush string arrangements, wiry bass, and dry, punchy drum
+    production. Their texture shifts between lo-fi scrappiness and dense, layered
+    studio construction, often incorporating found sound, noise, and electronic elements.
+    Lyrically, themes centre on urban alienation, mundane suburban life, fractured
+    relationships, class observation, and surreal vignettes of everyday English existence.
+    Imagery tends toward the quotidian rendered strange — supermarkets, housing estates,
+    television, and restless modern ennui. The tone oscillates between sardonic detachment
+    and aching sincerity, frequently within the same piece. Emotionally, the register
+    spans brittle anxiety, wry humour, melancholy, and occasional euphoric release.
+    The approach is primarily vocal-led, with narrative and character-driven delivery
+    that ranges from deadpan monotone to raw, strained expressiveness. Production
+    density varies dramatically across their catalogue, from sparse minimalism to
+    claustrophobic noise-rock saturation.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4436
+      present: 0.2501
+      future: 0.3063
+    spatial:
+      thing: 0.4445
+      place: 0.306
+      person: 0.2495
+    ontological:
+      imagined: 0.3545
+      forgotten: 0.2882
+      known: 0.3573
+    confidence: 0.0323
+  discogs_id: null
+  notes: ''
+Donovan:
+  slug: donovan
+  status: draft
+  description: 'Donovan''s sound blends acoustic fingerpicked guitar with delicate
+    orchestral and psychedelic studio ornamentation — harpsichord, flute, sitar, and
+    gentle percussion layered into a warm, intimate mix. Production tends toward softness
+    and airiness, creating a dreamy, chamber-folk density that feels both handcrafted
+    and subtly ornate. Vocals are central, delivered in a gentle, conversational tenor
+    with a folk-influenced lilt. Lyrically, themes orbit nature mysticism, romantic
+    idealism, fairy-tale imagery, Eastern philosophy, and countercultural innocence,
+    rendered through whimsical, symbolic language evoking pastoral and cosmic landscapes.
+    The emotional register is predominantly tender, wistful, and gently euphoric —
+    a childlike wonder tinged with contemplative calm. Occasional bluesy or jazz-inflected
+    moments introduce a slightly earthier mood without disturbing the overall sense
+    of gentle reverie. The work is distinctly vocal-led, with instrumentation functioning
+    as an enveloping, softly textured atmosphere around the sung narrative.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4471
+      present: 0.2465
+      future: 0.3063
+    spatial:
+      thing: 0.448
+      place: 0.306
+      person: 0.246
+    ontological:
+      imagined: 0.3553
+      forgotten: 0.2857
+      known: 0.3589
+    confidence: 0.0321
+  discogs_id: null
+  notes: ''
+Yellow Claw:
+  slug: yellow_claw
+  status: draft
+  description: 'Yellow Claw produces high-density electronic music rooted in trap,
+    hardstyle, and Dutch house, characterized by heavily distorted bass drops, compressed
+    percussion, and layered synthesis creating a dense, aggressive sonic texture.
+    The production employs industrial-grade sound design with gritty, metallic timbres
+    contrasted against melodic interludes, giving tracks a push-pull emotional architecture.
+    Studio work emphasizes maximum loudness and crowd-anticipatory dynamics, suggesting
+    festival-scale environments.
+
+
+    Lyrically, featured vocals frequently orbit themes of hedonism, defiance, urban
+    nightlife, and collective euphoria, often delivered in short, percussive phrases
+    built for rhythmic impact rather than narrative depth. The tone is confrontational
+    yet celebratory.
+
+
+    The emotional register hovers between aggression and exhilaration — a charged,
+    adrenaline-forward affect with undertones of tribalism and release. The project
+    is primarily vocal-featured rather than fully instrumental, though vocal elements
+    function more as rhythmic texture than lyrical storytelling.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4143
+      present: 0.2658
+      future: 0.3199
+    spatial:
+      thing: 0.4149
+      place: 0.3196
+      person: 0.2655
+    ontological:
+      imagined: 0.3429
+      forgotten: 0.3055
+      known: 0.3515
+    confidence: 0.0114
+  discogs_id: null
+  notes: ''
+Weezer:
+  slug: weezer
+  status: draft
+  description: 'Weezer is a primarily vocal rock act built around compressed, mid-forward
+    guitar tones layered beneath clean, melodic lead lines. Production favors tight,
+    dry drum sounds, crunchy power chords, and punchy bass — creating a dense yet
+    radio-clear wall of guitar-driven sound. Arrangements frequently contrast soft
+    verses with loud, distorted choruses, drawing on classic arena-rock dynamics filtered
+    through a nerdy, suburban sensibility. Lyrically, themes orbit adolescent longing,
+    romantic frustration, social alienation, escapism through fantasy or nostalgia,
+    and self-deprecating introspection. Imagery tends toward the mundane and specific
+    — domestic settings, pop-culture references, and personal confessions framed with
+    earnest sincerity. The emotional register is simultaneously vulnerable and energetic,
+    blending melancholy undercurrents with anthemic uplift. Vocal harmonies are clean
+    and stacked, reinforcing a bright, accessible texture that offsets the often quietly
+    anxious psychological tone beneath the surface.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4556
+      present: 0.2438
+      future: 0.3006
+    spatial:
+      thing: 0.4565
+      place: 0.3006
+      person: 0.2429
+    ontological:
+      imagined: 0.3517
+      forgotten: 0.2866
+      known: 0.3617
+    confidence: 0.0322
+  discogs_id: null
+  notes: ''
+Floating Points:
+  slug: floating_points
+  status: draft
+  description: 'Floating Points crafts music of refined sonic intricacy, blending
+    organic instrumentation — strings, woodwinds, jazz-inflected piano — with precisely
+    sculpted electronic textures. Production is warm yet meticulous, with layered
+    synthesis, deep sub-bass foundations, and expansive reverb creating a sense of
+    spatial depth. Arrangements breathe and shift gradually, favouring slow-burning
+    harmonic evolution over abrupt transitions. The work is predominantly instrumental,
+    though occasional vocal elements appear as atmospheric texture rather than narrative
+    vehicles. Thematically, the music orbits ideas of cosmic scale, inner stillness,
+    and temporal suspension — imagery suggestive of vast natural or celestial phenomena
+    rendered through abstract sound. The emotional register is contemplative and introspective,
+    carrying an understated melancholy alongside moments of luminous resolution. Rhythmic
+    structures range from fluid, jazz-adjacent grooves to polyrhythmic electronic
+    patterns, maintaining meditative coherence throughout. The overall character balances
+    intellectual precision with deeply felt emotional resonance.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4412
+      present: 0.2507
+      future: 0.3081
+    spatial:
+      thing: 0.442
+      place: 0.3079
+      person: 0.2501
+    ontological:
+      imagined: 0.3533
+      forgotten: 0.2912
+      known: 0.3555
+    confidence: 0.0306
+  discogs_id: null
+  notes: ''
+The Tallest Man on Earth:
+  slug: the_tallest_man_on_earth
+  status: draft
+  description: 'The Tallest Man on Earth centers on a singular, intimate vocal presence
+    — a raw, strained tenor delivered with folk-blues intensity over acoustic fingerpicked
+    guitar. Production is sparse and dry, often capturing room noise and string buzz,
+    giving recordings an unpolished, close-mic immediacy. Density is minimal; the
+    interplay between voice and guitar forms nearly the entire sonic architecture,
+    with occasional sparse instrumentation appearing at the edges. Lyrically, the
+    work gravitates toward nature imagery — open landscapes, birds, rivers, soil —
+    layered with existential restlessness, longing, and a searching quality that circles
+    themes of displacement, impermanence, and fractured connection. Figurative language
+    is dense and elliptical, resisting literal interpretation. The emotional register
+    is melancholic yet urgent, carrying an undercurrent of romantic yearning and philosophical
+    unease. The artist is primarily vocal, with guitar functioning as both rhythmic
+    foundation and melodic counterpoint.
+
+    '
+  style_tags: []
+  chromatic_score:
+    temporal:
+      past: 0.4249
+      present: 0.263
+      future: 0.3121
+    spatial:
+      thing: 0.426
+      place: 0.3118
+      person: 0.2622
+    ontological:
+      imagined: 0.3474
+      forgotten: 0.2994
+      known: 0.3532
+    confidence: 0.0225
+  discogs_id: null
+  notes: ''


### PR DESCRIPTION
## Summary
- Bulk-generated aesthetic descriptions for 116 missing artists across all production threads (Coldplay, Blur, Weezer, Donovan, Yellow Claw, and 111 others)
- Fixed `_append_entry` key truncation bug for artists with colons in their name (e.g. `Songs: Ohia` was being written as `'Songs:`)
- Fixed `score_chromatic` passing `lyric_text` to `score_batch` without the required `concept_text` argument
- Manually resolved two UNKNOWN stubs: `Hayden` → Petra Haden, `Palace Music` → Will Oldham
- Scored all 288 non-null catalog entries through Refractor for chromatic coordinates (3 skipped: Francisco López, Hayden stub pre-fix, Palace Music stub pre-fix — now all resolved)
- Renamed "samples" nav link to "candidate view" on Composition Board

## Test plan
- [x] Verify no "Artist not in catalog" warnings when running any pipeline phase against existing threads
- [x] Spot-check a few entries in `artist_catalog.yml` for well-formed YAML and plausible `chromatic_score` values
- [x] Confirm `Songs: Ohia` entry parses correctly (`yaml.safe_load` on the catalog)
- [x] Check "candidate view" link renders correctly on Composition Board nav

🤖 Generated with [Claude Code](https://claude.com/claude-code)