### PR TITLE
Switch LangChain agents to Fable (claude-fable-5)

### DIFF
--- a/packages/composition/src/white_composition/shrinkwrap_chain_artifacts.py
+++ b/packages/composition/src/white_composition/shrinkwrap_chain_artifacts.py
@@ -344,9 +344,9 @@ def write_index(output_dir: Path, all_metadata: list[dict]) -> Path:
             "key": meta["key"],
             "rainbow_color": meta["rainbow_color"],
             "concept": (
-                meta["concept"][:200] + "..."
-                if len(meta.get("concept", "")) > 200
-                else meta.get("concept", "")
+                (meta.get("concept") or "")[:200] + "..."
+                if len(meta.get("concept") or "") > 200
+                else (meta.get("concept") or "")
             ),
             "iteration_count": meta["iteration_count"],
         }

--- a/packages/core/src/white_core/agents/agent_settings.py
+++ b/packages/core/src/white_core/agents/agent_settings.py
@@ -9,8 +9,8 @@ load_dotenv()
 class AgentSettings(BaseModel):
 
     anthropic_api_key: SecretStr = SecretStr(os.getenv("ANTHROPIC_API_KEY") or "")
-    anthropic_model_name: str = "claude-sonnet-4-6"
-    anthropic_sub_model_name: str = "claude-sonnet-4-6"
+    anthropic_model_name: str = "claude-fable-5"
+    anthropic_sub_model_name: str = "claude-fable-5"
     work_product_path: str = os.getenv("AGENT_WORK_PRODUCT_PATH") or "/tmp/agent_work"
     temperature: float = 0.7
     max_retries: int = 3

--- a/packages/core/src/white_core/agents/base_rainbow_agent.py
+++ b/packages/core/src/white_core/agents/base_rainbow_agent.py
@@ -51,6 +51,19 @@ class BaseRainbowAgent(BaseModel, ABC):
             max_tokens=self.settings.max_tokens,
         )
 
+    @staticmethod
+    def _extract_text(content) -> str:
+        if isinstance(content, list):
+            return "".join(
+                (
+                    block.get("text", "")
+                    if isinstance(block, dict)
+                    else getattr(block, "text", str(block))
+                )
+                for block in content
+            )
+        return content or ""
+
 
 def skip_chance(chance, rng=None):
     rng = rng or __import__("random").random

--- a/packages/core/src/white_core/agents/base_rainbow_agent.py
+++ b/packages/core/src/white_core/agents/base_rainbow_agent.py
@@ -62,7 +62,7 @@ class BaseRainbowAgent(BaseModel, ABC):
                 )
                 for block in content
             )
-        return content or ""
+        return str(content) if content is not None else ""
 
 
 def skip_chance(chance, rng=None):

--- a/packages/ideation/src/white_ideation/agents/black_agent.py
+++ b/packages/ideation/src/white_ideation/agents/black_agent.py
@@ -276,7 +276,7 @@ Example: "I will weave hidden frequencies that awaken dormant resistance."
         try:
             claude = self._get_claude()
             wish_response = claude.invoke(prompt)
-            wish_text = wish_response.content
+            wish_text = self._extract_text(wish_response.content)
         except Exception as e:
             error_msg = f"LLM call for sigil wish generation failed: {e!s}"
             logger.error(error_msg)

--- a/packages/ideation/src/white_ideation/agents/orange_agent.py
+++ b/packages/ideation/src/white_ideation/agents/orange_agent.py
@@ -655,7 +655,7 @@ class OrangeAgent(BaseRainbowAgent, ABC):
 
             # Make Anthropic API call (same as MCP tool)
             response = self.llm.invoke([HumanMessage(content=prompt)], max_tokens=2000)
-            updated_text = response.content.strip()
+            updated_text = self._extract_text(response.content).strip()
 
             self.corpus.insert_symbolic_object(
                 story_id=state.selected_story_id,
@@ -787,7 +787,7 @@ class OrangeAgent(BaseRainbowAgent, ABC):
                 temperature=0.8 + (state.gonzo_intensity * 0.05),
                 max_tokens=3000,
             )
-            gonzo_text = response.content.strip()
+            gonzo_text = self._extract_text(response.content).strip()
 
             self.corpus.add_gonzo_rewrite(
                 story_id=state.selected_story_id,

--- a/packages/ideation/src/white_ideation/agents/white_agent.py
+++ b/packages/ideation/src/white_ideation/agents/white_agent.py
@@ -425,7 +425,7 @@ class WhiteAgent(BaseModel):
                 )
                 for block in content
             )
-        return content or ""
+        return str(content) if content is not None else ""
 
     @staticmethod
     def _normalize_song_proposal(proposal):
@@ -2202,11 +2202,11 @@ Structure your synthesis as a clear creative brief for solipsistic methodology.
                 response = claude.invoke(prompt)
                 return self._extract_text(response.content)
             except Exception as e:
-                error_msg = f"Indigo synthesis LLM call failed: {e!s}"
+                error_msg = f"Violet synthesis LLM call failed: {e!s}"
                 logger.error(error_msg)
                 if block_mode:
                     raise Exception(error_msg)
-                return "LLM call failed - Indigo synthesis unavailable"
+                return "LLM call failed - Violet synthesis unavailable"
 
     def _synthesize_document_for_white(
         self, rebracketed_analysis, violet_proposal, artifacts
@@ -2269,11 +2269,11 @@ Structure your synthesis as the final creative brief before manifestation.
                 response = claude.invoke(prompt)
                 return self._extract_text(response.content)
             except Exception as e:
-                error_msg = f"Indigo synthesis LLM call failed: {e!s}"
+                error_msg = f"White synthesis LLM call failed: {e!s}"
                 logger.error(error_msg)
                 if block_mode:
                     raise Exception(error_msg)
-                return "LLM call failed - Indigo synthesis unavailable"
+                return "LLM call failed - White synthesis unavailable"
 
     @staticmethod
     def route_after_black(state: MainAgentState) -> str:

--- a/packages/ideation/src/white_ideation/agents/white_agent.py
+++ b/packages/ideation/src/white_ideation/agents/white_agent.py
@@ -415,6 +415,19 @@ class WhiteAgent(BaseModel):
         )
 
     @staticmethod
+    def _extract_text(content) -> str:
+        if isinstance(content, list):
+            return "".join(
+                (
+                    block.get("text", "")
+                    if isinstance(block, dict)
+                    else getattr(block, "text", str(block))
+                )
+                for block in content
+            )
+        return content or ""
+
+    @staticmethod
     def _normalize_song_proposal(proposal):
         """
         Ensures proposal is a SongProposal instance.
@@ -1300,7 +1313,7 @@ Focus on revealing the underlying ORDER, not explaining away the solipsism.
             try:
                 claude = self._get_claude_supervisor()
                 response = claude.invoke(prompt)
-                return response.content
+                return self._extract_text(response.content)
             except Exception as e:
                 error_msg = f"Violet rebracketing LLM call failed: {e!s}"
                 logger.error(error_msg)
@@ -1374,7 +1387,7 @@ Focus on revealing the underlying ORDER, not solving the puzzles.
             try:
                 claude = self._get_claude_supervisor()
                 response = claude.invoke(prompt)
-                return response.content
+                return self._extract_text(response.content)
             except Exception as e:
                 error_msg = f"Indigo rebracketing LLM call failed: {e!s}"
                 logger.error(error_msg)
@@ -1443,7 +1456,7 @@ Focus on revealing the underlying ORDER, not choosing between timelines.
             try:
                 claude = self._get_claude_supervisor()
                 response = claude.invoke(prompt)
-                return response.content
+                return self._extract_text(response.content)
             except Exception as e:
                 error_msg = f"Blue rebracketing LLM call failed: {e!s}"
                 logger.error(error_msg)
@@ -1525,7 +1538,7 @@ Focus on revealing the underlying ORDER, not explaining away the complexity.
         try:
             claude = self._get_claude_supervisor()
             response = claude.invoke(prompt)
-            return response.content
+            return self._extract_text(response.content)
         except Exception as e:
             error_msg = f"Green rebracketing LLM call failed: {e!s}"
             logger.error(error_msg)
@@ -1589,7 +1602,7 @@ Focus on revealing the underlying ORDER, not explaining away the complexity.
             try:
                 claude = self._get_claude_supervisor()
                 response = claude.invoke(prompt)
-                return response.content
+                return self._extract_text(response.content)
             except Exception as e:
                 error_msg = f"Yellow rebracketing LLM call failed: {e!s}"
                 logger.error(error_msg)
@@ -1653,7 +1666,7 @@ Focus on revealing the underlying ORDER, not explaining away the complexity.
             try:
                 claude = self._get_claude_supervisor()
                 response = claude.invoke(prompt)
-                return response.content
+                return self._extract_text(response.content)
             except Exception as e:
                 error_msg = f"Orange rebracketing LLM call failed: {e!s}"
                 logger.error(error_msg)
@@ -1709,7 +1722,7 @@ Focus on revealing the underlying ORDER, not explaining away the complexity.
             try:
                 claude = self._get_claude_supervisor()
                 response = claude.invoke(prompt)
-                return response.content
+                return self._extract_text(response.content)
             except Exception as e:
                 error_msg = f"Red rebracketing LLM call failed: {e!s}"
                 logger.error(error_msg)
@@ -1771,7 +1784,7 @@ Focus on revealing the underlying ORDER, not explaining away the paradox.
             try:
                 claude = self._get_claude_supervisor()
                 response = claude.invoke(prompt)
-                return response.content
+                return self._extract_text(response.content)
             except Exception as e:
                 error_msg = f"Black rebracketing LLM call failed: {e!s}"
                 logger.error(error_msg)
@@ -1829,7 +1842,7 @@ Structure your synthesis as a clear creative brief.
             try:
                 claude = self._get_claude_supervisor()
                 response = claude.invoke(prompt)
-                return response.content
+                return self._extract_text(response.content)
             except Exception as e:
                 error_msg = f"Red synthesis LLM call failed: {e!s}"
                 logger.error(error_msg)
@@ -1887,7 +1900,7 @@ Structure your synthesis as a clear creative brief.
             try:
                 claude = self._get_claude_supervisor()
                 response = claude.invoke(prompt)
-                return response.content
+                return self._extract_text(response.content)
             except Exception as e:
                 error_msg = f"Orange synthesis LLM call failed: {e!s}"
                 logger.error(error_msg)
@@ -1945,7 +1958,7 @@ Structure your synthesis as a clear creative brief.
             try:
                 claude = self._get_claude_supervisor()
                 response = claude.invoke(prompt)
-                return response.content
+                return self._extract_text(response.content)
             except Exception as e:
                 error_msg = f"Yellow synthesis LLM call failed: {e!s}"
                 logger.error(error_msg)
@@ -2003,7 +2016,7 @@ Structure your synthesis as a clear creative brief.
             try:
                 claude = self._get_claude_supervisor()
                 response = claude.invoke(prompt)
-                return response.content
+                return self._extract_text(response.content)
             except Exception as e:
                 error_msg = f"Green synthesis LLM call failed: {e!s}"
                 logger.error(error_msg)
@@ -2061,7 +2074,7 @@ Structure your synthesis as a clear creative brief.
             try:
                 claude = self._get_claude_supervisor()
                 response = claude.invoke(prompt)
-                return response.content
+                return self._extract_text(response.content)
             except Exception as e:
                 error_msg = f"Blue synthesis LLM call failed: {e!s}"
                 logger.error(error_msg)
@@ -2124,7 +2137,7 @@ Structure your synthesis as a clear creative brief for cryptographic methodology
             try:
                 claude = self._get_claude_supervisor()
                 response = claude.invoke(prompt)
-                return response.content
+                return self._extract_text(response.content)
             except Exception as e:
                 error_msg = f"Indigo synthesis LLM call failed: {e!s}"
                 logger.error(error_msg)
@@ -2187,7 +2200,7 @@ Structure your synthesis as a clear creative brief for solipsistic methodology.
             try:
                 claude = self._get_claude_supervisor()
                 response = claude.invoke(prompt)
-                return response.content
+                return self._extract_text(response.content)
             except Exception as e:
                 error_msg = f"Indigo synthesis LLM call failed: {e!s}"
                 logger.error(error_msg)
@@ -2254,7 +2267,7 @@ Structure your synthesis as the final creative brief before manifestation.
             try:
                 claude = self._get_claude_supervisor()
                 response = claude.invoke(prompt)
-                return response.content
+                return self._extract_text(response.content)
             except Exception as e:
                 error_msg = f"Indigo synthesis LLM call failed: {e!s}"
                 logger.error(error_msg)
@@ -2805,7 +2818,7 @@ Generate comprehensive meta-analysis revealing the ORDER beneath the rainbow.
         try:
             claude = self._get_claude_supervisor()
             response = claude.invoke(prompt)
-            return response.content
+            return self._extract_text(response.content)
         except Exception as e:
             logger.error(f"Meta-rebracketing LLM call failed: {e}")
             return f"Meta-rebracketing unavailable: {e}"
@@ -2893,7 +2906,7 @@ through sound into a REAL, COMPLETE song ready for human implementation.
         try:
             claude = self._get_claude_supervisor()
             response = claude.invoke(prompt)
-            return response.content
+            return self._extract_text(response.content)
         except Exception as e:
             logger.error(f"Chromatic synthesis LLM call failed: {e}")
             return f"Chromatic synthesis unavailable: {e}"
@@ -3010,7 +3023,7 @@ Keep it to 2-3 paragraphs maximum.
         try:
             claude = self._get_claude_supervisor()
             response = claude.invoke(prompt)
-            return response.content
+            return self._extract_text(response.content)
         except Exception as e:
             logger.error(f"Mini-synthesis for {agent_name} failed: {e}")
             # Fallback to content_excerpt


### PR DESCRIPTION
## Summary

- Switches all LangChain agents (White supervisor + all color sub-agents) from `claude-sonnet-4-6` to `claude-fable-5` via `AgentSettings` defaults and hardcoded supervisor
- Adds `_extract_text()` helper to `WhiteAgent` and `BaseRainbowAgent` to handle Fable returning `response.content` as a list of content blocks rather than a plain string — applied across all 23 LLM response sites in `white_agent.py`, `black_agent.py`, and `orange_agent.py`
- Fixes `NoneType` crash in `shrinkwrap_chain_artifacts.write_index()` when a thread's `concept` field is explicitly `None` (broke index.yml and negative_constraints.yml generation)

## Test plan

- [x] Full agent run completed successfully with Fable (thread `7308908d`, 17 proposals, all 8 agents)
- [x] Shrinkwrap ran cleanly post-fix, writing `index.yml` (7 threads) and `negative_constraints.yml`
- [x] Confirm sub-agent Fable responses parse correctly across multiple runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)