### PR TITLE
Lyric generation quality + LP-side sequencing

### DIFF
--- a/openspec/changes/add-lp-sequencing-integration/proposal.md
+++ b/openspec/changes/add-lp-sequencing-integration/proposal.md
@@ -1,0 +1,34 @@
+# Change: Integrate LP-side sequencing into navigation, song status, and a Claude-facing analysis tool
+
+## Why
+`add-lp-side-sequencing` introduces `sides.yml` and the assignment API/UI, but three
+things are still missing for it to be usable day-to-day: a discoverable path to the new
+page from the existing client, a way to see at a glance which songs are being considered
+for LP placement (distinct from mix/lifecycle stage), and a way for Claude to reason
+about the current sequencing against the album's aesthetic goals (chromatic color
+balance, mood/energy flow across sides) rather than just raw duration math.
+
+## What Changes
+- Add a "Sides" nav entry to the client alongside the existing board/candidates/songs/
+  collaborators links.
+- Add an `lp_consideration` field to `manifest_bootstrap.yml` (alongside the existing
+  `lifecycle_status` from `add-song-lifecycle-statuses`), with values `not_considered`
+  (default), `candidate`, `placed`. Surfaced as a filter pill and badge in the song list,
+  following the same pattern as the `merged`/`abandoned`/`scrapped` pills.
+- New `POST /songs/{id}/lp-consideration` endpoint to set the flag directly; the side
+  assignment endpoints from `add-lp-side-sequencing` also auto-set it to `placed` on
+  assignment and `candidate` when a song has a mix but isn't yet on any side.
+- New CLI script `lp_sequence_advisor.py` (`packages/composition`) that Claude runs via
+  Bash (same pattern as `song_dashboard.py` / `plan_drift_report.py`): reads `sides.yml`
+  plus each placed song's chromatic color/mood/BPM metadata and cached duration, and
+  prints/writes a report on aesthetic flow per side (color clustering, energy arc,
+  duration balance) with suggestions. It is read-only — it never modifies `sides.yml`.
+
+## Impact
+- Affected specs: `candidate-browser-web` (ADDED: nav entry, `lp_consideration`
+  status/filter/endpoint), `lp-sequencing-analysis` (new capability: CLI advisor tool)
+- Affected code: `packages/client/app/*` (nav layout, song list badge/filter),
+  `packages/api/src/white_api/candidate_server.py` (status endpoint, hook into side
+  assignment), new `packages/composition/src/white_composition/lp_sequence_advisor.py`
+- Depends on: `add-lp-side-sequencing` (requires `sides.yml` schema and assignment
+  endpoints to exist first)

--- a/openspec/changes/add-lp-sequencing-integration/specs/candidate-browser-web/spec.md
+++ b/openspec/changes/add-lp-sequencing-integration/specs/candidate-browser-web/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Sides Navigation Entry
+The client SHALL expose a "Sides" navigation link alongside the existing board,
+candidates, songs, and collaborators links, routing to the LP-side sequencing page.
+
+#### Scenario: Nav link present
+- **WHEN** any client page renders the shared navigation
+- **THEN** a "Sides" link is present and navigates to `/sides`
+
+### Requirement: LP Consideration Status
+Each song SHALL carry an `lp_consideration` status (`not_considered`, `candidate`,
+`placed`) tracked in `manifest_bootstrap.yml`, independent of `lifecycle_status` and
+mix stage.
+
+#### Scenario: Default status
+- **WHEN** a song's `manifest_bootstrap.yml` has no `lp_consideration` field
+- **THEN** `scan_songs()` reports it as `not_considered`
+
+#### Scenario: Manual status set
+- **WHEN** `POST /songs/{id}/lp-consideration` is called with `{status: "candidate"}`
+- **THEN** the song's `manifest_bootstrap.yml` is updated with
+  `lp_consideration: candidate`
+- **AND** `{"ok": true, "status": "candidate"}` is returned
+
+#### Scenario: Auto-set to placed on side assignment
+- **WHEN** a song is assigned to a side via the `add-lp-side-sequencing` assign/move
+  endpoints
+- **THEN** the song's `lp_consideration` is automatically set to `placed`
+
+#### Scenario: Auto-revert on removal
+- **WHEN** a song is removed from all sides via the remove endpoint
+- **THEN** `lp_consideration` reverts to `candidate` if the song still has a mix file,
+  or `not_considered` if it does not
+
+#### Scenario: Filter pill and badge
+- **WHEN** the song list filter bar renders
+- **THEN** `lp: candidate` and `lp: placed` pills are available
+- **AND** each song row shows a badge reflecting its current `lp_consideration` value

--- a/openspec/changes/add-lp-sequencing-integration/specs/lp-sequencing-analysis/spec.md
+++ b/openspec/changes/add-lp-sequencing-integration/specs/lp-sequencing-analysis/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Sequencing Aesthetic Analysis CLI
+The system SHALL provide `lp_sequence_advisor.py`, a read-only CLI script that Claude
+(or a human) runs directly to analyze the current `sides.yml` arrangement against
+aesthetic goals — chromatic color balance and mood/energy flow — rather than duration
+alone.
+
+#### Scenario: Report generated from current sides
+- **WHEN** `lp_sequence_advisor.py --album-dir <shrink_wrapped_dir>` is run
+- **THEN** it loads `sides.yml` and, for each placed song, reads `rainbow_color`, mood,
+  and BPM from `manifest_bootstrap.yml`
+- **AND** prints a per-side summary of color distribution and BPM/energy spread
+
+#### Scenario: Suggestions included
+- **WHEN** a side's placed songs are heavily concentrated in one or two chromatic colors
+  or a narrow BPM band
+- **THEN** the report includes a plain-language suggestion (e.g. naming the imbalance
+  and a candidate song from another side that could help)
+
+#### Scenario: Read-only guarantee
+- **WHEN** `lp_sequence_advisor.py` is run in any mode
+- **THEN** `sides.yml` and all `manifest_bootstrap.yml` files are read but never written
+
+#### Scenario: Output modes
+- **WHEN** `--output report.yml` is passed
+- **THEN** the analysis is written to `report.yml` in addition to being printed
+- **WHEN** `--dry-run` is passed instead
+- **THEN** only stdout output is produced, matching the convention used by
+  `generate_negative_constraints.py --dry-run`
+
+#### Scenario: Empty or unplaced album
+- **WHEN** `sides.yml` does not exist or has no placed songs
+- **THEN** the tool prints a note that no analysis is possible yet and exits cleanly
+  (exit code 0, no error)

--- a/openspec/changes/add-lp-sequencing-integration/tasks.md
+++ b/openspec/changes/add-lp-sequencing-integration/tasks.md
@@ -1,25 +1,26 @@
 ## 1. Song status flag
-- [ ] 1.1 Add `lp_consideration` handling to the manifest patch helper (`_patch_manifest`
+- [x] 1.1 Add `lp_consideration` handling to the manifest patch helper (`_patch_manifest`
       in `candidate_server.py`), mirroring the existing `lifecycle_status` handling
-- [ ] 1.2 `POST /songs/{id}/lp-consideration` endpoint accepting
+- [x] 1.2 `POST /songs/{id}/lp-consideration` endpoint accepting
       `{status: "not_considered" | "candidate" | "placed"}`
-- [ ] 1.3 Hook `placed`/`candidate` auto-transitions into the `add-lp-side-sequencing`
+- [x] 1.3 Hook `placed`/`candidate` auto-transitions into the `add-lp-side-sequencing`
       assign/move/remove endpoints (assign/move → `placed`, remove → `candidate` if a
       mix still exists, else `not_considered`)
-- [ ] 1.4 Add `lp_consideration` to `scan_songs()` output
-- [ ] 1.5 Filter pill (`lp: candidate` / `lp: placed`) and badge in the client song list
+- [x] 1.4 Add `lp_consideration` to `scan_songs()` output
+- [x] 1.5 Filter pill (`lp: candidate` / `lp: placed`) and badge in the client song list
 
 ## 2. Navigation
-- [ ] 2.1 Add a "Sides" link to the client's shared navigation, alongside
-      board/candidates/songs/collaborators
+- [x] 2.1 Add a "Sides" link — there's no single shared nav component in this client
+      (each page has its own ad hoc header), so the link was added to the header of
+      every page that already cross-links to others: home (`/`), board, and candidates
 
 ## 3. Claude sequencing advisor
-- [ ] 3.1 `lp_sequence_advisor.py`: load `sides.yml` + each placed song's
+- [x] 3.1 `lp_sequence_advisor.py`: load `sides.yml` + each placed song's
       `rainbow_color`/mood/BPM (from `manifest_bootstrap.yml`) and cached duration;
       compute per-side color clustering and BPM/energy spread
-- [ ] 3.2 CLI flags: `--album-dir` (default `$SHRINKWRAP_OUTPUT_DIR`), `--output report.yml`,
+- [x] 3.2 CLI flags: `--album-dir` (default `$SHRINKWRAP_OUTPUT_DIR`), `--output report.yml`,
       `--dry-run` (print only, matching the `generate_negative_constraints.py` convention)
-- [ ] 3.3 Report includes plain-language suggestions (e.g. "Side B is all Blue/Indigo —
+- [x] 3.3 Report includes plain-language suggestions (e.g. "Side B is all Blue/Indigo —
       consider moving a warmer-color song in") without modifying `sides.yml`
-- [ ] 3.4 Unit tests for the report generation given a fixture `sides.yml` + fixture
+- [x] 3.4 Unit tests for the report generation given a fixture `sides.yml` + fixture
       manifests

--- a/openspec/changes/add-lp-sequencing-integration/tasks.md
+++ b/openspec/changes/add-lp-sequencing-integration/tasks.md
@@ -1,0 +1,25 @@
+## 1. Song status flag
+- [ ] 1.1 Add `lp_consideration` handling to the manifest patch helper (`_patch_manifest`
+      in `candidate_server.py`), mirroring the existing `lifecycle_status` handling
+- [ ] 1.2 `POST /songs/{id}/lp-consideration` endpoint accepting
+      `{status: "not_considered" | "candidate" | "placed"}`
+- [ ] 1.3 Hook `placed`/`candidate` auto-transitions into the `add-lp-side-sequencing`
+      assign/move/remove endpoints (assign/move → `placed`, remove → `candidate` if a
+      mix still exists, else `not_considered`)
+- [ ] 1.4 Add `lp_consideration` to `scan_songs()` output
+- [ ] 1.5 Filter pill (`lp: candidate` / `lp: placed`) and badge in the client song list
+
+## 2. Navigation
+- [ ] 2.1 Add a "Sides" link to the client's shared navigation, alongside
+      board/candidates/songs/collaborators
+
+## 3. Claude sequencing advisor
+- [ ] 3.1 `lp_sequence_advisor.py`: load `sides.yml` + each placed song's
+      `rainbow_color`/mood/BPM (from `manifest_bootstrap.yml`) and cached duration;
+      compute per-side color clustering and BPM/energy spread
+- [ ] 3.2 CLI flags: `--album-dir` (default `$SHRINKWRAP_OUTPUT_DIR`), `--output report.yml`,
+      `--dry-run` (print only, matching the `generate_negative_constraints.py` convention)
+- [ ] 3.3 Report includes plain-language suggestions (e.g. "Side B is all Blue/Indigo —
+      consider moving a warmer-color song in") without modifying `sides.yml`
+- [ ] 3.4 Unit tests for the report generation given a fixture `sides.yml` + fixture
+      manifests

--- a/openspec/changes/add-lp-side-sequencing/design.md
+++ b/openspec/changes/add-lp-side-sequencing/design.md
@@ -1,0 +1,72 @@
+## Context
+White is the only double-album (4-side) release in the catalog. Songs are scanned by
+`scan_songs()` in `candidate_server.py` (`packages/api/src/white_api/candidate_server.py:262`)
+from `manifest_bootstrap.yml` files, each keyed by `id = f"{thread_slug}__{production_slug}"`.
+Mix files are tracked per-song in `song_context.yml` (`mix_file` field) but no duration is
+stored anywhere today. There is no cross-song "album assembly" concept in the data model —
+every existing file (`review.yml`, `production_plan.yml`, `manifest_bootstrap.yml`) is
+scoped to a single song.
+
+## Goals / Non-Goals
+- Goals: track 4 sides (A–D), each an ordered list of songs with a running duration total
+  against a ~20-minute soft limit; drag-and-drop assignment/reordering in the client;
+  read mix duration without adding a new heavy dependency.
+- Non-Goals: enforcing the limit as a hard constraint (it's a soft creative guide, not a
+  physical pressing — over-limit sides are allowed, just flagged); no audio transcoding
+  or waveform analysis; no automatic bin-packing/auto-sequencing (that's covered by the
+  separate `lp-sequencing-analysis` advisor tool in `add-lp-sequencing-integration`).
+
+## Decisions
+
+- **Decision: `sides.yml` lives at the album root (`$SHRINKWRAP_OUTPUT_DIR/sides.yml`)**,
+  matching the existing `index.yml` / `negative_constraints.yml` convention — one
+  album-scoped file, not one per song.
+  - Shape:
+    ```yaml
+    side_limit_seconds: 1200
+    sides:
+      A: {songs: [{song_id: "violet__foo", duration_seconds: 187.4}]}
+      B: {songs: []}
+      C: {songs: []}
+      D: {songs: []}
+    ```
+  - Alternatives considered: storing side assignment inside each song's
+    `manifest_bootstrap.yml` — rejected because ordering within a side is a cross-song
+    concern (position matters) that a per-song file can't represent cleanly.
+
+- **Decision: duration is computed on read via `soundfile.info(path).frames / samplerate`**,
+  not stored redundantly in `song_context.yml`. `sides.yml` caches the duration at the
+  moment a song is assigned to a side (so the UI doesn't need to re-probe every mix file
+  on every load), and the cached value is refreshed whenever the song is re-assigned or
+  an explicit "refresh durations" action is triggered.
+  - Alternatives considered: writing `mix_duration_seconds` into `song_context.yml` at mix-set
+    time — rejected as unnecessary duplication; the existing `/production/mix/info`
+    endpoint is the natural place to expose duration on demand.
+
+- **Decision: use `@dnd-kit/core` for the client drag-and-drop board.** It's actively
+  maintained, has no legacy-context issues with React 19 (used by `packages/client`
+  today), and is a common, boring choice — no drag-and-drop library exists in the client
+  yet, so this is a new dependency either way.
+  - Alternatives considered: `react-beautiful-dnd` (unmaintained, React 18 issues),
+    hand-rolled HTML5 drag events (more code, worse accessibility) — both rejected.
+
+- **Decision: only songs with `has_mix: true` are assignable.** Songs without a mix
+  appear in an "available" list but are visually disabled/non-draggable, since duration
+  cannot be computed without an audio file.
+
+## Risks / Trade-offs
+- Soft-limit-only enforcement means sides can silently grow past 20 minutes — mitigated
+  by a clear visual warning (not a block) in the UI, matching the user's stated intent
+  that this is a creative constraint, not a hard rule.
+- Duration caching in `sides.yml` can go stale if a mix file is replaced without
+  re-assigning — mitigated by a manual "refresh durations" action rather than trying to
+  detect file changes automatically (keeps the implementation simple per project
+  conventions).
+
+## Migration Plan
+Net-new feature; no existing data migrates. `sides.yml` is created on first write (empty
+A–D sides) if it doesn't exist.
+
+## Open Questions
+- None outstanding — the two ambiguous points (tool shape for the advisor, proposal
+  split) were resolved before scaffolding and are captured in `add-lp-sequencing-integration`.

--- a/openspec/changes/add-lp-side-sequencing/proposal.md
+++ b/openspec/changes/add-lp-side-sequencing/proposal.md
@@ -1,0 +1,31 @@
+# Change: Add LP-side sequencing (drag-and-drop mix assembly against a 20-minute limit)
+
+## Why
+White is the only double album in the catalog, and there is currently no way to see how
+finished mixes add up against real LP-side runtime limits — `song_context.yml` doesn't
+even track mix duration. The user wants a lightweight, duration-aware sequencing surface:
+assign completed mixes into 4 sides (A–D) and see cumulative time against a ~20-minute
+soft ceiling per side, used as a compositional/sequencing constraint even though the
+record won't be physically pressed.
+
+## What Changes
+- Extract and cache mix duration (via `soundfile`, already a project dependency) for any
+  song with a mix file, exposed through the existing `GET /production/mix/info` endpoint.
+- New `sides.yml` data file at the album root (`$SHRINKWRAP_OUTPUT_DIR`, alongside
+  `index.yml`) storing 4 sides (A–D), each an ordered list of song IDs with cached
+  durations, and a configurable `side_limit_seconds` (default 1200 = 20 minutes).
+- New `candidate_server.py` endpoints: list sides with computed totals, assign a song to
+  a side at a position, reorder within a side, move between sides, remove from a side.
+- New client page (`packages/client/app/sides/`) with 4 drag-and-drop columns, one per
+  side, each showing assigned songs (title, duration) and a running total with a visual
+  warning when the side exceeds the soft limit.
+- Only songs with `has_mix: true` are assignable; songs without a mix are shown as
+  unavailable/non-draggable in the source list.
+
+## Impact
+- Affected specs: `lp-side-sequencing` (new capability)
+- Affected code: `packages/api/src/white_api/candidate_server.py` (new endpoints), new
+  `packages/composition/src/white_composition/lp_sides.py` (data model + duration
+  extraction + read/write helpers), new `packages/client/app/sides/page.tsx`,
+  `packages/client/lib/api.ts` / `lib/types.ts` additions, new client dependency for
+  drag-and-drop (see `design.md`)

--- a/openspec/changes/add-lp-side-sequencing/specs/lp-side-sequencing/spec.md
+++ b/openspec/changes/add-lp-side-sequencing/specs/lp-side-sequencing/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Mix Duration Extraction
+The system SHALL compute mix audio duration on demand using `soundfile.info()` and
+surface it through the existing mix-info endpoint.
+
+#### Scenario: Duration available
+- **WHEN** `GET /production/mix/info` is called for a song with a valid `mix_file`
+- **THEN** the response includes `duration_seconds` as a float
+
+#### Scenario: No mix file
+- **WHEN** `GET /production/mix/info` is called for a song with no `mix_file` set
+- **THEN** `duration_seconds` is `null` and `has_mix` is `false`
+
+#### Scenario: Unreadable mix file
+- **WHEN** the mix file path exists in `song_context.yml` but the file is missing or
+  unreadable by `soundfile`
+- **THEN** `duration_seconds` is `null` and no exception is raised to the caller
+
+### Requirement: Sides Data File
+The system SHALL persist LP-side assignments in `sides.yml` at the album root
+(`$SHRINKWRAP_OUTPUT_DIR/sides.yml`), containing exactly 4 sides (A–D) and a
+`side_limit_seconds` soft limit (default 1200).
+
+#### Scenario: File created on first write
+- **WHEN** no `sides.yml` exists and a song is first assigned to a side
+- **THEN** `sides.yml` is created with all 4 sides (A–D) and the assigned song placed
+  in the target side
+
+#### Scenario: Cached duration stored per assignment
+- **WHEN** a song is assigned to a side
+- **THEN** its `duration_seconds` (read via mix duration extraction at assignment time)
+  is cached in `sides.yml` alongside the song reference
+
+### Requirement: Side Assignment API
+`candidate_server.py` SHALL expose endpoints to list, assign, move, and remove songs
+from sides, plus computed per-side totals.
+
+#### Scenario: List sides with totals
+- **WHEN** `GET /sides` is called
+- **THEN** all 4 sides are returned, each with its ordered song list, cached durations,
+  a summed `total_seconds`, and an `over_limit` boolean (`total_seconds > side_limit_seconds`)
+
+#### Scenario: Assign a song
+- **WHEN** `POST /sides/A/assign` is called with `{song_id, position}` for a song with
+  `has_mix: true`
+- **THEN** the song is inserted into side A at `position`, its duration is cached, and
+  the updated side is returned
+
+#### Scenario: Reject assignment of a song without a mix
+- **WHEN** `POST /sides/{side}/assign` is called for a song with `has_mix: false`
+- **THEN** a 400 response is returned and `sides.yml` is not modified
+
+#### Scenario: Move a song between sides
+- **WHEN** `POST /sides/{side}/move` is called with `{song_id, to_side, to_position}`
+- **THEN** the song is removed from its current side and inserted into `to_side` at
+  `to_position`
+
+#### Scenario: Remove a song from a side
+- **WHEN** `DELETE /sides/{side}/songs/{song_id}` is called
+- **THEN** the song is removed from that side's list and `sides.yml` is updated
+
+### Requirement: Drag-and-Drop Sides UI
+The client SHALL provide a page with 4 drop-target columns (one per side) showing
+assigned songs with duration and a running total against the soft limit.
+
+#### Scenario: Running total display
+- **WHEN** the sides page loads
+- **THEN** each side column shows its songs (title + duration) and a running total
+  formatted as `MM:SS` (or `H:MM:SS` if over an hour)
+
+#### Scenario: Over-limit warning
+- **WHEN** a side's total exceeds `side_limit_seconds`
+- **THEN** the column displays a visual warning (e.g. total shown in a warning color)
+  without blocking further assignment
+
+#### Scenario: Non-mixed songs are not draggable
+- **WHEN** the available-songs list includes a song with `has_mix: false`
+- **THEN** that song is rendered in a disabled state and cannot be dragged onto a side
+
+#### Scenario: Drag updates assignment
+- **WHEN** a song is dragged from the available list (or another side) onto a side column
+- **THEN** the corresponding assign/move API call is made and the UI reflects the new
+  side totals without a full page reload

--- a/openspec/changes/add-lp-side-sequencing/tasks.md
+++ b/openspec/changes/add-lp-side-sequencing/tasks.md
@@ -25,8 +25,8 @@
 
 ## 4. Client UI
 - [x] 4.1 Add `@dnd-kit/core` to `packages/client` — `@dnd-kit/sortable` turned out to be
-      unnecessary: the page refetches `/sides` after every drop rather than maintaining
-      optimistic client-side reordering, so plain `useDraggable`/`useDroppable` covers it
+      unnecessary: `useDraggable`/`useDroppable` plus local optimistic state updates
+      (see 4.6 note) cover both cross-side moves and same-side reordering
 - [x] 4.2 New page `packages/client/app/sides/page.tsx` with 4 drop-column layout
 - [x] 4.3 Side column: song list (title, duration), running total, over-limit visual warning
 - [x] 4.4 Available-songs source list: only `has_mix: true` songs draggable
@@ -35,7 +35,11 @@
       warning appears once the side exceeds 20 minutes — **partially verified**: `tsc`
       and `next build` pass, and I ran the exact API sequence the drag handlers issue
       (assign/move/remove) live against a fixture album, confirming durations, ordering,
-      and the no-mix 400 rejection all work end-to-end. I could not drive an actual
-      pointer-drag gesture in a browser (Chrome extension wasn't connected in this
-      session) — **please try the real drag interaction yourself** before treating this
-      as fully verified.
+      and the no-mix 400 rejection all work end-to-end. Confirmed via real usage: the
+      first pass refetched `/sides`+`/songs` after every drop, so the dragged item
+      lingered in its source column until the round-trip resolved. Fixed by updating
+      `sides` state optimistically in `handleDragEnd`/`handleRemove` before the API call
+      (with duration backfilled from the response, and rollback to the previous state
+      on error) — dropped items now move instantly. I still could not drive an actual
+      pointer-drag gesture in a browser myself (Chrome extension wasn't connected in
+      this session) — **please confirm the instant-move fix looks right** on your end.

--- a/openspec/changes/add-lp-side-sequencing/tasks.md
+++ b/openspec/changes/add-lp-side-sequencing/tasks.md
@@ -31,15 +31,7 @@
 - [x] 4.3 Side column: song list (title, duration), running total, over-limit visual warning
 - [x] 4.4 Available-songs source list: only `has_mix: true` songs draggable
 - [x] 4.5 `lib/api.ts` / `lib/types.ts` additions for the new endpoints
-- [~] 4.6 Manual verification: drag a mixed song onto side A, confirm total updates and
-      warning appears once the side exceeds 20 minutes — **partially verified**: `tsc`
-      and `next build` pass, and I ran the exact API sequence the drag handlers issue
-      (assign/move/remove) live against a fixture album, confirming durations, ordering,
-      and the no-mix 400 rejection all work end-to-end. Confirmed via real usage: the
-      first pass refetched `/sides`+`/songs` after every drop, so the dragged item
-      lingered in its source column until the round-trip resolved. Fixed by updating
-      `sides` state optimistically in `handleDragEnd`/`handleRemove` before the API call
-      (with duration backfilled from the response, and rollback to the previous state
-      on error) — dropped items now move instantly. I still could not drive an actual
-      pointer-drag gesture in a browser myself (Chrome extension wasn't connected in
-      this session) — **please confirm the instant-move fix looks right** on your end.
+- [x] 4.6 Manual verification: drag a mixed song onto side A, confirm total updates and
+      warning appears once the side exceeds 20 minutes — verified via real usage: you
+      tried the actual drag interaction and reported two issues (item not disappearing
+      on release; black-on-black text on side tiles), both fixed and confirmed working.

--- a/openspec/changes/add-lp-side-sequencing/tasks.md
+++ b/openspec/changes/add-lp-side-sequencing/tasks.md
@@ -1,0 +1,33 @@
+## 1. Duration extraction
+- [ ] 1.1 Add a `mix_duration_seconds(path)` helper (using `soundfile.info`) to
+      `packages/composition/src/white_composition/lp_sides.py`
+- [ ] 1.2 Extend `GET /production/mix/info` in `candidate_server.py` to include
+      `duration_seconds` (null if no mix or unreadable file)
+- [ ] 1.3 Unit tests for duration extraction against a short fixture WAV, and for the
+      missing-file / no-mix cases
+
+## 2. Sides data model
+- [ ] 2.1 Define `sides.yml` read/write helpers in `lp_sides.py`: `load_sides(album_dir)`,
+      `save_sides(album_dir, sides)`, initializing empty A–D sides if the file is absent
+- [ ] 2.2 Implement `assign_song(sides, song_id, side, position, duration_seconds)`,
+      `move_song(sides, song_id, to_side, to_position)`, `remove_song(sides, song_id)`
+- [ ] 2.3 Implement `side_totals(sides)` returning per-side summed duration and an
+      `over_limit` flag against `side_limit_seconds`
+- [ ] 2.4 Unit tests for assign/move/remove/reorder and total/over-limit computation
+
+## 3. API endpoints
+- [ ] 3.1 `GET /sides` — return all 4 sides with songs, cached durations, and totals
+- [ ] 3.2 `POST /sides/{side}/assign` — assign a song at a position (body: song_id, position)
+- [ ] 3.3 `POST /sides/{side}/move` — move a song within/between sides
+- [ ] 3.4 `DELETE /sides/{side}/songs/{song_id}` — remove a song from a side
+- [ ] 3.5 Integration tests in `packages/api/tests` covering the above against a temp
+      album dir with fixture manifests
+
+## 4. Client UI
+- [ ] 4.1 Add `@dnd-kit/core` (and `@dnd-kit/sortable`) to `packages/client`
+- [ ] 4.2 New page `packages/client/app/sides/page.tsx` with 4 drop-column layout
+- [ ] 4.3 Side column: song list (title, duration), running total, over-limit visual warning
+- [ ] 4.4 Available-songs source list: only `has_mix: true` songs draggable
+- [ ] 4.5 `lib/api.ts` / `lib/types.ts` additions for the new endpoints
+- [ ] 4.6 Manual verification: drag a mixed song onto side A, confirm total updates and
+      warning appears once the side exceeds 20 minutes

--- a/openspec/changes/add-lp-side-sequencing/tasks.md
+++ b/openspec/changes/add-lp-side-sequencing/tasks.md
@@ -1,33 +1,41 @@
 ## 1. Duration extraction
-- [ ] 1.1 Add a `mix_duration_seconds(path)` helper (using `soundfile.info`) to
+- [x] 1.1 Add a `mix_duration_seconds(path)` helper (using `soundfile.info`) to
       `packages/composition/src/white_composition/lp_sides.py`
-- [ ] 1.2 Extend `GET /production/mix/info` in `candidate_server.py` to include
+- [x] 1.2 Extend `GET /production/mix/info` in `candidate_server.py` to include
       `duration_seconds` (null if no mix or unreadable file)
-- [ ] 1.3 Unit tests for duration extraction against a short fixture WAV, and for the
+- [x] 1.3 Unit tests for duration extraction against a short fixture WAV, and for the
       missing-file / no-mix cases
 
 ## 2. Sides data model
-- [ ] 2.1 Define `sides.yml` read/write helpers in `lp_sides.py`: `load_sides(album_dir)`,
+- [x] 2.1 Define `sides.yml` read/write helpers in `lp_sides.py`: `load_sides(album_dir)`,
       `save_sides(album_dir, sides)`, initializing empty A–D sides if the file is absent
-- [ ] 2.2 Implement `assign_song(sides, song_id, side, position, duration_seconds)`,
+- [x] 2.2 Implement `assign_song(sides, song_id, side, position, duration_seconds)`,
       `move_song(sides, song_id, to_side, to_position)`, `remove_song(sides, song_id)`
-- [ ] 2.3 Implement `side_totals(sides)` returning per-side summed duration and an
+- [x] 2.3 Implement `side_totals(sides)` returning per-side summed duration and an
       `over_limit` flag against `side_limit_seconds`
-- [ ] 2.4 Unit tests for assign/move/remove/reorder and total/over-limit computation
+- [x] 2.4 Unit tests for assign/move/remove/reorder and total/over-limit computation
 
 ## 3. API endpoints
-- [ ] 3.1 `GET /sides` — return all 4 sides with songs, cached durations, and totals
-- [ ] 3.2 `POST /sides/{side}/assign` — assign a song at a position (body: song_id, position)
-- [ ] 3.3 `POST /sides/{side}/move` — move a song within/between sides
-- [ ] 3.4 `DELETE /sides/{side}/songs/{song_id}` — remove a song from a side
-- [ ] 3.5 Integration tests in `packages/api/tests` covering the above against a temp
+- [x] 3.1 `GET /sides` — return all 4 sides with songs, cached durations, and totals
+- [x] 3.2 `POST /sides/{side}/assign` — assign a song at a position (body: song_id, position)
+- [x] 3.3 `POST /sides/{side}/move` — move a song within/between sides
+- [x] 3.4 `DELETE /sides/{side}/songs/{song_id}` — remove a song from a side
+- [x] 3.5 Integration tests in `packages/api/tests` covering the above against a temp
       album dir with fixture manifests
 
 ## 4. Client UI
-- [ ] 4.1 Add `@dnd-kit/core` (and `@dnd-kit/sortable`) to `packages/client`
-- [ ] 4.2 New page `packages/client/app/sides/page.tsx` with 4 drop-column layout
-- [ ] 4.3 Side column: song list (title, duration), running total, over-limit visual warning
-- [ ] 4.4 Available-songs source list: only `has_mix: true` songs draggable
-- [ ] 4.5 `lib/api.ts` / `lib/types.ts` additions for the new endpoints
-- [ ] 4.6 Manual verification: drag a mixed song onto side A, confirm total updates and
-      warning appears once the side exceeds 20 minutes
+- [x] 4.1 Add `@dnd-kit/core` to `packages/client` — `@dnd-kit/sortable` turned out to be
+      unnecessary: the page refetches `/sides` after every drop rather than maintaining
+      optimistic client-side reordering, so plain `useDraggable`/`useDroppable` covers it
+- [x] 4.2 New page `packages/client/app/sides/page.tsx` with 4 drop-column layout
+- [x] 4.3 Side column: song list (title, duration), running total, over-limit visual warning
+- [x] 4.4 Available-songs source list: only `has_mix: true` songs draggable
+- [x] 4.5 `lib/api.ts` / `lib/types.ts` additions for the new endpoints
+- [~] 4.6 Manual verification: drag a mixed song onto side A, confirm total updates and
+      warning appears once the side exceeds 20 minutes — **partially verified**: `tsc`
+      and `next build` pass, and I ran the exact API sequence the drag handlers issue
+      (assign/move/remove) live against a fixture album, confirming durations, ordering,
+      and the no-mix 400 rejection all work end-to-end. I could not drive an actual
+      pointer-drag gesture in a browser (Chrome extension wasn't connected in this
+      session) — **please try the real drag interaction yourself** before treating this
+      as fully verified.

--- a/openspec/changes/add-lyric-negative-constraints/proposal.md
+++ b/openspec/changes/add-lyric-negative-constraints/proposal.md
@@ -1,0 +1,36 @@
+# Change: Add lyric-scoped negative constraints to avoid word/imagery convergence
+
+## Why
+Lyric candidates converge on the same small set of concrete words and images across
+songs (and across candidates within a song) — e.g. "blue thing" in one song, "dead" in
+the next — because nothing in the lyric pipeline tracks what language has already been
+used. `packages/extraction/src/white_extraction/util/generate_negative_constraints.py`
+solves a structurally similar convergence problem, but it operates on song-proposal
+metadata (key, BPM, title words, concept phrases, dialogue openers) for the White
+ideation agent's `negative_constraints.yml`, and has no visibility into lyric text —
+it is not wired into `lyric_pipeline.py` at all. This is a genuinely different concern
+(word/imagery frequency in generated lyric text) consumed by a different pipeline, and
+needs its own mechanism rather than extending the agent-level one.
+
+## What Changes
+- New module `lyric_negative_constraints.py` (same analysis pattern as
+  `generate_negative_constraints.py`: `Counter`-based frequency counting + threshold +
+  severity) scoped entirely to lyric text.
+- Walks an album/thread's promoted `melody/lyrics.txt` files (optionally including
+  pending `melody/candidates/lyrics_*.txt`) and computes: overused short/monosyllabic
+  words, overused concrete nouns/images, and per-word frequency across the album.
+- Writes `lyrics_negative_constraints.yml` at the shrink-wrapped album root (same
+  location pattern as the existing `negative_constraints.yml` and `index.yml`).
+- `lyric_pipeline.py` loads this file when present (no error if absent) and injects a
+  formatted avoidance block into the generation prompt, the same way `artist_context`
+  is injected today.
+- Explicitly does **not** modify `generate_negative_constraints.py` or
+  `negative_constraints.yml` — the two mechanisms remain independent, with different
+  inputs (proposal metadata vs. lyric text) and different consumers (White agent vs.
+  lyric pipeline).
+
+## Impact
+- Affected specs: `lyric-negative-constraints` (new capability)
+- Affected code: new `packages/generation/src/white_generation/lyric_negative_constraints.py`;
+  `packages/generation/src/white_generation/pipelines/lyric_pipeline.py` (prompt building,
+  new CLI flag)

--- a/openspec/changes/add-lyric-negative-constraints/specs/lyric-negative-constraints/spec.md
+++ b/openspec/changes/add-lyric-negative-constraints/specs/lyric-negative-constraints/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: Lyric Word/Imagery Frequency Analysis
+The system SHALL provide a `lyric_negative_constraints.py` module that walks an album's
+promoted lyric files and computes word-frequency statistics distinct from the
+proposal-level constraints produced by `generate_negative_constraints.py`.
+
+#### Scenario: Album-wide frequency scan
+- **WHEN** `lyric_negative_constraints.py --album-dir <shrink_wrapped_dir>` is run
+- **THEN** every `melody/lyrics.txt` found under `<shrink_wrapped_dir>/*/production/*/`
+  is read and tokenized
+- **AND** a per-word frequency count is computed across all songs
+
+#### Scenario: Overused short word flagged
+- **WHEN** a monosyllabic content word (e.g. "blue", "dead") appears in more than 30%
+  of scanned songs' lyrics
+- **THEN** it is recorded as an overused word with `severity: avoid` and a human-readable
+  reason string, following the same threshold/severity shape as
+  `generate_negative_constraints.analyze_title_vocabulary`
+
+#### Scenario: Independent from proposal-level constraints
+- **WHEN** `lyric_negative_constraints.py` runs
+- **THEN** it does not read or write `negative_constraints.yml`
+- **AND** `generate_negative_constraints.py` is unmodified and continues to operate only
+  on song-proposal metadata (key, BPM, title, concept, dialogue openers)
+
+### Requirement: Lyric Negative Constraints File
+The system SHALL write `lyrics_negative_constraints.yml` to the album root
+(`$SHRINKWRAP_OUTPUT_DIR`), following the same file-location convention as
+`index.yml` and `negative_constraints.yml`.
+
+#### Scenario: Constraints file written
+- **WHEN** the analysis completes with at least one overused word
+- **THEN** `lyrics_negative_constraints.yml` is written with `overused_words`, per-word
+  `count`/`fraction`/`reason`, and a `generated_from` field recording the album dir scanned
+
+#### Scenario: No constraints yet
+- **WHEN** the album has fewer than 2 songs with promoted lyrics
+- **THEN** the file is still written with an empty `overused_words` list and a note
+  that too few songs exist for meaningful frequency analysis
+
+### Requirement: Lyric Pipeline Constraint Injection
+`lyric_pipeline.py` SHALL load `lyrics_negative_constraints.yml` from the album root
+when present and inject a formatted avoidance block into the generation prompt for
+both standard and White cut-up modes.
+
+#### Scenario: Constraints present
+- **WHEN** `lyrics_negative_constraints.yml` exists and lists overused words
+- **THEN** the Claude prompt built by `_build_prompt` (or `_build_white_cutup_prompt`
+  for White) includes a block listing those words as language to avoid
+
+#### Scenario: Constraints absent
+- **WHEN** `lyrics_negative_constraints.yml` does not exist for the album
+- **THEN** the pipeline proceeds without an avoidance block and without error or warning
+  beyond an informational log line
+
+### Requirement: Refresh Constraints CLI Flag
+`lyric_pipeline.py` SHALL accept a `--refresh-constraints` flag that regenerates
+`lyrics_negative_constraints.yml` from the current album state before generating
+new candidates.
+
+#### Scenario: Refresh before generation
+- **WHEN** `lyric_pipeline.py --production-dir <dir> --refresh-constraints` is run
+- **THEN** `lyric_negative_constraints.py`'s analysis is re-run against the album root
+  and `lyrics_negative_constraints.yml` is overwritten before the prompt is built

--- a/openspec/changes/add-lyric-negative-constraints/tasks.md
+++ b/openspec/changes/add-lyric-negative-constraints/tasks.md
@@ -1,0 +1,21 @@
+## 1. Analysis module
+- [ ] 1.1 Create `packages/generation/src/white_generation/lyric_negative_constraints.py`
+      with word-frequency and overuse-threshold logic (reuse the `Counter` +
+      threshold/severity pattern from `generate_negative_constraints.py`)
+- [ ] 1.2 Implement `collect_lyric_texts(album_dir)` — walks `*/production/*/melody/lyrics.txt`
+      (promoted) under the album root, matching the existing `scan_songs`-style glob
+- [ ] 1.3 Implement `analyze_word_frequency(texts)` returning overused words/short-word
+      clusters above a configurable fraction threshold (mirrors `analyze_title_vocabulary`)
+- [ ] 1.4 CLI entry point: `--album-dir` (default `$SHRINKWRAP_OUTPUT_DIR`),
+      `--output lyrics_negative_constraints.yml`, `--dry-run`
+- [ ] 1.5 Unit tests for frequency analysis and threshold flagging with a small fixture set
+
+## 2. Pipeline integration
+- [ ] 2.1 Add a loader in `lyric_pipeline.py` that reads `lyrics_negative_constraints.yml`
+      from the album root if present; no error or behavior change if absent
+- [ ] 2.2 Format constraints into a prompt block (mirrors `format_for_prompt`) and inject
+      into both `_build_prompt` and `_build_white_cutup_prompt`
+- [ ] 2.3 Add a `--refresh-constraints` CLI flag to `lyric_pipeline.py` that regenerates
+      `lyrics_negative_constraints.yml` before generating candidates
+- [ ] 2.4 Tests confirming the prompt includes the avoidance block when the constraints
+      file is present, and generation behavior is unchanged when it is absent

--- a/openspec/changes/add-lyric-negative-constraints/tasks.md
+++ b/openspec/changes/add-lyric-negative-constraints/tasks.md
@@ -1,21 +1,21 @@
 ## 1. Analysis module
-- [ ] 1.1 Create `packages/generation/src/white_generation/lyric_negative_constraints.py`
+- [x] 1.1 Create `packages/generation/src/white_generation/lyric_negative_constraints.py`
       with word-frequency and overuse-threshold logic (reuse the `Counter` +
       threshold/severity pattern from `generate_negative_constraints.py`)
-- [ ] 1.2 Implement `collect_lyric_texts(album_dir)` — walks `*/production/*/melody/lyrics.txt`
+- [x] 1.2 Implement `collect_lyric_texts(album_dir)` — walks `*/production/*/melody/lyrics.txt`
       (promoted) under the album root, matching the existing `scan_songs`-style glob
-- [ ] 1.3 Implement `analyze_word_frequency(texts)` returning overused words/short-word
+- [x] 1.3 Implement `analyze_word_frequency(texts)` returning overused words/short-word
       clusters above a configurable fraction threshold (mirrors `analyze_title_vocabulary`)
-- [ ] 1.4 CLI entry point: `--album-dir` (default `$SHRINKWRAP_OUTPUT_DIR`),
+- [x] 1.4 CLI entry point: `--album-dir` (default `$SHRINKWRAP_OUTPUT_DIR`),
       `--output lyrics_negative_constraints.yml`, `--dry-run`
-- [ ] 1.5 Unit tests for frequency analysis and threshold flagging with a small fixture set
+- [x] 1.5 Unit tests for frequency analysis and threshold flagging with a small fixture set
 
 ## 2. Pipeline integration
-- [ ] 2.1 Add a loader in `lyric_pipeline.py` that reads `lyrics_negative_constraints.yml`
+- [x] 2.1 Add a loader in `lyric_pipeline.py` that reads `lyrics_negative_constraints.yml`
       from the album root if present; no error or behavior change if absent
-- [ ] 2.2 Format constraints into a prompt block (mirrors `format_for_prompt`) and inject
+- [x] 2.2 Format constraints into a prompt block (mirrors `format_for_prompt`) and inject
       into both `_build_prompt` and `_build_white_cutup_prompt`
-- [ ] 2.3 Add a `--refresh-constraints` CLI flag to `lyric_pipeline.py` that regenerates
+- [x] 2.3 Add a `--refresh-constraints` CLI flag to `lyric_pipeline.py` that regenerates
       `lyrics_negative_constraints.yml` before generating candidates
-- [ ] 2.4 Tests confirming the prompt includes the avoidance block when the constraints
+- [x] 2.4 Tests confirming the prompt includes the avoidance block when the constraints
       file is present, and generation behavior is unchanged when it is absent

--- a/openspec/changes/add-lyric-phrase-fitting/proposal.md
+++ b/openspec/changes/add-lyric-phrase-fitting/proposal.md
@@ -1,0 +1,13 @@
+# Change: Widen syllable targets for short MIDI phrases in lyric generation
+
+## Why
+Very short MIDI phrases (1–2 notes) currently get a syllable target of `floor(notes*0.8)`–`ceil(notes*1.15)` — often 1–2 syllables — and the prompt explicitly instructs Claude to hit that target on every line. Across candidates and across songs this repeatedly steers lyrics toward the same small pool of blunt monosyllables ("blue," "dead," "gone"), even though ACE Studio handles melisma (one syllable/word sustained across several notes) automatically. The tight per-note ratio was the right fix for the original "splits needed" (too many syllables) problem, but it overcorrected against short phrases, where a *wider* range — not a tighter one — is appropriate.
+
+## What Changes
+- Introduce a note-count threshold (`SHORT_PHRASE_NOTE_THRESHOLD`, default 3) below which the syllable target range is widened rather than computed from the strict 0.8x–1.15x multiplier, and a spacious (fewer syllables than notes) ratio is not treated as a fitting concern for these phrases.
+- Update the per-phrase prompt instructions (`_build_prompt`, `_build_white_cutup_prompt`) to explicitly offer melisma as a legal option for short phrases, instead of only ever asking for one-syllable-per-note density.
+- No change to phrase extraction, MIDI note counting, or the paste-ready/tight/splits-needed verdict bands for phrases above the threshold.
+
+## Impact
+- Affected specs: `lyric-generation` (MODIFIED: Lyric Fitting Score)
+- Affected code: `packages/generation/src/white_generation/pipelines/lyric_pipeline.py` — phrase target computation and prompt text in `_build_prompt` (~lines 1065–1085) and `_build_white_cutup_prompt` (~lines 939–956)

--- a/openspec/changes/add-lyric-phrase-fitting/specs/lyric-generation/spec.md
+++ b/openspec/changes/add-lyric-phrase-fitting/specs/lyric-generation/spec.md
@@ -1,0 +1,77 @@
+## MODIFIED Requirements
+
+### Requirement: Lyric Fitting Score
+The pipeline SHALL compute a per-phrase syllable fitting score for each candidate by
+comparing syllable count per lyric line against note count per MIDI phrase group within
+each vocal section. The overall verdict for a section is driven by the worst-case phrase,
+not the section mean.
+
+A MIDI phrase group is a sequence of note-on events separated from adjacent events by
+a rest of at least 0.5 beats. Single-note phrases are permitted.
+
+Fitting ratio = syllables / notes for each phrase.
+- **paste-ready**: 0.75–1.10 — syllables map directly to notes with minimal adjustment
+- **tight but workable**: 1.10–1.30 — a few notes will need splitting
+- **splits needed**: >1.30 — significant manual work in ACE Studio
+- **spacious**: <0.75 — melody has held notes; ACE Studio handles this automatically
+
+When the approved MIDI file for a section is not available, the pipeline SHALL fall back
+to section-level fitting (total syllables / total notes) with no error.
+
+#### Short-phrase target widening
+For phrases with a note count at or below `SHORT_PHRASE_NOTE_THRESHOLD` (default: 3),
+the syllable target range presented in the generation prompt SHALL NOT be the strict
+`floor(notes*0.8)`–`ceil(notes*1.15)` window. The pipeline SHALL widen the lower bound
+of the range so that a single word or short phrase sustained across the notes (melisma)
+is a legal, encouraged option, and a "spacious" ratio (fewer syllables than notes) on
+one of these phrases SHALL NOT be treated as a fitting concern or drive the section's
+overall verdict. This prevents the prompt from pinning every short phrase to a 1–2
+syllable target, which previously converged candidates on a small pool of monosyllabic
+words across songs.
+
+#### Note source: approved melody MIDIs per section
+Note counts SHALL be derived from the approved melody MIDI files in `melody/approved/`,
+not from a merged `melody/melody.mid` (which is never written by the pipeline).
+
+#### Syllable counting algorithm
+Syllable count SHALL use a vowel-cluster heuristic (no NLP dependency):
+1. Strip comment lines (starting with `#`) and section header lines (`[name]`)
+2. Split remaining text into words
+3. For each word, count contiguous vowel-character groups (`[aeiouAEIOU]`) as
+   syllables, with a floor of 1 syllable per word
+4. Sum across all lines for that section
+
+#### Scenario: Per-phrase fitting computed when MIDI available
+- **WHEN** the approved MIDI for a section exists in `melody/approved/`
+- **THEN** the pipeline extracts phrase groups separated by rests ≥ 0.5 beats,
+  scores each lyric line against its corresponding phrase's note count, and records
+  per-phrase ratios, verdicts, worst_ratio, worst_verdict, mean_ratio, and overall
+  in `lyrics_review.yml`
+
+#### Scenario: Worst-case phrase drives overall verdict
+- **WHEN** a section has 4 phrases and 3 are paste-ready but 1 is splits-needed
+- **THEN** the section's overall verdict is "splits needed"
+
+#### Scenario: Fallback to section-level when no MIDI
+- **WHEN** no approved MIDI exists for a section
+- **THEN** fitting falls back to total syllables / total notes for that section;
+  no error is raised
+
+#### Scenario: Prompt includes phrase structure
+- **WHEN** phrase data is available before the Claude API call
+- **THEN** the generation prompt includes per-phrase note counts and syllable target
+  ranges, and instructs Claude to write exactly one line per phrase
+- **AND** for phrases at or below `SHORT_PHRASE_NOTE_THRESHOLD`, the instruction notes
+  that a single word or short phrase may be sustained across the notes (melisma)
+  rather than requiring one syllable per note
+
+#### Scenario: Paste-ready target
+- **WHEN** all phrases in all sections have ratio 0.75–1.10
+- **THEN** the candidate is flagged as paste-ready (no splits expected in ACE Studio)
+
+#### Scenario: Short phrase does not force a monosyllabic line
+- **WHEN** a phrase has 2 notes
+- **THEN** the syllable target range presented to Claude is wider than
+  `floor(2*0.8)`–`ceil(2*1.15)` (i.e. wider than 1–3 syllables)
+- **AND** a lyric line with fewer syllables than notes for that phrase is not flagged
+  as a fitting problem or included in the worst-case verdict calculation

--- a/openspec/changes/add-lyric-phrase-fitting/tasks.md
+++ b/openspec/changes/add-lyric-phrase-fitting/tasks.md
@@ -6,4 +6,4 @@
 ## 2. Verification
 - [x] 2.1 Add/adjust unit tests in `packages/generation/tests/test_lyric_pipeline.py` covering: a 1-note phrase gets a widened range, a 2-note phrase gets a widened range, a 4+ note phrase is unaffected (matches current behavior)
 - [x] 2.2 Run `pytest packages/generation/tests/test_lyric_pipeline.py` and confirm no regressions to existing fitting-verdict tests
-- [ ] 2.3 Generate a real candidate against a song with several short melody phrases and manually confirm the output no longer defaults to single monosyllables on those lines — **left for you**: this calls the Anthropic API against a real production dir, which I didn't want to trigger unprompted
+- [x] 2.3 Generate a real candidate against a song with several short melody phrases and manually confirm the output no longer defaults to single monosyllables on those lines — verified against `filing_cipher_prism_v1/melody/lyrics.txt`: short phrases now land on real multisyllable words ("colander," "junipers," "forgotten," "untouched," "blackened") instead of defaulting to monosyllables

--- a/openspec/changes/add-lyric-phrase-fitting/tasks.md
+++ b/openspec/changes/add-lyric-phrase-fitting/tasks.md
@@ -1,0 +1,9 @@
+## 1. Fitting math
+- [ ] 1.1 Add `SHORT_PHRASE_NOTE_THRESHOLD` constant and a `_phrase_syllable_range(notes)` helper in `lyric_pipeline.py` that widens the low end of the target range (and disables the "spacious" penalty framing) for phrases at/below the threshold
+- [ ] 1.2 Wire the helper into the phrase-target loop shared by `_build_prompt` and `_build_white_cutup_prompt`
+- [ ] 1.3 Update the phrase instruction text to mention melisma as a legal option when a phrase is short
+
+## 2. Verification
+- [ ] 2.1 Add/adjust unit tests in `packages/generation/tests/test_lyric_pipeline.py` covering: a 1-note phrase gets a widened range, a 2-note phrase gets a widened range, a 4+ note phrase is unaffected (matches current behavior)
+- [ ] 2.2 Run `pytest packages/generation/tests/test_lyric_pipeline.py` and confirm no regressions to existing fitting-verdict tests
+- [ ] 2.3 Generate a real candidate against a song with several short melody phrases and manually confirm the output no longer defaults to single monosyllables on those lines

--- a/openspec/changes/add-lyric-phrase-fitting/tasks.md
+++ b/openspec/changes/add-lyric-phrase-fitting/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Fitting math
-- [ ] 1.1 Add `SHORT_PHRASE_NOTE_THRESHOLD` constant and a `_phrase_syllable_range(notes)` helper in `lyric_pipeline.py` that widens the low end of the target range (and disables the "spacious" penalty framing) for phrases at/below the threshold
-- [ ] 1.2 Wire the helper into the phrase-target loop shared by `_build_prompt` and `_build_white_cutup_prompt`
-- [ ] 1.3 Update the phrase instruction text to mention melisma as a legal option when a phrase is short
+- [x] 1.1 Add `SHORT_PHRASE_NOTE_THRESHOLD` constant and a `_phrase_syllable_range(notes)` helper in `lyric_pipeline.py` that widens the low end of the target range (and disables the "spacious" penalty framing) for phrases at/below the threshold
+- [x] 1.2 Wire the helper into the phrase-target loop shared by `_build_prompt` and `_build_white_cutup_prompt`
+- [x] 1.3 Update the phrase instruction text to mention melisma as a legal option when a phrase is short
 
 ## 2. Verification
-- [ ] 2.1 Add/adjust unit tests in `packages/generation/tests/test_lyric_pipeline.py` covering: a 1-note phrase gets a widened range, a 2-note phrase gets a widened range, a 4+ note phrase is unaffected (matches current behavior)
-- [ ] 2.2 Run `pytest packages/generation/tests/test_lyric_pipeline.py` and confirm no regressions to existing fitting-verdict tests
-- [ ] 2.3 Generate a real candidate against a song with several short melody phrases and manually confirm the output no longer defaults to single monosyllables on those lines
+- [x] 2.1 Add/adjust unit tests in `packages/generation/tests/test_lyric_pipeline.py` covering: a 1-note phrase gets a widened range, a 2-note phrase gets a widened range, a 4+ note phrase is unaffected (matches current behavior)
+- [x] 2.2 Run `pytest packages/generation/tests/test_lyric_pipeline.py` and confirm no regressions to existing fitting-verdict tests
+- [ ] 2.3 Generate a real candidate against a song with several short melody phrases and manually confirm the output no longer defaults to single monosyllables on those lines — **left for you**: this calls the Anthropic API against a real production dir, which I didn't want to trigger unprompted

--- a/packages/api/src/white_api/candidate_server.py
+++ b/packages/api/src/white_api/candidate_server.py
@@ -1520,6 +1520,7 @@ def create_app(
     def move_within_sides(side: str, body: SideMoveBody):
         from white_composition.lp_sides import (
             SIDE_NAMES,
+            find_song_side,
             load_sides,
             move_song,
             save_sides,
@@ -1529,6 +1530,15 @@ def create_app(
             raise HTTPException(status_code=404, detail="Unknown side")
         album_dir = _require_shrink_wrapped_dir()
         doc = load_sides(album_dir)
+        actual_side = find_song_side(doc, body.song_id)
+        if actual_side != side:
+            raise HTTPException(
+                status_code=404,
+                detail=(
+                    f"Song '{body.song_id}' is not on side '{side}' "
+                    f"(currently on {actual_side!r})"
+                ),
+            )
         try:
             move_song(doc, body.song_id, body.to_side, body.to_position)
         except ValueError as e:

--- a/packages/api/src/white_api/candidate_server.py
+++ b/packages/api/src/white_api/candidate_server.py
@@ -191,6 +191,7 @@ def _schema_is_valid(sv: str | None) -> bool:
 
 
 _LIFECYCLE_STATUSES = {"merged", "abandoned", "scrapped"}
+_LP_CONSIDERATION_STATUSES = {"not_considered", "candidate", "placed"}
 
 
 def _compute_stage(prod_dir: Path) -> str:
@@ -302,6 +303,7 @@ def scan_songs(shrink_wrapped_dir: Path) -> list[dict]:
                 "lifecycle_status": data.get("lifecycle_status"),
                 "merged_with": data.get("merged_with") or [],
                 "uses_parts_from": data.get("uses_parts_from") or [],
+                "lp_consideration": data.get("lp_consideration") or "not_considered",
             }
         )
     return songs
@@ -457,6 +459,22 @@ def create_app(
                 os.unlink(tmp_path)
             raise
 
+    def _set_lp_consideration(song_id: str, prod_dir: Path, status: str) -> None:
+        """Patch lp_consideration and keep the active-song cache fresh if needed."""
+        global _active_song
+        _patch_manifest(prod_dir, {"lp_consideration": status})
+        if (
+            _shrink_wrapped_dir
+            and _active_song
+            and _active_song.get("production_path") == str(prod_dir)
+        ):
+            refreshed = next(
+                (s for s in scan_songs(_shrink_wrapped_dir) if s["id"] == song_id),
+                None,
+            )
+            if refreshed:
+                _active_song = refreshed
+
     class LifecycleBody(BaseModel):
         status: str
         merged_with: list[str] = Field(default_factory=list)
@@ -508,6 +526,20 @@ def create_app(
             )
             if refreshed:
                 _active_song = refreshed
+        return {"ok": True, "status": body.status}
+
+    class LpConsiderationBody(BaseModel):
+        status: str
+
+    @app.post("/songs/{song_id}/lp-consideration")
+    def set_lp_consideration(song_id: str, body: LpConsiderationBody):
+        if body.status not in _LP_CONSIDERATION_STATUSES:
+            raise HTTPException(
+                status_code=422,
+                detail=f"status must be one of: {sorted(_LP_CONSIDERATION_STATUSES)}",
+            )
+        _entry, prod_dir = _resolve_song(song_id)
+        _set_lp_consideration(song_id, prod_dir, body.status)
         return {"ok": True, "status": body.status}
 
     @app.get("/songs/scrapped")
@@ -1470,6 +1502,9 @@ def create_app(
         doc = load_sides(album_dir)
         assign_song(doc, body.song_id, side, body.position, duration)
         save_sides(album_dir, doc)
+        _set_lp_consideration(
+            body.song_id, Path(song_entry["production_path"]), "placed"
+        )
         return {
             "ok": True,
             "side": side,
@@ -1499,6 +1534,10 @@ def create_app(
         except ValueError as e:
             raise HTTPException(status_code=404, detail=str(e))
         save_sides(album_dir, doc)
+        song_entry = _resolve_song_for_sides(body.song_id)
+        _set_lp_consideration(
+            body.song_id, Path(song_entry["production_path"]), "placed"
+        )
         return {
             "ok": True,
             "side": body.to_side,
@@ -1524,6 +1563,9 @@ def create_app(
             )
         remove_song(doc, song_id)
         save_sides(album_dir, doc)
+        song_entry = _resolve_song_for_sides(song_id)
+        next_status = "candidate" if song_entry["has_mix"] else "not_considered"
+        _set_lp_consideration(song_id, Path(song_entry["production_path"]), next_status)
         return {"ok": True}
 
     # ------------------------------------------------------------------

--- a/packages/api/src/white_api/candidate_server.py
+++ b/packages/api/src/white_api/candidate_server.py
@@ -1330,12 +1330,15 @@ def create_app(
     def mix_info():
         prod = _require_production_dir()
         from white_composition.init_production import load_song_context
+        from white_composition.lp_sides import mix_duration_seconds
 
         ctx = load_song_context(prod)
         mix_file = ctx.get("mix_file") or None
+        has_mix = bool(mix_file and Path(mix_file).exists())
         return {
-            "has_mix": bool(mix_file and Path(mix_file).exists()),
+            "has_mix": has_mix,
             "mix_file": mix_file,
+            "duration_seconds": mix_duration_seconds(mix_file) if has_mix else None,
         }
 
     class MixFileBody(BaseModel):
@@ -1388,6 +1391,140 @@ def create_app(
             ".m4a": "audio/mp4",
         }.get(suffix, "audio/mpeg")
         return FileResponse(str(mix_path), media_type=media_type)
+
+    # ------------------------------------------------------------------
+    # LP-side sequencing
+    # ------------------------------------------------------------------
+
+    def _require_shrink_wrapped_dir() -> Path:
+        if _shrink_wrapped_dir is None:
+            raise HTTPException(
+                status_code=503,
+                detail="No album (shrink_wrapped) directory configured",
+            )
+        return _shrink_wrapped_dir
+
+    def _resolve_song_for_sides(song_id: str) -> dict:
+        album_dir = _require_shrink_wrapped_dir()
+        entry = next((s for s in scan_songs(album_dir) if s["id"] == song_id), None)
+        if entry is None:
+            raise HTTPException(status_code=404, detail=f"Song '{song_id}' not found")
+        return entry
+
+    def _song_mix_duration(song_entry: dict) -> float | None:
+        from white_composition.init_production import load_song_context
+        from white_composition.lp_sides import mix_duration_seconds
+
+        ctx = load_song_context(Path(song_entry["production_path"]))
+        mix_file = ctx.get("mix_file")
+        if not mix_file:
+            return None
+        return mix_duration_seconds(mix_file)
+
+    @app.get("/sides")
+    def list_sides():
+        from white_composition.lp_sides import load_sides, side_totals
+
+        album_dir = _require_shrink_wrapped_dir()
+        doc = load_sides(album_dir)
+        totals = side_totals(doc)
+        return {
+            "side_limit_seconds": doc.side_limit_seconds,
+            "sides": {
+                name: {
+                    "songs": [s.model_dump() for s in side.songs],
+                    **totals[name],
+                }
+                for name, side in doc.sides.items()
+            },
+        }
+
+    class SideAssignBody(BaseModel):
+        song_id: str
+        position: int = 0
+
+    @app.post("/sides/{side}/assign")
+    def assign_to_side(side: str, body: SideAssignBody):
+        from white_composition.lp_sides import (
+            SIDE_NAMES,
+            assign_song,
+            load_sides,
+            save_sides,
+        )
+
+        if side not in SIDE_NAMES:
+            raise HTTPException(status_code=404, detail=f"Unknown side '{side}'")
+        album_dir = _require_shrink_wrapped_dir()
+        song_entry = _resolve_song_for_sides(body.song_id)
+        if not song_entry["has_mix"]:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Song '{body.song_id}' has no mix file — cannot be sequenced",
+            )
+        duration = _song_mix_duration(song_entry)
+        if duration is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Could not read mix duration for '{body.song_id}'",
+            )
+        doc = load_sides(album_dir)
+        assign_song(doc, body.song_id, side, body.position, duration)
+        save_sides(album_dir, doc)
+        return {
+            "ok": True,
+            "side": side,
+            "songs": [s.model_dump() for s in doc.sides[side].songs],
+        }
+
+    class SideMoveBody(BaseModel):
+        song_id: str
+        to_side: str
+        to_position: int = 0
+
+    @app.post("/sides/{side}/move")
+    def move_within_sides(side: str, body: SideMoveBody):
+        from white_composition.lp_sides import (
+            SIDE_NAMES,
+            load_sides,
+            move_song,
+            save_sides,
+        )
+
+        if side not in SIDE_NAMES or body.to_side not in SIDE_NAMES:
+            raise HTTPException(status_code=404, detail="Unknown side")
+        album_dir = _require_shrink_wrapped_dir()
+        doc = load_sides(album_dir)
+        try:
+            move_song(doc, body.song_id, body.to_side, body.to_position)
+        except ValueError as e:
+            raise HTTPException(status_code=404, detail=str(e))
+        save_sides(album_dir, doc)
+        return {
+            "ok": True,
+            "side": body.to_side,
+            "songs": [s.model_dump() for s in doc.sides[body.to_side].songs],
+        }
+
+    @app.delete("/sides/{side}/songs/{song_id}")
+    def remove_from_side(side: str, song_id: str):
+        from white_composition.lp_sides import (
+            SIDE_NAMES,
+            load_sides,
+            remove_song,
+            save_sides,
+        )
+
+        if side not in SIDE_NAMES:
+            raise HTTPException(status_code=404, detail=f"Unknown side '{side}'")
+        album_dir = _require_shrink_wrapped_dir()
+        doc = load_sides(album_dir)
+        if not any(s.song_id == song_id for s in doc.sides[side].songs):
+            raise HTTPException(
+                status_code=404, detail=f"Song '{song_id}' is not on side {side}"
+            )
+        remove_song(doc, song_id)
+        save_sides(album_dir, doc)
+        return {"ok": True}
 
     # ------------------------------------------------------------------
     # Lyrics review

--- a/packages/api/tests/test_sides_api.py
+++ b/packages/api/tests/test_sides_api.py
@@ -157,3 +157,67 @@ class TestRemoveFromSide:
         song_id = _make_song(sw_dir, "thread-a", "song_one", mix_seconds=200.0)
         resp = client.delete(f"/sides/A/songs/{song_id}")
         assert resp.status_code == 404
+
+
+def _lp_consideration(client, song_id: str) -> str | None:
+    songs = client.get("/songs").json()
+    entry = next(s for s in songs if s["id"] == song_id)
+    return entry["lp_consideration"]
+
+
+class TestLpConsiderationDirectEndpoint:
+    def test_default_not_considered(self, sw_dir, client):
+        song_id = _make_song(sw_dir, "thread-a", "song_one")
+        assert _lp_consideration(client, song_id) == "not_considered"
+
+    def test_set_candidate(self, sw_dir, client):
+        song_id = _make_song(sw_dir, "thread-a", "song_one")
+        resp = client.post(
+            f"/songs/{song_id}/lp-consideration", json={"status": "candidate"}
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "status": "candidate"}
+        assert _lp_consideration(client, song_id) == "candidate"
+
+    def test_invalid_status_422(self, sw_dir, client):
+        song_id = _make_song(sw_dir, "thread-a", "song_one")
+        resp = client.post(
+            f"/songs/{song_id}/lp-consideration", json={"status": "bogus"}
+        )
+        assert resp.status_code == 422
+
+    def test_unknown_song_404(self, client):
+        resp = client.post(
+            "/songs/nope__nope/lp-consideration", json={"status": "candidate"}
+        )
+        assert resp.status_code == 404
+
+
+class TestLpConsiderationAutoTransitions:
+    def test_assign_sets_placed(self, sw_dir, client):
+        song_id = _make_song(sw_dir, "thread-a", "song_one", mix_seconds=200.0)
+        client.post("/sides/A/assign", json={"song_id": song_id, "position": 0})
+        assert _lp_consideration(client, song_id) == "placed"
+
+    def test_move_keeps_placed(self, sw_dir, client):
+        song_id = _make_song(sw_dir, "thread-a", "song_one", mix_seconds=200.0)
+        client.post("/sides/A/assign", json={"song_id": song_id, "position": 0})
+        client.post(
+            "/sides/A/move",
+            json={"song_id": song_id, "to_side": "C", "to_position": 0},
+        )
+        assert _lp_consideration(client, song_id) == "placed"
+
+    def test_remove_reverts_to_candidate_when_mix_still_exists(self, sw_dir, client):
+        song_id = _make_song(sw_dir, "thread-a", "song_one", mix_seconds=200.0)
+        client.post("/sides/A/assign", json={"song_id": song_id, "position": 0})
+        client.delete(f"/sides/A/songs/{song_id}")
+        assert _lp_consideration(client, song_id) == "candidate"
+
+    def test_remove_reverts_to_not_considered_when_mix_missing(self, sw_dir, client):
+        song_id = _make_song(sw_dir, "thread-a", "song_one", mix_seconds=200.0)
+        client.post("/sides/A/assign", json={"song_id": song_id, "position": 0})
+        # Simulate the mix file having been deleted/moved after assignment.
+        (sw_dir / "thread-a" / "production" / "song_one" / "mix.wav").unlink()
+        client.delete(f"/sides/A/songs/{song_id}")
+        assert _lp_consideration(client, song_id) == "not_considered"

--- a/packages/api/tests/test_sides_api.py
+++ b/packages/api/tests/test_sides_api.py
@@ -1,0 +1,159 @@
+"""Tests for /sides endpoints (LP-side sequencing)."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import soundfile as sf
+import yaml
+from fastapi.testclient import TestClient
+
+from white_api.candidate_server import create_app
+
+
+def _write_wav(path: Path, seconds: float, samplerate: int = 8000) -> None:
+    samples = np.zeros(int(seconds * samplerate), dtype="float32")
+    sf.write(str(path), samples, samplerate)
+
+
+def _make_song(
+    root: Path,
+    thread_slug: str,
+    production_slug: str,
+    *,
+    mix_seconds: float | None = None,
+) -> str:
+    prod_dir = root / thread_slug / "production" / production_slug
+    prod_dir.mkdir(parents=True, exist_ok=True)
+    with open(prod_dir / "manifest_bootstrap.yml", "w") as f:
+        yaml.dump({"title": production_slug, "rainbow_color": "Red"}, f)
+
+    if mix_seconds is not None:
+        mix_path = prod_dir / "mix.wav"
+        _write_wav(mix_path, mix_seconds)
+        with open(prod_dir / "song_context.yml", "w") as f:
+            yaml.dump({"mix_file": str(mix_path)}, f)
+
+    return f"{thread_slug}__{production_slug}"
+
+
+@pytest.fixture
+def sw_dir(tmp_path):
+    return tmp_path / "sw"
+
+
+@pytest.fixture
+def client(sw_dir):
+    sw_dir.mkdir(parents=True, exist_ok=True)
+    app = create_app(shrink_wrapped_dir=sw_dir)
+    return TestClient(app)
+
+
+class TestMixInfoDuration:
+    def test_duration_present_for_valid_mix(self, sw_dir, tmp_path):
+        song_id = _make_song(sw_dir, "thread-a", "song_one", mix_seconds=3.0)
+        prod_dir = sw_dir / "thread-a" / "production" / "song_one"
+        app = create_app(production_dir=prod_dir, shrink_wrapped_dir=sw_dir)
+        client = TestClient(app)
+        resp = client.get("/production/mix/info")
+        assert resp.status_code == 200
+        assert resp.json()["duration_seconds"] == 3.0
+        assert song_id  # sanity: fixture returned an id
+
+    def test_duration_null_without_mix(self, sw_dir):
+        _make_song(sw_dir, "thread-a", "song_two")
+        prod_dir = sw_dir / "thread-a" / "production" / "song_two"
+        app = create_app(production_dir=prod_dir, shrink_wrapped_dir=sw_dir)
+        client = TestClient(app)
+        resp = client.get("/production/mix/info")
+        assert resp.status_code == 200
+        assert resp.json()["duration_seconds"] is None
+        assert resp.json()["has_mix"] is False
+
+
+class TestListSides:
+    def test_empty_sides_default(self, client):
+        resp = client.get("/sides")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert set(data["sides"].keys()) == {"A", "B", "C", "D"}
+        assert data["side_limit_seconds"] == 1200.0
+        assert data["sides"]["A"]["songs"] == []
+        assert data["sides"]["A"]["total_seconds"] == 0.0
+        assert data["sides"]["A"]["over_limit"] is False
+
+
+class TestAssignToSide:
+    def test_assign_song_with_mix(self, sw_dir, client):
+        song_id = _make_song(sw_dir, "thread-a", "song_one", mix_seconds=200.0)
+        resp = client.post("/sides/A/assign", json={"song_id": song_id, "position": 0})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["songs"][0]["song_id"] == song_id
+        assert body["songs"][0]["duration_seconds"] == 200.0
+
+    def test_assign_rejects_song_without_mix(self, sw_dir, client):
+        song_id = _make_song(sw_dir, "thread-a", "song_two")
+        resp = client.post("/sides/A/assign", json={"song_id": song_id, "position": 0})
+        assert resp.status_code == 400
+
+    def test_assign_unknown_song_404(self, client):
+        resp = client.post(
+            "/sides/A/assign", json={"song_id": "nope__nope", "position": 0}
+        )
+        assert resp.status_code == 404
+
+    def test_assign_unknown_side_404(self, sw_dir, client):
+        song_id = _make_song(sw_dir, "thread-a", "song_one", mix_seconds=200.0)
+        resp = client.post("/sides/Z/assign", json={"song_id": song_id, "position": 0})
+        assert resp.status_code == 404
+
+    def test_totals_reflect_assignment(self, sw_dir, client):
+        song_id = _make_song(sw_dir, "thread-a", "song_one", mix_seconds=700.0)
+        client.post("/sides/A/assign", json={"song_id": song_id, "position": 0})
+        resp = client.get("/sides")
+        assert resp.json()["sides"]["A"]["total_seconds"] == 700.0
+        assert resp.json()["sides"]["A"]["over_limit"] is False
+
+    def test_over_limit_flagged(self, sw_dir, client):
+        id1 = _make_song(sw_dir, "thread-a", "song_one", mix_seconds=700.0)
+        id2 = _make_song(sw_dir, "thread-a", "song_two", mix_seconds=700.0)
+        client.post("/sides/A/assign", json={"song_id": id1, "position": 0})
+        client.post("/sides/A/assign", json={"song_id": id2, "position": 1})
+        resp = client.get("/sides")
+        assert resp.json()["sides"]["A"]["over_limit"] is True
+
+
+class TestMoveBetweenSides:
+    def test_move_updates_side(self, sw_dir, client):
+        song_id = _make_song(sw_dir, "thread-a", "song_one", mix_seconds=200.0)
+        client.post("/sides/A/assign", json={"song_id": song_id, "position": 0})
+        resp = client.post(
+            "/sides/A/move",
+            json={"song_id": song_id, "to_side": "C", "to_position": 0},
+        )
+        assert resp.status_code == 200
+        sides = client.get("/sides").json()["sides"]
+        assert sides["A"]["songs"] == []
+        assert sides["C"]["songs"][0]["song_id"] == song_id
+
+    def test_move_unassigned_song_404(self, client):
+        resp = client.post(
+            "/sides/A/move",
+            json={"song_id": "ghost__ghost", "to_side": "B", "to_position": 0},
+        )
+        assert resp.status_code == 404
+
+
+class TestRemoveFromSide:
+    def test_remove_song(self, sw_dir, client):
+        song_id = _make_song(sw_dir, "thread-a", "song_one", mix_seconds=200.0)
+        client.post("/sides/A/assign", json={"song_id": song_id, "position": 0})
+        resp = client.delete(f"/sides/A/songs/{song_id}")
+        assert resp.status_code == 200
+        assert client.get("/sides").json()["sides"]["A"]["songs"] == []
+
+    def test_remove_song_not_on_side_404(self, sw_dir, client):
+        song_id = _make_song(sw_dir, "thread-a", "song_one", mix_seconds=200.0)
+        resp = client.delete(f"/sides/A/songs/{song_id}")
+        assert resp.status_code == 404

--- a/packages/api/tests/test_sides_api.py
+++ b/packages/api/tests/test_sides_api.py
@@ -144,6 +144,20 @@ class TestMoveBetweenSides:
         )
         assert resp.status_code == 404
 
+    def test_move_wrong_source_side_404(self, sw_dir, client):
+        """The {side} path param must match where the song actually is."""
+        song_id = _make_song(sw_dir, "thread-a", "song_one", mix_seconds=200.0)
+        client.post("/sides/A/assign", json={"song_id": song_id, "position": 0})
+        resp = client.post(
+            "/sides/B/move",
+            json={"song_id": song_id, "to_side": "C", "to_position": 0},
+        )
+        assert resp.status_code == 404
+        # Song must not have moved.
+        sides = client.get("/sides").json()["sides"]
+        assert sides["A"]["songs"][0]["song_id"] == song_id
+        assert sides["C"]["songs"] == []
+
 
 class TestRemoveFromSide:
     def test_remove_song(self, sw_dir, client):

--- a/packages/client/app/board/page.tsx
+++ b/packages/client/app/board/page.tsx
@@ -645,6 +645,9 @@ export default function BoardPage() {
         <Link href="/candidates" className="text-zinc-500 hover:text-zinc-300 text-xs font-sans transition-colors">
           candidate view
         </Link>
+        <Link href="/sides" className="text-zinc-500 hover:text-zinc-300 text-xs font-sans transition-colors">
+          sides
+        </Link>
         <h1 className="text-lg font-bold text-white tracking-tight">Composition Board</h1>
         {activeSong && (
           <Link href="/" className="text-zinc-500 hover:text-zinc-300 text-xs font-sans ml-2 truncate transition-colors" title="Switch song">

--- a/packages/client/app/candidates/page.tsx
+++ b/packages/client/app/candidates/page.tsx
@@ -331,6 +331,8 @@ export default function CandidatesPage() {
           <Link href="/" className="hover:text-zinc-300 transition-colors">← Songs</Link>
           <span>/</span>
           <span className="text-zinc-300">{activeSong.title}</span>
+          <span>/</span>
+          <Link href="/sides" className="hover:text-zinc-300 transition-colors">Sides</Link>
         </div>
       )}
 

--- a/packages/client/app/page.tsx
+++ b/packages/client/app/page.tsx
@@ -72,6 +72,7 @@ export default function SongBrowserPage() {
   const [error, setError] = useState<string | null>(null);
   const [toast, setToast] = useState<Toast | null>(null);
   const [stageFilter, setStageFilter] = useState<StageFilter>("all");
+  const [lpFilter, setLpFilter] = useState<"" | "candidate" | "placed">("");
 
   const activeSongs = useMemo(() => songs.filter(s => !LIFECYCLE_STAGES.has(s.stage)), [songs]);
 
@@ -139,6 +140,12 @@ export default function SongBrowserPage() {
         <h1 className="text-xl font-bold text-white tracking-tight">Songs</h1>
         <div className="flex items-center gap-2">
           <Link
+            href="/sides"
+            className="px-3 py-1.5 text-xs font-sans rounded bg-zinc-800 border border-zinc-700 text-zinc-300 hover:bg-zinc-700 hover:border-zinc-600 transition-colors"
+          >
+            Sides
+          </Link>
+          <Link
             href="/collaborators"
             className="px-3 py-1.5 text-xs font-sans rounded bg-zinc-800 border border-zinc-700 text-zinc-300 hover:bg-zinc-700 hover:border-zinc-600 transition-colors"
           >
@@ -181,6 +188,32 @@ export default function SongBrowserPage() {
         </div>
       )}
 
+      {/* LP consideration filter */}
+      {!error && songs.length > 0 && (
+        <div className="flex gap-1.5 flex-wrap mb-4">
+          {(["candidate", "placed"] as const).map(lp => {
+            const count = songs.filter(s => s.lp_consideration === lp).length;
+            if (count === 0) return null;
+            const active = lpFilter === lp;
+            return (
+              <button
+                key={lp}
+                type="button"
+                aria-pressed={active}
+                onClick={() => setLpFilter(active ? "" : lp)}
+                className={`px-2.5 py-1 text-[10px] font-sans border transition-colors ${
+                  active
+                    ? "bg-blue-200 text-blue-950 border-blue-200"
+                    : "bg-zinc-900 text-zinc-400 border-zinc-700 hover:border-zinc-500 hover:text-zinc-200"
+                }`}
+              >
+                lp: {lp} <span className="text-zinc-600">{count}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+
       {toast && (
         <div
           className={`rounded p-3 mb-4 text-sm font-sans border ${
@@ -207,6 +240,7 @@ export default function SongBrowserPage() {
 
       <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
         {songs.filter(s => {
+          if (lpFilter && s.lp_consideration !== lpFilter) return false;
           if (stageFilter === "all") return !LIFECYCLE_STAGES.has(s.stage);
           if (stageFilter === "stub") return s.stub;
           return s.stage === stageFilter;
@@ -251,14 +285,21 @@ export default function SongBrowserPage() {
                   : STAGE_LABELS[song.stage]}
               </span>
             </div>
-            {(song.schema_version !== "2.0.0" || song.stub) && (
+            {(song.schema_version !== "2.0.0" || song.stub || song.lp_consideration !== "not_considered") && (
               <div className="mt-1.5 flex items-center gap-1.5">
-                <span className="text-[9px] font-sans px-1 py-0.5 rounded bg-zinc-800 border border-zinc-700 text-zinc-500">
-                  v{song.schema_version}
-                </span>
+                {(song.schema_version !== "2.0.0" || song.stub) && (
+                  <span className="text-[9px] font-sans px-1 py-0.5 rounded bg-zinc-800 border border-zinc-700 text-zinc-500">
+                    v{song.schema_version}
+                  </span>
+                )}
                 {song.stub && (
                   <span className="text-[9px] font-sans px-1 py-0.5 rounded bg-amber-900/30 border border-amber-800 text-amber-400">
                     stub
+                  </span>
+                )}
+                {song.lp_consideration !== "not_considered" && (
+                  <span className="text-[9px] font-sans px-1 py-0.5 rounded bg-blue-900/30 border border-blue-800 text-blue-400">
+                    lp: {song.lp_consideration}
                   </span>
                 )}
               </div>

--- a/packages/client/app/sides/page.tsx
+++ b/packages/client/app/sides/page.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
+  PointerSensor,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { assignSongToSide, fetchSides, fetchSongs, moveSongBetweenSides, removeSongFromSide } from "@/lib/api";
+import { SideName, SidesResponse, SongEntry } from "@/lib/types";
+
+const SIDE_NAMES: SideName[] = ["A", "B", "C", "D"];
+
+function formatDuration(seconds: number): string {
+  const total = Math.round(seconds);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h > 0) return `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+interface DragPayload {
+  songId: string;
+  title: string;
+  fromSide: SideName | null;
+}
+
+function AvailableSongRow({ song }: { song: SongEntry }) {
+  const disabled = !song.has_mix;
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `avail:${song.id}`,
+    data: { songId: song.id, title: song.title, fromSide: null } satisfies DragPayload,
+    disabled,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      {...(disabled ? {} : { ...attributes, ...listeners })}
+      className={`px-3 py-2 rounded border text-xs font-sans flex items-center justify-between gap-2 ${
+        disabled
+          ? "border-zinc-800 text-zinc-600 cursor-not-allowed"
+          : "border-zinc-700 text-zinc-200 cursor-grab hover:border-zinc-500"
+      } ${isDragging ? "opacity-40" : ""}`}
+      title={disabled ? "No mix file — cannot be sequenced" : "Drag onto a side"}
+    >
+      <span className="truncate">{song.title}</span>
+      {disabled && <span className="text-[10px] text-zinc-600 shrink-0">no mix</span>}
+    </div>
+  );
+}
+
+function SideSongRow({
+  side,
+  songId,
+  title,
+  durationSeconds,
+  onRemove,
+}: {
+  side: SideName;
+  songId: string;
+  title: string;
+  durationSeconds: number;
+  onRemove: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: `side:${side}:${songId}`,
+    data: { songId, title, fromSide: side } satisfies DragPayload,
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+      className={`px-3 py-2 rounded border border-zinc-700 bg-zinc-900 text-xs font-sans flex items-center justify-between gap-2 cursor-grab hover:border-zinc-500 ${
+        isDragging ? "opacity-40" : ""
+      }`}
+    >
+      <span className="truncate">{title}</span>
+      <span className="flex items-center gap-2 shrink-0">
+        <span className="text-zinc-500">{formatDuration(durationSeconds)}</span>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          className="text-zinc-600 hover:text-red-400 transition-colors"
+          title="Remove from side"
+        >
+          ×
+        </button>
+      </span>
+    </div>
+  );
+}
+
+function SideColumn({
+  side,
+  limitSeconds,
+  songs,
+  totalSeconds,
+  overLimit,
+  titleFor,
+  onRemove,
+}: {
+  side: SideName;
+  limitSeconds: number;
+  songs: { song_id: string; duration_seconds: number }[];
+  totalSeconds: number;
+  overLimit: boolean;
+  titleFor: (songId: string) => string;
+  onRemove: (songId: string) => void;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: `sidearea:${side}` });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`flex-1 min-w-[220px] rounded border p-3 flex flex-col gap-2 ${
+        isOver ? "border-blue-500 bg-blue-950/20" : "border-zinc-800"
+      }`}
+    >
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-bold text-white">Side {side}</h2>
+        <span className={`text-xs font-sans ${overLimit ? "text-red-400" : "text-zinc-500"}`}>
+          {formatDuration(totalSeconds)} / {formatDuration(limitSeconds)}
+        </span>
+      </div>
+      <div className="flex flex-col gap-1.5 min-h-[40px]">
+        {songs.map((s) => (
+          <SideSongRow
+            key={s.song_id}
+            side={side}
+            songId={s.song_id}
+            title={titleFor(s.song_id)}
+            durationSeconds={s.duration_seconds}
+            onRemove={() => onRemove(s.song_id)}
+          />
+        ))}
+        {songs.length === 0 && (
+          <div className="text-[11px] text-zinc-600 font-sans italic py-2">Drop a mixed song here</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function SidesPage() {
+  const [songs, setSongs] = useState<SongEntry[]>([]);
+  const [sides, setSides] = useState<SidesResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [activeDrag, setActiveDrag] = useState<DragPayload | null>(null);
+
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
+
+  const refresh = useCallback(() => {
+    Promise.all([fetchSongs(), fetchSides()])
+      .then(([songsRes, sidesRes]) => {
+        setSongs(songsRes);
+        setSides(sidesRes);
+        setError(null);
+      })
+      .catch((e) => setError(e.message ?? "Failed to load"))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const titleFor = useCallback(
+    (songId: string) => songs.find((s) => s.id === songId)?.title ?? songId,
+    [songs],
+  );
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveDrag(event.active.data.current as DragPayload);
+  };
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    setActiveDrag(null);
+    const { active, over } = event;
+    if (!over || !sides) return;
+
+    const payload = active.data.current as DragPayload;
+    const overId = String(over.id);
+    let toSide: SideName | null = null;
+    let toPosition = 0;
+
+    if (overId.startsWith("sidearea:")) {
+      toSide = overId.split(":")[1] as SideName;
+      toPosition = sides.sides[toSide].songs.length;
+    } else if (overId.startsWith("side:")) {
+      const [, sideName, overSongId] = overId.split(":");
+      toSide = sideName as SideName;
+      const idx = sides.sides[toSide].songs.findIndex((s) => s.song_id === overSongId);
+      toPosition = idx < 0 ? sides.sides[toSide].songs.length : idx;
+    }
+    if (!toSide) return;
+
+    try {
+      if (payload.fromSide === null) {
+        await assignSongToSide(toSide, payload.songId, toPosition);
+      } else {
+        await moveSongBetweenSides(payload.fromSide, payload.songId, toSide, toPosition);
+      }
+      refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Drop failed");
+    }
+  };
+
+  const handleRemove = async (side: SideName, songId: string) => {
+    try {
+      await removeSongFromSide(side, songId);
+      refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Remove failed");
+    }
+  };
+
+  const assignedIds = new Set(
+    sides ? SIDE_NAMES.flatMap((s) => sides.sides[s].songs.map((song) => song.song_id)) : [],
+  );
+  const available = songs.filter((s) => !assignedIds.has(s.id));
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <div className="border-b border-zinc-800 px-6 py-4 flex items-center gap-4">
+        <Link href="/" className="text-zinc-500 hover:text-zinc-300 text-xs font-sans transition-colors">
+          ← home
+        </Link>
+        <h1 className="text-lg font-bold text-white tracking-tight">LP Side Sequencing</h1>
+      </div>
+
+      {error && (
+        <div className="mx-6 mt-4 px-3 py-2 rounded border border-red-800 bg-red-950/30 text-red-300 text-xs font-sans">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="p-6 text-zinc-500 text-sm font-sans">Loading…</div>
+      ) : (
+        <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+          <div className="flex-1 flex gap-4 p-6">
+            <div className="w-64 flex flex-col gap-2">
+              <h2 className="text-sm font-bold text-white">Available</h2>
+              <div className="flex flex-col gap-1.5">
+                {available.map((song) => (
+                  <AvailableSongRow key={song.id} song={song} />
+                ))}
+                {available.length === 0 && (
+                  <div className="text-[11px] text-zinc-600 font-sans italic py-2">
+                    All songs are assigned to a side
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {sides &&
+              SIDE_NAMES.map((side) => (
+                <SideColumn
+                  key={side}
+                  side={side}
+                  limitSeconds={sides.side_limit_seconds}
+                  songs={sides.sides[side].songs}
+                  totalSeconds={sides.sides[side].total_seconds}
+                  overLimit={sides.sides[side].over_limit}
+                  titleFor={titleFor}
+                  onRemove={(songId) => handleRemove(side, songId)}
+                />
+              ))}
+          </div>
+
+          <DragOverlay>
+            {activeDrag && (
+              <div className="px-3 py-2 rounded border border-blue-500 bg-zinc-900 text-xs font-sans text-zinc-200 shadow-lg">
+                {activeDrag.title}
+              </div>
+            )}
+          </DragOverlay>
+        </DndContext>
+      )}
+    </div>
+  );
+}

--- a/packages/client/app/sides/page.tsx
+++ b/packages/client/app/sides/page.tsx
@@ -14,9 +14,54 @@ import {
   useSensors,
 } from "@dnd-kit/core";
 import { assignSongToSide, fetchSides, fetchSongs, moveSongBetweenSides, removeSongFromSide } from "@/lib/api";
-import { SideName, SidesResponse, SongEntry } from "@/lib/types";
+import { SideEntry, SideName, SideSong, SidesResponse, SongEntry } from "@/lib/types";
 
 const SIDE_NAMES: SideName[] = ["A", "B", "C", "D"];
+
+function sideEntryFromSongs(songs: SideSong[], limitSeconds: number): SideEntry {
+  const total = songs.reduce((sum, s) => sum + s.duration_seconds, 0);
+  return { songs, total_seconds: total, over_limit: total > limitSeconds };
+}
+
+/** Move songId to toSide/toPosition in a local copy of `sides`, recomputing totals. */
+function applyLocalPlacement(
+  sides: SidesResponse,
+  songId: string,
+  toSide: SideName,
+  toPosition: number,
+  knownDuration: number | null,
+): SidesResponse {
+  let duration = knownDuration;
+  const withoutSong: Record<SideName, SideSong[]> = {} as Record<SideName, SideSong[]>;
+  for (const name of SIDE_NAMES) {
+    const existing = sides.sides[name].songs.find((s) => s.song_id === songId);
+    if (existing && duration === null) duration = existing.duration_seconds;
+    withoutSong[name] = sides.sides[name].songs.filter((s) => s.song_id !== songId);
+  }
+
+  const targetSongs = [...withoutSong[toSide]];
+  const position = Math.max(0, Math.min(toPosition, targetSongs.length));
+  targetSongs.splice(position, 0, { song_id: songId, duration_seconds: duration ?? 0 });
+  withoutSong[toSide] = targetSongs;
+
+  const newSides = {} as Record<SideName, SideEntry>;
+  for (const name of SIDE_NAMES) {
+    newSides[name] = sideEntryFromSongs(withoutSong[name], sides.side_limit_seconds);
+  }
+  return { side_limit_seconds: sides.side_limit_seconds, sides: newSides };
+}
+
+/** Remove songId from `side` in a local copy of `sides`, recomputing totals. */
+function applyLocalRemoval(sides: SidesResponse, side: SideName, songId: string): SidesResponse {
+  const remaining = sides.sides[side].songs.filter((s) => s.song_id !== songId);
+  return {
+    ...sides,
+    sides: {
+      ...sides.sides,
+      [side]: sideEntryFromSongs(remaining, sides.side_limit_seconds),
+    },
+  };
+}
 
 function formatDuration(seconds: number): string {
   const total = Math.round(seconds);
@@ -208,23 +253,53 @@ export default function SidesPage() {
     }
     if (!toSide) return;
 
+    const previousSides = sides;
+    const knownDuration =
+      payload.fromSide !== null
+        ? (sides.sides[payload.fromSide].songs.find((s) => s.song_id === payload.songId)
+            ?.duration_seconds ?? null)
+        : null;
+
+    // Update the UI immediately so the item disappears from its source on release;
+    // reconcile with the server's authoritative (duration-accurate) response after.
+    setSides(applyLocalPlacement(sides, payload.songId, toSide, toPosition, knownDuration));
+
     try {
-      if (payload.fromSide === null) {
-        await assignSongToSide(toSide, payload.songId, toPosition);
-      } else {
-        await moveSongBetweenSides(payload.fromSide, payload.songId, toSide, toPosition);
-      }
-      refresh();
+      const response =
+        payload.fromSide === null
+          ? await assignSongToSide(toSide, payload.songId, toPosition)
+          : await moveSongBetweenSides(payload.fromSide, payload.songId, toSide, toPosition);
+      const resolvedSide = toSide;
+      setSides((current) =>
+        current
+          ? {
+              ...current,
+              sides: {
+                ...current.sides,
+                [resolvedSide]: sideEntryFromSongs(response.songs, current.side_limit_seconds),
+              },
+            }
+          : current,
+      );
+      setError(null);
+      fetchSongs().then(setSongs).catch(() => {});
     } catch (e) {
+      setSides(previousSides);
       setError(e instanceof Error ? e.message : "Drop failed");
     }
   };
 
   const handleRemove = async (side: SideName, songId: string) => {
+    if (!sides) return;
+    const previousSides = sides;
+    setSides(applyLocalRemoval(sides, side, songId));
+
     try {
       await removeSongFromSide(side, songId);
-      refresh();
+      setError(null);
+      fetchSongs().then(setSongs).catch(() => {});
     } catch (e) {
+      setSides(previousSides);
       setError(e instanceof Error ? e.message : "Remove failed");
     }
   };

--- a/packages/client/app/sides/page.tsx
+++ b/packages/client/app/sides/page.tsx
@@ -116,28 +116,37 @@ function SideSongRow({
   durationSeconds: number;
   onRemove: () => void;
 }) {
-  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+  const { attributes, listeners, setNodeRef: setDragRef, isDragging } = useDraggable({
     id: `side:${side}:${songId}`,
     data: { songId, title, fromSide: side } satisfies DragPayload,
   });
+  // Also a drop target so releasing directly on this row inserts before it,
+  // instead of always falling back to appending at the end of the side.
+  const { setNodeRef: setDropRef, isOver } = useDroppable({ id: `side:${side}:${songId}` });
+  const setRefs = (node: HTMLDivElement | null) => {
+    setDragRef(node);
+    setDropRef(node);
+  };
 
   return (
     <div
-      ref={setNodeRef}
+      ref={setRefs}
       {...attributes}
       {...listeners}
-      className={`px-3 py-2 rounded border border-zinc-700 bg-zinc-900 text-xs font-sans text-zinc-200 flex items-center justify-between gap-2 cursor-grab hover:border-zinc-500 ${
-        isDragging ? "opacity-40" : ""
-      }`}
+      className={`px-3 py-2 rounded border bg-zinc-900 text-xs font-sans text-zinc-200 flex items-center justify-between gap-2 cursor-grab ${
+        isOver ? "border-blue-500" : "border-zinc-700 hover:border-zinc-500"
+      } ${isDragging ? "opacity-40" : ""}`}
     >
       <span className="truncate">{title}</span>
       <span className="flex items-center gap-2 shrink-0">
         <span className="text-zinc-500">{formatDuration(durationSeconds)}</span>
         <button
+          type="button"
           onClick={(e) => {
             e.stopPropagation();
             onRemove();
           }}
+          aria-label={`Remove ${title} from side ${side}`}
           className="text-zinc-600 hover:text-red-400 transition-colors"
           title="Remove from side"
         >

--- a/packages/client/app/sides/page.tsx
+++ b/packages/client/app/sides/page.tsx
@@ -126,7 +126,7 @@ function SideSongRow({
       ref={setNodeRef}
       {...attributes}
       {...listeners}
-      className={`px-3 py-2 rounded border border-zinc-700 bg-zinc-900 text-xs font-sans flex items-center justify-between gap-2 cursor-grab hover:border-zinc-500 ${
+      className={`px-3 py-2 rounded border border-zinc-700 bg-zinc-900 text-xs font-sans text-zinc-200 flex items-center justify-between gap-2 cursor-grab hover:border-zinc-500 ${
         isDragging ? "opacity-40" : ""
       }`}
     >

--- a/packages/client/lib/api.ts
+++ b/packages/client/lib/api.ts
@@ -558,6 +558,22 @@ export async function moveSongBetweenSides(
   return res.json();
 }
 
+export async function setLpConsideration(
+  songId: string,
+  status: import("./types").LpConsiderationStatus,
+): Promise<{ ok: boolean; status: string }> {
+  const res = await fetch(`${BASE}/songs/${encodeURIComponent(songId)}/lp-consideration`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ status }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error((err as { detail?: string }).detail ?? "LP consideration update failed");
+  }
+  return res.json();
+}
+
 export async function removeSongFromSide(
   side: string,
   songId: string,

--- a/packages/client/lib/api.ts
+++ b/packages/client/lib/api.ts
@@ -516,3 +516,59 @@ export async function exportSample(segmentId: string): Promise<{ ok: boolean; de
   }
   return res.json();
 }
+
+export async function fetchSides(): Promise<import("./types").SidesResponse> {
+  const res = await fetch(`${BASE}/sides`, { cache: "no-store" });
+  if (!res.ok) throw new Error("Failed to fetch sides");
+  return res.json();
+}
+
+export async function assignSongToSide(
+  side: string,
+  songId: string,
+  position: number,
+): Promise<{ ok: boolean; side: string; songs: import("./types").SideSong[] }> {
+  const res = await fetch(`${BASE}/sides/${encodeURIComponent(side)}/assign`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ song_id: songId, position }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error((err as { detail?: string }).detail ?? "Assign failed");
+  }
+  return res.json();
+}
+
+export async function moveSongBetweenSides(
+  fromSide: string,
+  songId: string,
+  toSide: string,
+  toPosition: number,
+): Promise<{ ok: boolean; side: string; songs: import("./types").SideSong[] }> {
+  const res = await fetch(`${BASE}/sides/${encodeURIComponent(fromSide)}/move`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ song_id: songId, to_side: toSide, to_position: toPosition }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error((err as { detail?: string }).detail ?? "Move failed");
+  }
+  return res.json();
+}
+
+export async function removeSongFromSide(
+  side: string,
+  songId: string,
+): Promise<{ ok: boolean }> {
+  const res = await fetch(
+    `${BASE}/sides/${encodeURIComponent(side)}/songs/${encodeURIComponent(songId)}`,
+    { method: "DELETE" },
+  );
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error((err as { detail?: string }).detail ?? "Remove failed");
+  }
+  return res.json();
+}

--- a/packages/client/lib/types.ts
+++ b/packages/client/lib/types.ts
@@ -228,3 +228,21 @@ export interface WorkOrder {
   created_at: string;
   updated_at: string;
 }
+
+export type SideName = "A" | "B" | "C" | "D";
+
+export interface SideSong {
+  song_id: string;
+  duration_seconds: number;
+}
+
+export interface SideEntry {
+  songs: SideSong[];
+  total_seconds: number;
+  over_limit: boolean;
+}
+
+export interface SidesResponse {
+  side_limit_seconds: number;
+  sides: Record<SideName, SideEntry>;
+}

--- a/packages/client/lib/types.ts
+++ b/packages/client/lib/types.ts
@@ -2,6 +2,8 @@ export type CandidateStatus = "pending" | "approved" | "accepted" | "rejected";
 
 export type LifecycleStatus = "merged" | "abandoned" | "scrapped";
 
+export type LpConsiderationStatus = "not_considered" | "candidate" | "placed";
+
 export interface SongEntry {
   id: string;
   thread_slug: string;
@@ -23,6 +25,7 @@ export interface SongEntry {
   lifecycle_status: LifecycleStatus | null;
   merged_with: string[];
   uses_parts_from: string[];
+  lp_consideration: LpConsiderationStatus;
 }
 
 export interface RegressionInfo {

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
         "next": "16.2.2",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -31,6 +32,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/runtime": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -8,6 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
     "next": "16.2.2",
     "react": "19.2.4",
     "react-dom": "19.2.4"

--- a/packages/composition/pyproject.toml
+++ b/packages/composition/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "anthropic>=0.34.0",
     "langchain-anthropic>=0.2.0",
     "pydantic>=2.0",
+    "soundfile>=0.12.1",
 ]
 
 [build-system]

--- a/packages/composition/src/white_composition/lp_sequence_advisor.py
+++ b/packages/composition/src/white_composition/lp_sequence_advisor.py
@@ -1,0 +1,208 @@
+"""LP sequencing aesthetic advisor.
+
+Read-only CLI Claude (or a human) can run to check the current `sides.yml`
+arrangement against aesthetic goals — chromatic color balance and BPM/energy
+spread — rather than duration alone (duration is handled by the sides UI/API
+itself). Never modifies `sides.yml`; the human decides whether to act on
+suggestions via the drag-and-drop sides page.
+
+Usage:
+    python -m white_composition.lp_sequence_advisor --album-dir shrink_wrapped
+    python -m white_composition.lp_sequence_advisor --album-dir shrink_wrapped --output report.yml
+    python -m white_composition.lp_sequence_advisor --dry-run
+"""
+
+import argparse
+import os
+from collections import Counter
+from pathlib import Path
+
+import yaml
+
+from white_composition.lp_sides import SIDE_NAMES, load_sides, side_totals
+
+# Flag a side's color distribution when one color makes up at least this
+# fraction of its (>=2) placed songs.
+COLOR_CLUSTER_THRESHOLD = 0.6
+
+
+def _load_song_metadata(album_dir: Path, song_id: str) -> dict:
+    """Read rainbow_color/bpm/mood/title for a song_id from its manifest_bootstrap.yml."""
+    thread_slug, _, production_slug = song_id.partition("__")
+    manifest_path = (
+        Path(album_dir)
+        / thread_slug
+        / "production"
+        / production_slug
+        / "manifest_bootstrap.yml"
+    )
+    if not manifest_path.exists():
+        return {}
+    with open(manifest_path) as f:
+        data = yaml.safe_load(f) or {}
+    return {
+        "title": data.get("title") or production_slug,
+        "rainbow_color": data.get("rainbow_color"),
+        "bpm": data.get("bpm"),
+        "mood": data.get("mood") or [],
+    }
+
+
+def _generate_suggestions(
+    side_reports: dict, song_meta: dict, sides: dict
+) -> list[str]:
+    """Plain-language suggestions for sides whose placed songs cluster on one color."""
+    suggestions = []
+    for side_name, report in side_reports.items():
+        dist = report["color_distribution"]
+        total = sum(dist.values())
+        if total < 2:
+            continue
+        dominant_color, count = max(dist.items(), key=lambda kv: kv[1])
+        fraction = count / total
+        if fraction < COLOR_CLUSTER_THRESHOLD:
+            continue
+
+        candidate = None
+        for other_side, other in sides.items():
+            if other_side == side_name:
+                continue
+            for song in other.songs:
+                color = song_meta.get(song.song_id, {}).get("rainbow_color")
+                if color and color != dominant_color:
+                    title = song_meta.get(song.song_id, {}).get("title", song.song_id)
+                    candidate = (title, color, other_side)
+                    break
+            if candidate:
+                break
+
+        msg = (
+            f"Side {side_name} is {fraction:.0%} {dominant_color} "
+            f"({count}/{total} songs) — consider more color variety."
+        )
+        if candidate:
+            title, color, other_side = candidate
+            msg += f" '{title}' ({color}, currently on side {other_side}) could add contrast."
+        suggestions.append(msg)
+    return suggestions
+
+
+def analyze_sides(album_dir: Path) -> dict:
+    """Analyze the current sides.yml for color/BPM balance. Read-only."""
+    album_dir = Path(album_dir)
+    doc = load_sides(album_dir)
+    totals = side_totals(doc)
+
+    song_meta: dict[str, dict] = {}
+    for side in doc.sides.values():
+        for song in side.songs:
+            song_meta[song.song_id] = _load_song_metadata(album_dir, song.song_id)
+
+    side_reports: dict[str, dict] = {}
+    for side_name in SIDE_NAMES:
+        side = doc.sides[side_name]
+        colors = [
+            song_meta.get(s.song_id, {}).get("rainbow_color")
+            for s in side.songs
+            if song_meta.get(s.song_id, {}).get("rainbow_color")
+        ]
+        bpms = [
+            song_meta.get(s.song_id, {}).get("bpm")
+            for s in side.songs
+            if song_meta.get(s.song_id, {}).get("bpm")
+        ]
+        side_reports[side_name] = {
+            "song_count": len(side.songs),
+            "total_seconds": totals[side_name]["total_seconds"],
+            "over_limit": totals[side_name]["over_limit"],
+            "color_distribution": dict(Counter(colors)),
+            "bpm_range": {"min": min(bpms), "max": max(bpms)} if bpms else None,
+        }
+
+    suggestions = _generate_suggestions(side_reports, song_meta, doc.sides)
+
+    return {
+        "generated_from": str(album_dir),
+        "side_limit_seconds": doc.side_limit_seconds,
+        "sides": side_reports,
+        "suggestions": suggestions,
+    }
+
+
+def format_report_text(report: dict) -> str:
+    """Format an analysis report as human-readable text for stdout."""
+    lines = []
+    any_placed = any(s["song_count"] > 0 for s in report["sides"].values())
+    if not any_placed:
+        return "No songs are placed on any side yet — nothing to analyze."
+
+    for side_name, side in report["sides"].items():
+        if side["song_count"] == 0:
+            lines.append(f"Side {side_name}: (empty)")
+            continue
+        colors = ", ".join(f"{c}×{n}" for c, n in side["color_distribution"].items())
+        bpm = side["bpm_range"]
+        bpm_str = f"{bpm['min']}-{bpm['max']} BPM" if bpm else "BPM unknown"
+        limit_flag = " ⚠ OVER LIMIT" if side["over_limit"] else ""
+        lines.append(
+            f"Side {side_name}: {side['song_count']} song(s), "
+            f"{side['total_seconds']:.0f}s{limit_flag} — colors: {colors or 'unknown'} — {bpm_str}"
+        )
+
+    if report["suggestions"]:
+        lines.append("")
+        lines.append("Suggestions:")
+        for s in report["suggestions"]:
+            lines.append(f"  - {s}")
+
+    return "\n".join(lines)
+
+
+def write_report(output_path: Path, report: dict) -> Path:
+    with open(output_path, "w") as f:
+        yaml.dump(
+            report,
+            f,
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+            width=float("inf"),
+        )
+    return output_path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Analyze LP-side sequencing for color/BPM balance (read-only)"
+    )
+    _sw_dir = os.getenv("SHRINKWRAP_OUTPUT_DIR", "shrink_wrapped")
+    parser.add_argument(
+        "--album-dir",
+        type=Path,
+        default=Path(_sw_dir),
+        help="Album (shrink_wrapped) root directory (default: $SHRINKWRAP_OUTPUT_DIR)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Also write the report to this YAML path",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print the report without writing"
+    )
+
+    args = parser.parse_args()
+    report = analyze_sides(args.album_dir)
+
+    print(format_report_text(report))
+
+    if args.dry_run:
+        return
+    if args.output:
+        path = write_report(args.output, report)
+        print(f"\nWrote report to {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/composition/src/white_composition/lp_sides.py
+++ b/packages/composition/src/white_composition/lp_sides.py
@@ -14,7 +14,7 @@ from typing import Optional
 
 import soundfile as sf
 import yaml
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 SIDES_FILENAME = "sides.yml"
 SIDE_NAMES = ["A", "B", "C", "D"]
@@ -27,7 +27,7 @@ class SideSong(BaseModel):
 
 
 class Side(BaseModel):
-    songs: list[SideSong] = []
+    songs: list[SideSong] = Field(default_factory=list)
 
 
 class SidesDocument(BaseModel):
@@ -98,7 +98,7 @@ def save_sides(album_dir: Path, doc: SidesDocument) -> Path:
     return path
 
 
-def _find_song_side(doc: SidesDocument, song_id: str) -> Optional[str]:
+def find_song_side(doc: SidesDocument, song_id: str) -> Optional[str]:
     for name, side in doc.sides.items():
         if any(s.song_id == song_id for s in side.songs):
             return name
@@ -129,7 +129,7 @@ def move_song(
 
     Preserves the song's previously cached duration.
     """
-    current_side = _find_song_side(doc, song_id)
+    current_side = find_song_side(doc, song_id)
     if current_side is None:
         raise ValueError(f"Song '{song_id}' is not assigned to any side")
     existing = next(s for s in doc.sides[current_side].songs if s.song_id == song_id)

--- a/packages/composition/src/white_composition/lp_sides.py
+++ b/packages/composition/src/white_composition/lp_sides.py
@@ -1,0 +1,155 @@
+"""LP-side sequencing — bucket finished mixes into 4 sides (A-D) against a soft duration limit.
+
+White is the only double album in the catalog. This module tracks which songs are
+assigned to which of the 4 physical-LP sides (A-D), caches each assignment's mix
+duration (read via `soundfile`), and computes per-side running totals against a
+soft (non-enforced) `side_limit_seconds`, default 1200 (20 minutes).
+
+`sides.yml` lives at the album root, alongside `index.yml` and
+`negative_constraints.yml`.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+import soundfile as sf
+import yaml
+from pydantic import BaseModel
+
+SIDES_FILENAME = "sides.yml"
+SIDE_NAMES = ["A", "B", "C", "D"]
+DEFAULT_SIDE_LIMIT_SECONDS = 1200.0
+
+
+class SideSong(BaseModel):
+    song_id: str
+    duration_seconds: float
+
+
+class Side(BaseModel):
+    songs: list[SideSong] = []
+
+
+class SidesDocument(BaseModel):
+    side_limit_seconds: float = DEFAULT_SIDE_LIMIT_SECONDS
+    sides: dict[str, Side]
+
+    @classmethod
+    def empty(cls) -> "SidesDocument":
+        return cls(sides={name: Side() for name in SIDE_NAMES})
+
+
+def mix_duration_seconds(path: Path) -> Optional[float]:
+    """Return mix audio duration in seconds, or None if missing/unreadable."""
+    path = Path(path)
+    if not path.exists():
+        return None
+    try:
+        info = sf.info(str(path))
+        return round(info.frames / info.samplerate, 3)
+    except Exception:
+        return None
+
+
+def load_sides(album_dir: Path) -> SidesDocument:
+    """Load sides.yml from the album root, or an empty 4-side document if absent."""
+    path = Path(album_dir) / SIDES_FILENAME
+    if not path.exists():
+        return SidesDocument.empty()
+    with open(path) as f:
+        data = yaml.safe_load(f) or {}
+    raw_sides = data.get("sides") or {}
+    sides = {
+        name: Side(
+            songs=[SideSong(**s) for s in (raw_sides.get(name) or {}).get("songs", [])]
+        )
+        for name in SIDE_NAMES
+    }
+    return SidesDocument(
+        side_limit_seconds=data.get("side_limit_seconds", DEFAULT_SIDE_LIMIT_SECONDS),
+        sides=sides,
+    )
+
+
+def save_sides(album_dir: Path, doc: SidesDocument) -> Path:
+    """Write sides.yml to the album root."""
+    path = Path(album_dir) / SIDES_FILENAME
+    data = {
+        "side_limit_seconds": doc.side_limit_seconds,
+        "sides": {
+            name: {
+                "songs": [
+                    {"song_id": s.song_id, "duration_seconds": s.duration_seconds}
+                    for s in side.songs
+                ]
+            }
+            for name, side in doc.sides.items()
+        },
+    }
+    with open(path, "w") as f:
+        yaml.dump(
+            data,
+            f,
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+            width=float("inf"),
+        )
+    return path
+
+
+def _find_song_side(doc: SidesDocument, song_id: str) -> Optional[str]:
+    for name, side in doc.sides.items():
+        if any(s.song_id == song_id for s in side.songs):
+            return name
+    return None
+
+
+def assign_song(
+    doc: SidesDocument,
+    song_id: str,
+    side: str,
+    position: int,
+    duration_seconds: float,
+) -> SidesDocument:
+    """Insert song_id into `side` at `position`, removing it from any other side first."""
+    if side not in doc.sides:
+        raise ValueError(f"Unknown side '{side}'")
+    remove_song(doc, song_id)
+    songs = doc.sides[side].songs
+    position = max(0, min(position, len(songs)))
+    songs.insert(position, SideSong(song_id=song_id, duration_seconds=duration_seconds))
+    return doc
+
+
+def move_song(
+    doc: SidesDocument, song_id: str, to_side: str, to_position: int
+) -> SidesDocument:
+    """Move an already-assigned song to a (possibly different) side/position.
+
+    Preserves the song's previously cached duration.
+    """
+    current_side = _find_song_side(doc, song_id)
+    if current_side is None:
+        raise ValueError(f"Song '{song_id}' is not assigned to any side")
+    existing = next(s for s in doc.sides[current_side].songs if s.song_id == song_id)
+    return assign_song(doc, song_id, to_side, to_position, existing.duration_seconds)
+
+
+def remove_song(doc: SidesDocument, song_id: str) -> SidesDocument:
+    """Remove song_id from whichever side it's currently on, if any."""
+    for side in doc.sides.values():
+        side.songs = [s for s in side.songs if s.song_id != song_id]
+    return doc
+
+
+def side_totals(doc: SidesDocument) -> dict[str, dict]:
+    """Return per-side {total_seconds, over_limit} summary."""
+    totals = {}
+    for name, side in doc.sides.items():
+        total = round(sum(s.duration_seconds for s in side.songs), 3)
+        totals[name] = {
+            "total_seconds": total,
+            "over_limit": total > doc.side_limit_seconds,
+        }
+    return totals

--- a/packages/composition/tests/test_lp_sequence_advisor.py
+++ b/packages/composition/tests/test_lp_sequence_advisor.py
@@ -1,0 +1,115 @@
+"""Tests for lp_sequence_advisor."""
+
+from pathlib import Path
+
+import yaml
+
+from white_composition.lp_sequence_advisor import (
+    analyze_sides,
+    format_report_text,
+    write_report,
+)
+from white_composition.lp_sides import SidesDocument, assign_song, save_sides
+
+
+def _make_song(
+    album_dir: Path,
+    thread_slug: str,
+    production_slug: str,
+    *,
+    rainbow_color: str | None = None,
+    bpm: int | None = None,
+) -> str:
+    prod_dir = album_dir / thread_slug / "production" / production_slug
+    prod_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {"title": production_slug}
+    if rainbow_color is not None:
+        manifest["rainbow_color"] = rainbow_color
+    if bpm is not None:
+        manifest["bpm"] = bpm
+    with open(prod_dir / "manifest_bootstrap.yml", "w") as f:
+        yaml.dump(manifest, f)
+    return f"{thread_slug}__{production_slug}"
+
+
+class TestAnalyzeSides:
+    def test_empty_album_no_songs_placed(self, tmp_path):
+        report = analyze_sides(tmp_path)
+        assert all(s["song_count"] == 0 for s in report["sides"].values())
+        assert report["suggestions"] == []
+
+    def test_single_song_no_suggestion(self, tmp_path):
+        song_id = _make_song(tmp_path, "t1", "song_a", rainbow_color="Blue", bpm=90)
+        doc = SidesDocument.empty()
+        assign_song(doc, song_id, "A", 0, 200.0)
+        save_sides(tmp_path, doc)
+
+        report = analyze_sides(tmp_path)
+        assert report["sides"]["A"]["song_count"] == 1
+        assert report["sides"]["A"]["color_distribution"] == {"Blue": 1}
+        assert report["sides"]["A"]["bpm_range"] == {"min": 90, "max": 90}
+        assert report["suggestions"] == []
+
+    def test_color_cluster_flagged(self, tmp_path):
+        id1 = _make_song(tmp_path, "t1", "song_a", rainbow_color="Blue", bpm=90)
+        id2 = _make_song(tmp_path, "t1", "song_b", rainbow_color="Blue", bpm=95)
+        id3 = _make_song(tmp_path, "t1", "song_c", rainbow_color="Orange", bpm=140)
+        doc = SidesDocument.empty()
+        assign_song(doc, id1, "A", 0, 200.0)
+        assign_song(doc, id2, "A", 1, 210.0)
+        assign_song(doc, id3, "B", 0, 220.0)
+        save_sides(tmp_path, doc)
+
+        report = analyze_sides(tmp_path)
+        assert len(report["suggestions"]) == 1
+        assert "Side A" in report["suggestions"][0]
+        assert "Blue" in report["suggestions"][0]
+        assert (
+            "song_c" in report["suggestions"][0] or "Orange" in report["suggestions"][0]
+        )
+
+    def test_over_limit_reflected(self, tmp_path):
+        id1 = _make_song(tmp_path, "t1", "song_a", rainbow_color="Red")
+        doc = SidesDocument.empty()
+        assign_song(doc, id1, "A", 0, 1300.0)
+        save_sides(tmp_path, doc)
+
+        report = analyze_sides(tmp_path)
+        assert report["sides"]["A"]["over_limit"] is True
+
+
+class TestFormatReportText:
+    def test_no_songs_placed_note(self):
+        report = {"sides": {n: {"song_count": 0} for n in "ABCD"}, "suggestions": []}
+        text = format_report_text(report)
+        assert "nothing to analyze" in text.lower()
+
+    def test_includes_suggestions(self):
+        report = {
+            "sides": {
+                "A": {
+                    "song_count": 2,
+                    "total_seconds": 400.0,
+                    "over_limit": False,
+                    "color_distribution": {"Blue": 2},
+                    "bpm_range": {"min": 90, "max": 95},
+                },
+                "B": {"song_count": 0},
+                "C": {"song_count": 0},
+                "D": {"song_count": 0},
+            },
+            "suggestions": ["Side A is 100% Blue (2/2 songs) — consider more variety."],
+        }
+        text = format_report_text(report)
+        assert "Suggestions:" in text
+        assert "100% Blue" in text
+
+
+class TestWriteReport:
+    def test_writes_yaml(self, tmp_path):
+        report = {"sides": {}, "suggestions": []}
+        out_path = tmp_path / "report.yml"
+        write_report(out_path, report)
+        with open(out_path) as f:
+            data = yaml.safe_load(f)
+        assert data["suggestions"] == []

--- a/packages/composition/tests/test_lp_sides.py
+++ b/packages/composition/tests/test_lp_sides.py
@@ -1,0 +1,127 @@
+"""Tests for lp_sides."""
+
+import numpy as np
+import soundfile as sf
+
+from white_composition.lp_sides import (
+    SidesDocument,
+    assign_song,
+    load_sides,
+    mix_duration_seconds,
+    move_song,
+    remove_song,
+    save_sides,
+    side_totals,
+)
+
+
+def _write_wav(path, seconds: float = 2.0, samplerate: int = 8000):
+    samples = np.zeros(int(seconds * samplerate), dtype="float32")
+    sf.write(str(path), samples, samplerate)
+
+
+class TestMixDurationSeconds:
+    def test_valid_wav(self, tmp_path):
+        wav_path = tmp_path / "mix.wav"
+        _write_wav(wav_path, seconds=3.0)
+        duration = mix_duration_seconds(wav_path)
+        assert duration == 3.0
+
+    def test_missing_file(self, tmp_path):
+        assert mix_duration_seconds(tmp_path / "nope.wav") is None
+
+    def test_unreadable_file(self, tmp_path):
+        bad_path = tmp_path / "bad.wav"
+        bad_path.write_text("not audio")
+        assert mix_duration_seconds(bad_path) is None
+
+
+class TestLoadSaveSides:
+    def test_load_absent_returns_empty(self, tmp_path):
+        doc = load_sides(tmp_path)
+        assert set(doc.sides.keys()) == {"A", "B", "C", "D"}
+        assert all(side.songs == [] for side in doc.sides.values())
+        assert doc.side_limit_seconds == 1200.0
+
+    def test_round_trip(self, tmp_path):
+        doc = SidesDocument.empty()
+        assign_song(doc, "thread__song_a", "A", 0, 187.4)
+        save_sides(tmp_path, doc)
+
+        loaded = load_sides(tmp_path)
+        assert loaded.sides["A"].songs[0].song_id == "thread__song_a"
+        assert loaded.sides["A"].songs[0].duration_seconds == 187.4
+
+
+class TestAssignMoveRemove:
+    def test_assign_inserts_at_position(self):
+        doc = SidesDocument.empty()
+        assign_song(doc, "song_1", "A", 0, 100.0)
+        assign_song(doc, "song_2", "A", 0, 200.0)
+        ids = [s.song_id for s in doc.sides["A"].songs]
+        assert ids == ["song_2", "song_1"]
+
+    def test_assign_removes_from_previous_side(self):
+        doc = SidesDocument.empty()
+        assign_song(doc, "song_1", "A", 0, 100.0)
+        assign_song(doc, "song_1", "B", 0, 100.0)
+        assert doc.sides["A"].songs == []
+        assert doc.sides["B"].songs[0].song_id == "song_1"
+
+    def test_assign_unknown_side_raises(self):
+        doc = SidesDocument.empty()
+        try:
+            assign_song(doc, "song_1", "Z", 0, 100.0)
+            assert False, "expected ValueError"
+        except ValueError:
+            pass
+
+    def test_move_between_sides_preserves_duration(self):
+        doc = SidesDocument.empty()
+        assign_song(doc, "song_1", "A", 0, 150.0)
+        move_song(doc, "song_1", "C", 0)
+        assert doc.sides["A"].songs == []
+        assert doc.sides["C"].songs[0].duration_seconds == 150.0
+
+    def test_move_unassigned_song_raises(self):
+        doc = SidesDocument.empty()
+        try:
+            move_song(doc, "ghost", "A", 0)
+            assert False, "expected ValueError"
+        except ValueError:
+            pass
+
+    def test_remove_song(self):
+        doc = SidesDocument.empty()
+        assign_song(doc, "song_1", "A", 0, 100.0)
+        remove_song(doc, "song_1")
+        assert doc.sides["A"].songs == []
+
+    def test_remove_absent_song_is_noop(self):
+        doc = SidesDocument.empty()
+        remove_song(doc, "ghost")
+        assert all(side.songs == [] for side in doc.sides.values())
+
+
+class TestSideTotals:
+    def test_totals_under_limit(self):
+        doc = SidesDocument.empty()
+        assign_song(doc, "song_1", "A", 0, 300.0)
+        assign_song(doc, "song_2", "A", 1, 400.0)
+        totals = side_totals(doc)
+        assert totals["A"]["total_seconds"] == 700.0
+        assert totals["A"]["over_limit"] is False
+
+    def test_totals_over_limit(self):
+        doc = SidesDocument.empty()
+        assign_song(doc, "song_1", "A", 0, 700.0)
+        assign_song(doc, "song_2", "A", 1, 700.0)
+        totals = side_totals(doc)
+        assert totals["A"]["total_seconds"] == 1400.0
+        assert totals["A"]["over_limit"] is True
+
+    def test_empty_side_zero_total(self):
+        doc = SidesDocument.empty()
+        totals = side_totals(doc)
+        assert totals["B"]["total_seconds"] == 0.0
+        assert totals["B"]["over_limit"] is False

--- a/packages/generation/src/white_generation/lyric_negative_constraints.py
+++ b/packages/generation/src/white_generation/lyric_negative_constraints.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""
+Lyric negative constraints — word/imagery frequency analysis across an album.
+
+Scans promoted `melody/lyrics.txt` files across an album's song productions and
+flags words that recur across an unhealthy fraction of songs (e.g. "blue", "dead").
+This mirrors the frequency/threshold/severity pattern in
+`white_extraction.util.generate_negative_constraints`, but operates on lyric text
+rather than song-proposal metadata (key, BPM, title, concept), and is consumed by
+the lyric pipeline rather than the White ideation agent. The two mechanisms are
+intentionally independent — this module never reads or writes
+`negative_constraints.yml`.
+
+Usage:
+    python -m white_generation.lyric_negative_constraints \
+        --album-dir shrink_wrapped
+
+    python -m white_generation.lyric_negative_constraints --dry-run
+"""
+
+import argparse
+import os
+import re
+from collections import Counter
+from pathlib import Path
+
+import yaml
+
+# Threshold: flag a word if it appears in more than this fraction of scanned songs
+OVERUSE_THRESHOLD = 0.30
+
+# Only flag short/monosyllabic content words — this is the failure mode reported
+# (candidates converging on blunt monosyllables like "blue", "dead", "gone").
+SHORT_WORD_MAX_SYLLABLES = 1
+
+# Common function words excluded from frequency analysis so the tool flags
+# concrete/content words, not grammatical scaffolding.
+_STOPWORDS = {
+    "a",
+    "an",
+    "the",
+    "and",
+    "or",
+    "but",
+    "if",
+    "so",
+    "as",
+    "of",
+    "to",
+    "in",
+    "on",
+    "at",
+    "by",
+    "is",
+    "was",
+    "are",
+    "were",
+    "be",
+    "been",
+    "am",
+    "i",
+    "you",
+    "he",
+    "she",
+    "it",
+    "we",
+    "they",
+    "me",
+    "him",
+    "her",
+    "us",
+    "them",
+    "my",
+    "your",
+    "his",
+    "its",
+    "our",
+    "their",
+    "this",
+    "that",
+    "not",
+    "no",
+    "yes",
+    "do",
+    "did",
+    "does",
+    "for",
+    "with",
+    "from",
+    "up",
+    "down",
+    "out",
+    "off",
+    "into",
+    "over",
+    "than",
+    "then",
+    "now",
+    "here",
+    "there",
+    "all",
+    "just",
+    "can",
+    "will",
+    "would",
+    "could",
+    "should",
+}
+
+_HEADER_RE = re.compile(r"^\[[^\]]+\]\s*$")
+
+
+def _count_syllables(word: str) -> int:
+    """Vowel-cluster syllable heuristic — matches lyric_pipeline._count_syllables."""
+    return max(1, len(re.findall(r"[aeiouAEIOU]+", word)))
+
+
+def _tokenize(text: str) -> list[str]:
+    """Strip comment/header lines and split remaining text into lowercase words."""
+    words = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or _HEADER_RE.match(stripped):
+            continue
+        words.extend(re.findall(r"[a-zA-Z']+", stripped.lower()))
+    return words
+
+
+def collect_lyric_texts(album_dir: Path) -> list[dict]:
+    """Walk an album directory for promoted `melody/lyrics.txt` files.
+
+    Returns a list of {"song_id", "path", "text"} dicts, one per song with a
+    promoted lyrics file. Songs without promoted lyrics are skipped silently.
+    """
+    results = []
+    for lyrics_path in sorted(album_dir.glob("*/production/*/melody/lyrics.txt")):
+        parts = lyrics_path.parts
+        thread_slug = parts[-5]
+        production_slug = parts[-3]
+        text = lyrics_path.read_text(encoding="utf-8").strip()
+        if not text:
+            continue
+        results.append(
+            {
+                "song_id": f"{thread_slug}__{production_slug}",
+                "path": str(lyrics_path),
+                "text": text,
+            }
+        )
+    return results
+
+
+def analyze_word_frequency(
+    song_texts: list[dict], threshold: float = OVERUSE_THRESHOLD
+) -> dict:
+    """Compute per-word document frequency (fraction of songs containing the word).
+
+    Only short/monosyllabic, non-stopword content words are considered — these are
+    the words that converge across candidates when phrase syllable targets are tight.
+    """
+    total = len(song_texts)
+    if total == 0:
+        return {"overused_words": [], "word_song_counts": {}}
+
+    song_word_counts: Counter = Counter()
+    for entry in song_texts:
+        words_in_song = set(_tokenize(entry["text"]))
+        for word in words_in_song:
+            if word in _STOPWORDS or len(word) < 3:
+                continue
+            if _count_syllables(word) > SHORT_WORD_MAX_SYLLABLES:
+                continue
+            song_word_counts[word] += 1
+
+    overused = []
+    for word, count in song_word_counts.most_common():
+        fraction = count / total
+        if fraction >= threshold:
+            overused.append(
+                {
+                    "word": word,
+                    "count": count,
+                    "fraction": round(fraction, 2),
+                    "severity": "avoid",
+                    "reason": f"'{word}' appears in {count}/{total} songs' lyrics ({fraction:.0%})",
+                }
+            )
+
+    return {
+        "overused_words": overused,
+        "word_song_counts": dict(song_word_counts.most_common()),
+    }
+
+
+def generate_constraints(album_dir: Path, threshold: float = OVERUSE_THRESHOLD) -> dict:
+    """Generate lyric negative constraints for an album.
+
+    Returns a dict ready to write as YAML, containing `overused_words`, a
+    `generated_from` path, and `song_count`. Albums with fewer than 2 songs with
+    promoted lyrics still get a valid (empty) constraints file plus a note.
+    """
+    song_texts = collect_lyric_texts(album_dir)
+    analysis = analyze_word_frequency(song_texts, threshold=threshold)
+
+    constraints: dict = {
+        "generated_from": str(album_dir),
+        "song_count": len(song_texts),
+        "overused_words": analysis["overused_words"],
+        "word_song_counts": analysis["word_song_counts"],
+    }
+
+    if len(song_texts) < 2:
+        constraints["note"] = (
+            f"Only {len(song_texts)} song(s) with promoted lyrics found — "
+            "too few for meaningful frequency analysis"
+        )
+
+    return constraints
+
+
+def format_for_prompt(constraints: dict) -> str:
+    """Format constraints as a text block suitable for injection into a lyric prompt."""
+    overused = constraints.get("overused_words", [])
+    if not overused:
+        return ""
+
+    lines = ["## WORDS TO AVOID (overused across the album)", ""]
+    for entry in overused:
+        lines.append(f"- \"{entry['word']}\" — {entry['reason']}")
+    lines.append("")
+    lines.append(
+        "These words have converged across prior songs' lyrics. Reach for fresh "
+        "language and imagery instead of defaulting to this list."
+    )
+    return "\n".join(lines)
+
+
+def write_constraints(output_path: Path, constraints: dict) -> Path:
+    with open(output_path, "w") as f:
+        yaml.dump(
+            constraints,
+            f,
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+            width=float("inf"),
+        )
+    return output_path
+
+
+def load_constraints(album_dir: Path) -> dict | None:
+    """Load lyrics_negative_constraints.yml from an album root, or None if absent."""
+    path = album_dir / "lyrics_negative_constraints.yml"
+    if not path.exists():
+        return None
+    with open(path) as f:
+        return yaml.safe_load(f) or None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate lyric-scoped negative constraints from promoted lyrics"
+    )
+    _sw_dir = os.getenv("SHRINKWRAP_OUTPUT_DIR", "shrink_wrapped")
+    parser.add_argument(
+        "--album-dir",
+        type=Path,
+        default=Path(_sw_dir),
+        help="Album (shrink_wrapped) root directory (default: $SHRINKWRAP_OUTPUT_DIR)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Output path (default: <album-dir>/lyrics_negative_constraints.yml)",
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print constraints without writing"
+    )
+
+    args = parser.parse_args()
+    output_path = args.output or (args.album_dir / "lyrics_negative_constraints.yml")
+
+    constraints = generate_constraints(args.album_dir)
+
+    print(f"Scanned {constraints['song_count']} song(s) with promoted lyrics")
+    print(f"Overused words: {len(constraints['overused_words'])}")
+    for entry in constraints["overused_words"]:
+        print(f"  - {entry['reason']}")
+    if constraints.get("note"):
+        print(f"Note: {constraints['note']}")
+
+    if args.dry_run:
+        print("\n--- Prompt block preview ---")
+        preview = format_for_prompt(constraints)
+        print(preview or "(no overused words — nothing to inject)")
+        return
+
+    path = write_constraints(output_path, constraints)
+    print(f"\nWrote constraints to {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/generation/src/white_generation/pipelines/lyric_pipeline.py
+++ b/packages/generation/src/white_generation/pipelines/lyric_pipeline.py
@@ -432,6 +432,12 @@ def read_vocal_sections_from_arrangement(
 
 _VERDICT_ORDER = ["spacious", "paste-ready", "tight but workable", "splits needed"]
 
+# Phrases at or below this note count get a widened syllable target range in the
+# generation prompt — the strict 0.8x-1.15x multiplier collapses to a 1-2 syllable
+# window for very short phrases, which pushed candidates toward the same small pool
+# of monosyllabic words instead of treating melisma as a legitimate choice.
+SHORT_PHRASE_NOTE_THRESHOLD = 3
+
 
 def _fitting_verdict(ratio: float) -> str:
     if ratio < 0.75:
@@ -448,6 +454,22 @@ def _verdict_rank(verdict: str) -> int:
     """Rank verdict severity; spacious == paste-ready (both = 0)."""
     v = verdict if verdict != "spacious" else "paste-ready"
     return _VERDICT_ORDER.index(v)
+
+
+def _phrase_syllable_range(note_count: int) -> tuple[int, int]:
+    """Return (lo, hi) syllable target bounds for a phrase's note count.
+
+    Phrases at or below SHORT_PHRASE_NOTE_THRESHOLD get the range widened on both
+    ends so a word or short phrase sustained across the notes (melisma) is a legal,
+    encouraged choice rather than the prompt implicitly pinning every short phrase
+    to a near-single-syllable target.
+    """
+    lo = math.floor(note_count * 0.8)
+    hi = math.ceil(note_count * 1.15)
+    if note_count <= SHORT_PHRASE_NOTE_THRESHOLD:
+        lo = max(0, lo - 1)
+        hi = hi + 1
+    return lo, hi
 
 
 def _compute_fitting(
@@ -895,8 +917,6 @@ def _build_white_cutup_prompt(
         "(Headers are melody loop labels — each maps to one MIDI clip.)",
     ]
 
-    import math as _math
-
     variation_count_cutup: dict[str, int] = {}
 
     for sec in vocal_sections:
@@ -939,9 +959,8 @@ def _build_white_cutup_prompt(
         if phrases:
             all_phrases = phrases * sec["play_count"]
             phrase_counts = [p.note_count for p in all_phrases]
-            phrase_lo = [_math.floor(n * 0.8) for n in phrase_counts]
-            phrase_hi = [_math.ceil(n * 1.15) for n in phrase_counts]
-            ranges_str = ", ".join(f"{lo}–{hi}" for lo, hi in zip(phrase_lo, phrase_hi))
+            phrase_ranges = [_phrase_syllable_range(n) for n in phrase_counts]
+            ranges_str = ", ".join(f"{lo}–{hi}" for lo, hi in phrase_ranges)
             play_note = (
                 f" ({len(phrases)} per loop × {sec['play_count']} plays)"
                 if sec["play_count"] > 1
@@ -954,6 +973,12 @@ def _build_white_cutup_prompt(
                     f"    Write exactly {len(all_phrases)} lines for this section.",
                 ]
             )
+            if any(n <= SHORT_PHRASE_NOTE_THRESHOLD for n in phrase_counts):
+                lines.append(
+                    "    Some phrases above have very few notes — for those, a single"
+                    " word or short phrase sustained across the notes (melisma) is a"
+                    " good choice; don't default to one syllable per note."
+                )
 
     lines.extend(
         [
@@ -1066,9 +1091,8 @@ def _build_prompt(
             # Scale phrase list to cover all plays of this loop
             all_phrases = phrases * sec["play_count"]
             phrase_counts = [p.note_count for p in all_phrases]
-            phrase_lo = [math.floor(n * 0.8) for n in phrase_counts]
-            phrase_hi = [math.ceil(n * 1.15) for n in phrase_counts]
-            ranges_str = ", ".join(f"{lo}–{hi}" for lo, hi in zip(phrase_lo, phrase_hi))
+            phrase_ranges = [_phrase_syllable_range(n) for n in phrase_counts]
+            ranges_str = ", ".join(f"{lo}–{hi}" for lo, hi in phrase_ranges)
             play_note = (
                 f" ({len(phrases)} per loop × {sec['play_count']} plays)"
                 if sec["play_count"] > 1
@@ -1083,6 +1107,12 @@ def _build_prompt(
                     "    Each line should contain approximately the syllable count shown.",
                 ]
             )
+            if any(n <= SHORT_PHRASE_NOTE_THRESHOLD for n in phrase_counts):
+                lines.append(
+                    "    Some phrases above have very few notes — for those, a single"
+                    " word or short phrase sustained across the notes (melisma) is a"
+                    " good choice; don't default to one syllable per note."
+                )
 
     if artist_context:
         lines.extend(["", artist_context])

--- a/packages/generation/src/white_generation/pipelines/lyric_pipeline.py
+++ b/packages/generation/src/white_generation/pipelines/lyric_pipeline.py
@@ -47,6 +47,18 @@ from white_composition.production_plan import (  # noqa: E402
 )
 from white_core.enums.lyric_repeat_type import LyricRepeatType
 from white_generation.artist_catalog import load_artist_context  # noqa: E402
+from white_generation.lyric_negative_constraints import (  # noqa: E402
+    format_for_prompt as format_negative_constraints_for_prompt,
+)
+from white_generation.lyric_negative_constraints import (  # noqa: E402
+    generate_constraints as generate_lyric_negative_constraints,
+)
+from white_generation.lyric_negative_constraints import (  # noqa: E402
+    load_constraints as load_lyric_negative_constraints,
+)
+from white_generation.lyric_negative_constraints import (  # noqa: E402
+    write_constraints as write_lyric_negative_constraints,
+)
 from white_generation.pipelines.chord_pipeline import (  # noqa: E402
     _to_python,
     compute_chromatic_match,
@@ -869,6 +881,7 @@ def _build_white_cutup_prompt(
     syllable_targets: dict,
     sub_lyrics: list[dict],
     artist_context: str = "",
+    negative_constraints_block: str = "",
 ) -> str:
     """Build the Claude prompt for White lyric cut-up generation.
 
@@ -911,6 +924,9 @@ def _build_white_cutup_prompt(
 
     if artist_context:
         lines.extend(["", artist_context, ""])
+
+    if negative_constraints_block:
+        lines.extend(["", negative_constraints_block, ""])
 
     lines += [
         "SECTIONS TO WRITE:",
@@ -1002,6 +1018,7 @@ def _build_prompt(
     vocal_sections: list[dict],
     syllable_targets: dict,
     artist_context: str = "",
+    negative_constraints_block: str = "",
 ) -> str:
     """Build the Claude prompt for lyric generation.
 
@@ -1116,6 +1133,9 @@ def _build_prompt(
 
     if artist_context:
         lines.extend(["", artist_context])
+
+    if negative_constraints_block:
+        lines.extend(["", negative_constraints_block])
 
     lines.extend(
         [
@@ -1305,6 +1325,17 @@ def sync_lyric_candidates(melody_dir: Path) -> int:
 # ---------------------------------------------------------------------------
 
 
+def _resolve_album_dir(production_dir: Path) -> Path:
+    """Resolve the album (shrink_wrapped) root from a production directory.
+
+    production_dir is <album_dir>/<thread_slug>/production/<production_slug>, so the
+    album root is three levels up. Callers only ever check for a specific filename's
+    existence under the result, so an unconventional layout just resolves to a
+    directory with no matching file rather than raising.
+    """
+    return production_dir.parent.parent.parent
+
+
 def run_lyric_pipeline(
     production_dir: str,
     num_candidates: int = 3,
@@ -1314,6 +1345,7 @@ def run_lyric_pipeline(
     skip_scoring: bool = False,
     melody_channel: int = MELODY_CHANNEL,
     arrangement: Optional[str] = None,
+    refresh_constraints: bool = False,
 ) -> dict:
     """Run the lyric generation pipeline end-to-end.
 
@@ -1427,6 +1459,23 @@ def run_lyric_pipeline(
         for sec in vocal_sections
     }
 
+    # --- 4b. Lyric negative constraints (album-wide word/imagery avoidance) ---
+    album_dir = _resolve_album_dir(prod_path)
+    if refresh_constraints:
+        constraints = generate_lyric_negative_constraints(album_dir)
+        write_lyric_negative_constraints(
+            album_dir / "lyrics_negative_constraints.yml", constraints
+        )
+        print(
+            f"Refreshed lyrics_negative_constraints.yml "
+            f"({len(constraints['overused_words'])} overused word(s))"
+        )
+    else:
+        constraints = load_lyric_negative_constraints(album_dir)
+    negative_constraints_block = (
+        format_negative_constraints_for_prompt(constraints) if constraints else ""
+    )
+
     # --- 5. Build prompt ---
     artist_context = load_artist_context(meta.get("sounds_like") or [])
     is_white = str(meta.get("color", "")).strip().capitalize() == "White"
@@ -1455,10 +1504,21 @@ def run_lyric_pipeline(
         else:
             print("\nWhite cut-up mode: no sub-lyrics found — using synthesis fallback")
         prompt = _build_white_cutup_prompt(
-            meta, vocal_sections, syllable_targets, sub_lyrics, artist_context
+            meta,
+            vocal_sections,
+            syllable_targets,
+            sub_lyrics,
+            artist_context,
+            negative_constraints_block,
         )
     else:
-        prompt = _build_prompt(meta, vocal_sections, syllable_targets, artist_context)
+        prompt = _build_prompt(
+            meta,
+            vocal_sections,
+            syllable_targets,
+            artist_context,
+            negative_constraints_block,
+        )
 
     # --- 6. Generate candidates ---
     from anthropic import Anthropic
@@ -1655,6 +1715,14 @@ def main():
         default=None,
         help="Path to arrangement.txt (default: <production-dir>/arrangement.txt)",
     )
+    parser.add_argument(
+        "--refresh-constraints",
+        action="store_true",
+        help=(
+            "Regenerate lyrics_negative_constraints.yml from the album's promoted "
+            "lyrics before building the prompt"
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -1672,6 +1740,7 @@ def main():
         skip_scoring=args.skip_scoring,
         melody_channel=args.melody_channel,
         arrangement=args.arrangement,
+        refresh_constraints=args.refresh_constraints,
     )
 
 

--- a/packages/generation/tests/test_lyric_negative_constraints.py
+++ b/packages/generation/tests/test_lyric_negative_constraints.py
@@ -1,0 +1,142 @@
+"""Tests for lyric_negative_constraints."""
+
+from pathlib import Path
+
+import yaml
+
+from white_generation.lyric_negative_constraints import (
+    analyze_word_frequency,
+    collect_lyric_texts,
+    format_for_prompt,
+    generate_constraints,
+    load_constraints,
+    write_constraints,
+)
+
+
+def _write_song_lyrics(
+    album_dir: Path, thread: str, production: str, text: str
+) -> None:
+    melody_dir = album_dir / thread / "production" / production / "melody"
+    melody_dir.mkdir(parents=True, exist_ok=True)
+    (melody_dir / "lyrics.txt").write_text(text)
+
+
+class TestCollectLyricTexts:
+    def test_finds_promoted_lyrics(self, tmp_path):
+        _write_song_lyrics(tmp_path, "red-thread", "song_one", "[verse]\nBlue thing")
+        results = collect_lyric_texts(tmp_path)
+        assert len(results) == 1
+        assert results[0]["song_id"] == "red-thread__song_one"
+        assert "Blue thing" in results[0]["text"]
+
+    def test_skips_empty_lyrics(self, tmp_path):
+        _write_song_lyrics(tmp_path, "red-thread", "song_one", "   ")
+        results = collect_lyric_texts(tmp_path)
+        assert results == []
+
+    def test_no_songs(self, tmp_path):
+        assert collect_lyric_texts(tmp_path) == []
+
+
+class TestAnalyzeWordFrequency:
+    def test_overused_short_word_flagged(self):
+        song_texts = [
+            {"song_id": "a", "text": "[verse]\nblue thing is here"},
+            {"song_id": "b", "text": "[verse]\nnow it's blue and gone"},
+            {"song_id": "c", "text": "[verse]\nblue skies again"},
+            {"song_id": "d", "text": "[verse]\nsomething else entirely different"},
+        ]
+        result = analyze_word_frequency(song_texts, threshold=0.3)
+        words = {e["word"] for e in result["overused_words"]}
+        assert "blue" in words
+
+    def test_below_threshold_not_flagged(self):
+        song_texts = [
+            {"song_id": "a", "text": "[verse]\nblue thing"},
+            {"song_id": "b", "text": "[verse]\nsomething else"},
+            {"song_id": "c", "text": "[verse]\nanother line"},
+            {"song_id": "d", "text": "[verse]\nfully unrelated"},
+        ]
+        result = analyze_word_frequency(song_texts, threshold=0.3)
+        words = {e["word"] for e in result["overused_words"]}
+        assert "blue" not in words
+
+    def test_stopwords_excluded(self):
+        song_texts = [
+            {"song_id": "a", "text": "the you and it"},
+            {"song_id": "b", "text": "the you and it"},
+            {"song_id": "c", "text": "the you and it"},
+        ]
+        result = analyze_word_frequency(song_texts, threshold=0.3)
+        assert result["overused_words"] == []
+
+    def test_multisyllable_words_excluded(self):
+        song_texts = [
+            {"song_id": "a", "text": "consciousness examining consciousness"},
+            {"song_id": "b", "text": "consciousness again"},
+            {"song_id": "c", "text": "consciousness returns"},
+        ]
+        result = analyze_word_frequency(song_texts, threshold=0.3)
+        words = {e["word"] for e in result["overused_words"]}
+        assert "consciousness" not in words
+
+    def test_empty_input(self):
+        result = analyze_word_frequency([])
+        assert result["overused_words"] == []
+
+
+class TestGenerateConstraints:
+    def test_note_for_too_few_songs(self, tmp_path):
+        _write_song_lyrics(tmp_path, "red-thread", "song_one", "[verse]\nblue thing")
+        constraints = generate_constraints(tmp_path)
+        assert constraints["song_count"] == 1
+        assert "note" in constraints
+
+    def test_no_note_with_enough_songs(self, tmp_path):
+        for i in range(3):
+            _write_song_lyrics(
+                tmp_path, "red-thread", f"song_{i}", f"[verse]\nunique text {i}"
+            )
+        constraints = generate_constraints(tmp_path)
+        assert constraints["song_count"] == 3
+        assert "note" not in constraints
+
+
+class TestFormatForPrompt:
+    def test_empty_when_no_overused_words(self):
+        assert format_for_prompt({"overused_words": []}) == ""
+
+    def test_includes_words_and_reasons(self):
+        constraints = {
+            "overused_words": [
+                {"word": "blue", "reason": "'blue' appears in 3/4 songs' lyrics (75%)"}
+            ]
+        }
+        block = format_for_prompt(constraints)
+        assert "blue" in block
+        assert "75%" in block
+
+
+class TestWriteAndLoadConstraints:
+    def test_round_trip(self, tmp_path):
+        constraints = {
+            "generated_from": str(tmp_path),
+            "song_count": 2,
+            "overused_words": [{"word": "blue", "count": 2, "fraction": 1.0}],
+        }
+        out_path = tmp_path / "lyrics_negative_constraints.yml"
+        write_constraints(out_path, constraints)
+        loaded = load_constraints(tmp_path)
+        assert loaded["song_count"] == 2
+        assert loaded["overused_words"][0]["word"] == "blue"
+
+    def test_load_absent_returns_none(self, tmp_path):
+        assert load_constraints(tmp_path) is None
+
+    def test_writes_valid_yaml(self, tmp_path):
+        out_path = tmp_path / "lyrics_negative_constraints.yml"
+        write_constraints(out_path, {"song_count": 0, "overused_words": []})
+        with open(out_path) as f:
+            data = yaml.safe_load(f)
+        assert data["song_count"] == 0

--- a/packages/generation/tests/test_lyric_pipeline.py
+++ b/packages/generation/tests/test_lyric_pipeline.py
@@ -125,6 +125,46 @@ class TestFittingVerdict:
 
 
 # ---------------------------------------------------------------------------
+# 2b. _phrase_syllable_range
+# ---------------------------------------------------------------------------
+
+
+class TestPhraseSyllableRange:
+    def test_short_phrase_widened_beyond_strict_multiplier(self):
+        from white_generation.pipelines.lyric_pipeline import _phrase_syllable_range
+
+        # Strict 0.8x-1.15x multiplier would give (1, 3) for a 2-note phrase.
+        lo, hi = _phrase_syllable_range(2)
+        assert (lo, hi) != (1, 3)
+        assert lo <= 1
+        assert hi >= 4
+
+    def test_one_note_phrase_allows_more_than_two_syllables(self):
+        from white_generation.pipelines.lyric_pipeline import _phrase_syllable_range
+
+        lo, hi = _phrase_syllable_range(1)
+        assert lo == 0
+        assert hi >= 3
+
+    def test_short_phrase_lower_bound_never_negative(self):
+        from white_generation.pipelines.lyric_pipeline import _phrase_syllable_range
+
+        lo, _hi = _phrase_syllable_range(1)
+        assert lo >= 0
+
+    def test_longer_phrase_unaffected(self):
+        import math
+
+        from white_generation.pipelines.lyric_pipeline import _phrase_syllable_range
+
+        # Phrases above SHORT_PHRASE_NOTE_THRESHOLD keep the original multiplier.
+        for notes in (4, 8, 16):
+            lo, hi = _phrase_syllable_range(notes)
+            assert lo == math.floor(notes * 0.8)
+            assert hi == math.ceil(notes * 1.15)
+
+
+# ---------------------------------------------------------------------------
 # 3. _compute_fitting
 # ---------------------------------------------------------------------------
 
@@ -401,6 +441,48 @@ class TestBuildPrompt:
         prompt = _build_prompt(meta, vocal_sections, syllable_targets)
         assert "[verse]" in prompt
         assert "[chorus]" in prompt
+
+    def test_short_phrases_get_melisma_note(self):
+        from white_generation.pipelines.lyric_pipeline import Phrase, _build_prompt
+
+        meta = make_meta()
+        vocal_sections = [
+            {
+                "name": "bridge",
+                "bars": 2,
+                "play_count": 1,
+                "total_notes": 4,
+                "contour": "stepwise",
+                "phrases": [
+                    Phrase(start_tick=0, end_tick=100, note_count=1),
+                    Phrase(start_tick=200, end_tick=300, note_count=2),
+                ],
+            }
+        ]
+        syllable_targets = {"bridge": (2, 4)}
+        prompt = _build_prompt(meta, vocal_sections, syllable_targets)
+        assert "melisma" in prompt
+
+    def test_long_phrases_no_melisma_note(self):
+        from white_generation.pipelines.lyric_pipeline import Phrase, _build_prompt
+
+        meta = make_meta()
+        vocal_sections = [
+            {
+                "name": "verse",
+                "bars": 4,
+                "play_count": 1,
+                "total_notes": 16,
+                "contour": "scalar_run",
+                "phrases": [
+                    Phrase(start_tick=0, end_tick=100, note_count=8),
+                    Phrase(start_tick=200, end_tick=300, note_count=8),
+                ],
+            }
+        ]
+        syllable_targets = {"verse": (12, 17)}
+        prompt = _build_prompt(meta, vocal_sections, syllable_targets)
+        assert "melisma" not in prompt
 
 
 # ---------------------------------------------------------------------------
@@ -984,6 +1066,30 @@ class TestBuildWhiteCutupPrompt:
         prompt = _build_prompt(meta, sections, {"verse": (12, 17)})
         assert "SOURCE LYRICS" not in prompt
         assert "cut-up" not in prompt
+
+    def test_short_phrases_get_melisma_note(self):
+        from white_generation.pipelines.lyric_pipeline import (
+            Phrase,
+            _build_white_cutup_prompt,
+        )
+
+        sections = [
+            {
+                "name": "bridge",
+                "bars": 2,
+                "play_count": 1,
+                "total_notes": 3,
+                "contour": "stepwise",
+                "phrases": [
+                    Phrase(start_tick=0, end_tick=100, note_count=1),
+                    Phrase(start_tick=200, end_tick=300, note_count=2),
+                ],
+            }
+        ]
+        prompt = _build_white_cutup_prompt(
+            self._dummy_meta(), sections, {"bridge": (2, 3)}, []
+        )
+        assert "melisma" in prompt
 
 
 # ---------------------------------------------------------------------------

--- a/packages/generation/tests/test_lyric_pipeline.py
+++ b/packages/generation/tests/test_lyric_pipeline.py
@@ -802,6 +802,63 @@ class TestRunPipelineIntegration:
         assert len(txt_files) == 1
         assert txt_files[0].name == "lyrics_01.txt"
 
+    def test_negative_constraints_injected_into_prompt(self, tmp_path):
+        """When lyrics_negative_constraints.yml exists at the album root, its
+        avoidance block should reach the Claude prompt."""
+        import numpy as np
+        import yaml as _yaml
+
+        from white_generation.pipelines.lyric_pipeline import run_lyric_pipeline
+
+        album_dir = tmp_path
+        prod_dir = _make_production_dir(album_dir / "thread_one")
+        with open(album_dir / "lyrics_negative_constraints.yml", "w") as f:
+            _yaml.dump(
+                {
+                    "overused_words": [
+                        {
+                            "word": "blue",
+                            "reason": "'blue' appears in 3/4 songs' lyrics (75%)",
+                        }
+                    ]
+                },
+                f,
+            )
+
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(text="[verse]\nHello world\n")]
+        mock_client.messages.create.return_value = mock_response
+
+        mock_scorer = MagicMock()
+        mock_scorer.prepare_concept.return_value = np.zeros(768, dtype=np.float32)
+        mock_scorer.score_batch.return_value = [
+            {
+                "temporal": {"past": 0.6, "present": 0.3, "future": 0.1},
+                "spatial": {"thing": 0.7, "place": 0.2, "person": 0.1},
+                "ontological": {"imagined": 0.1, "forgotten": 0.1, "known": 0.8},
+                "confidence": 0.042,
+                "rank": 0,
+                "candidate": {"lyric_text": "[verse]\nHello world\n"},
+            }
+        ]
+
+        with (
+            patch("anthropic.Anthropic", return_value=mock_client),
+            patch("white_analysis.refractor.Refractor", return_value=mock_scorer),
+        ):
+            run_lyric_pipeline(
+                production_dir=str(prod_dir),
+                num_candidates=1,
+                model="claude-sonnet-4-6",
+            )
+
+        sent_prompt = mock_client.messages.create.call_args.kwargs["messages"][0][
+            "content"
+        ]
+        assert "blue" in sent_prompt
+        assert "75%" in sent_prompt
+
     def test_run_pipeline_writes_review_yml(self, tmp_path):
         """Pipeline should write lyrics_review.yml with one candidate entry."""
         import numpy as np

--- a/uv.lock
+++ b/uv.lock
@@ -7520,6 +7520,7 @@ dependencies = [
     { name = "mido" },
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "soundfile" },
     { name = "white-core" },
     { name = "white-generation" },
 ]
@@ -7531,6 +7532,7 @@ requires-dist = [
     { name = "mido", specifier = ">=1.3.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyyaml", specifier = ">=6.0.0" },
+    { name = "soundfile", specifier = ">=0.12.1" },
     { name = "white-core", editable = "packages/core" },
     { name = "white-generation", editable = "packages/generation" },
 ]


### PR DESCRIPTION
## Summary
- **Lyric phrase fitting**: short melody phrases (≤3 notes) no longer force a monosyllable target; the syllable range widens and melisma is offered explicitly in the prompt, so generation stops converging on blunt words like "blue"/"dead".
- **Lyric negative constraints**: new album-wide word-frequency scan (`lyric_negative_constraints.py`) flags overused short/monosyllabic content words across promoted lyrics and injects an avoidance block into the prompt. Kept fully independent from the existing proposal-level `generate_negative_constraints.py` (different input, different consumer).
- **LP-side sequencing**: since White is the only double album in the catalog, adds `sides.yml` (4 sides A–D with a soft 20-minute limit), mix duration extraction via `soundfile`, `/sides` API endpoints, and a new drag-and-drop `/sides` client page (`@dnd-kit/core`).
- **Sequencing integration**: "Sides" nav links, an `lp_consideration` song status (not_considered/candidate/placed) mirroring the existing `lifecycle_status` pattern with auto-transitions from side assignment, and a read-only `lp_sequence_advisor.py` CLI that reports per-side color/BPM clustering with suggestions.

Four OpenSpec change proposals cover this work in full (`openspec/changes/add-lyric-phrase-fitting`, `add-lyric-negative-constraints`, `add-lp-side-sequencing`, `add-lp-sequencing-integration`), all tasks complete and validated with `openspec validate --strict`.

## Test plan
- [x] `pytest` across `packages/generation`, `packages/composition`, `packages/api` — all green
- [x] `ruff check` on all touched Python files
- [x] `tsc --noEmit` and `next build` on the client — clean
- [x] Live end-to-end API smoke test of the full sides workflow (assign/move/remove, duration caching, no-mix rejection, `lp_consideration` transitions) against a fixture album
- [x] Real drag-and-drop verified manually in-browser (surfaced and fixed: optimistic UI update on drop, side-tile text color)
- [x] Real lyric generation run verified manually (`filing_cipher_prism_v1`) — short phrases now land on multisyllable words instead of defaulting to monosyllables

🤖 Generated with [Claude Code](https://claude.com/claude-code)