### PR TITLE
Fix melody/lyric assembly, sample export, and quartet voice alignment bugs

### DIFF
--- a/packages/api/src/white_api/candidate_server.py
+++ b/packages/api/src/white_api/candidate_server.py
@@ -1879,10 +1879,12 @@ def create_app(
             )
         except Exception as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
+        uncovered_count = sum(1 for a in alignment if a.get("uncovered"))
         return {
             "ok": True,
             "split_midi": str(output_path),
             "alignment": alignment,
+            "uncovered_phrase_count": uncovered_count,
         }
 
     @app.post("/production/auto-split-melody/all")
@@ -1933,6 +1935,7 @@ def create_app(
         return {
             "ok": True,
             "results": results,
+            "warnings": [r["warning"] for r in results if r.get("warning")],
             "logic_midi_dir": str(logic_midi_dir) if logic_midi_dir else None,
         }
 
@@ -1968,6 +1971,7 @@ def create_app(
         try:
             from white_generation.pipelines.melody_auto_split import (
                 assemble_melody_midi,
+                write_assembled_lyrics,
             )
 
             output_path = assemble_melody_midi(
@@ -1976,6 +1980,14 @@ def create_app(
                 bpm=bpm,
                 time_sig_str=time_sig,
             )
+
+            assembled_lyrics_path: Path | None = None
+            lyrics_path = prod / "melody" / "lyrics.txt"
+            if lyrics_path.exists():
+                assembled_lyrics_path = write_assembled_lyrics(
+                    arrangement_path=arrangement_path,
+                    lyrics_path=lyrics_path,
+                )
         except Exception as exc:
             raise HTTPException(status_code=500, detail=str(exc)) from exc
 
@@ -1997,6 +2009,9 @@ def create_app(
         return {
             "ok": True,
             "assembled_midi": str(output_path),
+            "assembled_lyrics": (
+                str(assembled_lyrics_path) if assembled_lyrics_path else None
+            ),
             "logic_midi_dir": str(logic_midi_dir) if logic_midi_dir else None,
         }
 

--- a/packages/api/src/white_api/candidate_server.py
+++ b/packages/api/src/white_api/candidate_server.py
@@ -986,15 +986,18 @@ def create_app(
                 status_code=503,
                 detail="No song selected — POST /songs/activate first",
             )
+
+        from white_composition.logic_handoff import resolve_song_dir
+
+        try:
+            song_dir = resolve_song_dir(Path(_active_song["production_path"]))
+        except Exception as exc:
+            raise HTTPException(
+                status_code=500, detail=f"Could not resolve Logic project dir: {exc}"
+            ) from exc
+
         logic_root = Path(logic_output_dir).resolve()
-        thread_slug = _active_song.get("thread_slug", "unknown")
-        title = _active_song.get("title", "unknown")
-        production_slug = _active_song.get("production_slug", "")
-        safe_title = title.replace("/", "-").replace(":", "-").replace("..", "")
-        song_folder = (
-            f"{safe_title} ({production_slug})" if production_slug else safe_title
-        )
-        dest_dir = (logic_root / thread_slug / song_folder / "Samples").resolve()
+        dest_dir = (song_dir / "Samples").resolve()
         try:
             dest_dir.relative_to(logic_root)
         except ValueError:

--- a/packages/api/tests/test_candidate_server.py
+++ b/packages/api/tests/test_candidate_server.py
@@ -1076,7 +1076,13 @@ class TestSamplesEndpoints:
         # song_context.yml diverges, simulating a post-revision title update.
         prod_dir = sw_dir / "thread-alpha" / "production" / "song_a_v1"
         with open(prod_dir / "song_context.yml", "w") as f:
-            _yaml.dump({"title": "Song Alpha (v2)", "thread": ""}, f)
+            _yaml.dump(
+                {"title": "Song Alpha (v2)", "thread": ""},
+                f,
+                sort_keys=False,
+                allow_unicode=True,
+                width=float("inf"),
+            )
 
         tc = self._active_client(sw_dir)
         wav = tmp_path / "seg_001.wav"

--- a/packages/api/tests/test_candidate_server.py
+++ b/packages/api/tests/test_candidate_server.py
@@ -1065,6 +1065,40 @@ class TestSamplesEndpoints:
         assert data["ok"] is True
         assert Path(data["dest"]).exists()
 
+    def test_export_uses_song_context_title_not_manifest_title(self, sw_dir, tmp_path):
+        """Regression: export must land in the real Logic folder (song_context.yml's
+        title), not a recomputed one from manifest_bootstrap.yml's title — the two can
+        drift (e.g. after a song is revised and only one file is updated)."""
+        import pandas as pd
+        import yaml as _yaml
+
+        # manifest_bootstrap.yml (from sw_dir fixture) has title "Song Alpha";
+        # song_context.yml diverges, simulating a post-revision title update.
+        prod_dir = sw_dir / "thread-alpha" / "production" / "song_a_v1"
+        with open(prod_dir / "song_context.yml", "w") as f:
+            _yaml.dump({"title": "Song Alpha (v2)", "thread": ""}, f)
+
+        tc = self._active_client(sw_dir)
+        wav = tmp_path / "seg_001.wav"
+        wav.write_bytes(b"RIFF")
+        logic_dir = tmp_path / "logic"
+        fake_df = pd.DataFrame(
+            [{"segment_id": "seg_001", "source_audio_file": str(wav)}]
+        )
+        with (
+            patch(
+                "white_composition.retrieve_samples.load_clap_index",
+                return_value=fake_df,
+            ),
+            patch("white_api.candidate_server._AUDIO_ROOT", tmp_path),
+            patch.dict("os.environ", {"LOGIC_OUTPUT_DIR": str(logic_dir)}),
+        ):
+            resp = tc.post("/samples/seg_001/export")
+        assert resp.status_code == 200
+        dest = Path(resp.json()["dest"])
+        assert "Song Alpha (v2) (song_a_v1)" in str(dest)
+        assert "Song Alpha (song_a_v1)" not in str(dest)
+
 
 # ---------------------------------------------------------------------------
 # Task 8.6: scan_songs — schema_version and stub fields

--- a/packages/client/app/board/page.tsx
+++ b/packages/client/app/board/page.tsx
@@ -505,10 +505,12 @@ export default function BoardPage() {
     setError(null);
     try {
       const res = await autoSplitMelody();
-      const sections = res.results.filter(r => !r.skipped).map(r => r.section).join(", ");
-      let message = `Split ${res.results.length} section(s): ${sections}`;
-      if (res.warnings.length > 0) {
-        message += ` — ⚠ ${res.warnings.join(" ")}`;
+      const results = res.results ?? [];
+      const warnings = res.warnings ?? [];
+      const sections = results.filter(r => !r.skipped).map(r => r.section).join(", ");
+      let message = `Split ${results.length} section(s): ${sections}`;
+      if (warnings.length > 0) {
+        message += ` — ⚠ ${warnings.join(" ")}`;
       }
       setSplitResult(message);
     } catch (e) {

--- a/packages/client/app/board/page.tsx
+++ b/packages/client/app/board/page.tsx
@@ -505,7 +505,12 @@ export default function BoardPage() {
     setError(null);
     try {
       const res = await autoSplitMelody();
-      setSplitResult(`Split ${res.results.length} section(s): ${res.results.map(r => r.label).join(", ")}`);
+      const sections = res.results.filter(r => !r.skipped).map(r => r.section).join(", ");
+      let message = `Split ${res.results.length} section(s): ${sections}`;
+      if (res.warnings.length > 0) {
+        message += ` — ⚠ ${res.warnings.join(" ")}`;
+      }
+      setSplitResult(message);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Auto-split failed");
     } finally {
@@ -550,8 +555,12 @@ export default function BoardPage() {
     setAssembleResult(null);
     setError(null);
     try {
-      await assembleMelody();
-      setAssembleResult("assembled_melody.mid written");
+      const res = await assembleMelody();
+      setAssembleResult(
+        res.assembled_lyrics
+          ? "assembled_melody.mid + assembled_lyrics.txt written"
+          : "assembled_melody.mid written (no lyrics.txt found to assemble)",
+      );
     } catch (e) {
       setError(e instanceof Error ? e.message : "Assemble failed");
     } finally {

--- a/packages/client/app/board/page.tsx
+++ b/packages/client/app/board/page.tsx
@@ -507,8 +507,15 @@ export default function BoardPage() {
       const res = await autoSplitMelody();
       const results = res.results ?? [];
       const warnings = res.warnings ?? [];
-      const sections = results.filter(r => !r.skipped).map(r => r.section).join(", ");
-      let message = `Split ${results.length} section(s): ${sections}`;
+      const splitResults = results.filter(r => !r.skipped);
+      const skippedCount = results.length - splitResults.length;
+      let message =
+        splitResults.length > 0
+          ? `Split ${splitResults.length} section(s): ${splitResults.map(r => r.section).join(", ")}`
+          : "No sections were split";
+      if (skippedCount > 0) {
+        message += ` (${skippedCount} skipped)`;
+      }
       if (warnings.length > 0) {
         message += ` — ⚠ ${warnings.join(" ")}`;
       }

--- a/packages/client/lib/api.ts
+++ b/packages/client/lib/api.ts
@@ -395,7 +395,20 @@ export async function draftWorkOrderEmail(collaboratorId: string): Promise<{
   return res.json();
 }
 
-export async function autoSplitMelody(): Promise<{ ok: boolean; results: { label: string; split_midi: string }[] }> {
+export interface AutoSplitResult {
+  section: string;
+  skipped: boolean;
+  reason?: string;
+  split_midi?: string;
+  uncovered_phrase_count?: number;
+  warning?: string;
+}
+
+export async function autoSplitMelody(): Promise<{
+  ok: boolean;
+  results: AutoSplitResult[];
+  warnings: string[];
+}> {
   const res = await fetch(`${BASE}/production/auto-split-melody/all`, { method: "POST" });
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
@@ -404,7 +417,11 @@ export async function autoSplitMelody(): Promise<{ ok: boolean; results: { label
   return res.json();
 }
 
-export async function assembleMelody(): Promise<{ ok: boolean; assembled_midi: string }> {
+export async function assembleMelody(): Promise<{
+  ok: boolean;
+  assembled_midi: string;
+  assembled_lyrics: string | null;
+}> {
   const res = await fetch(`${BASE}/production/assemble-melody`, { method: "POST" });
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));

--- a/packages/generation/src/white_generation/pipelines/melody_auto_split.py
+++ b/packages/generation/src/white_generation/pipelines/melody_auto_split.py
@@ -243,19 +243,32 @@ def auto_split_melody(
             n for n in notes if phrase.start_tick <= n.start_tick <= phrase.end_tick
         ]
 
-        if phrase_idx >= len(lyric_lines) or not phrase_notes:
+        if not phrase_notes:
+            continue
+
+        if phrase_idx >= len(lyric_lines):
+            # More melody phrases than lyric lines — usually means the approved MIDI
+            # was regenerated/re-approved after lyrics.txt was written. The notes are
+            # passed through unsplit so nothing is silently dropped from the MIDI, but
+            # this is flagged clearly since it means real notes have no lyric coverage.
             output_notes.extend(phrase_notes)
-            if phrase_notes:
-                alignment.append(
-                    {
-                        "phrase": phrase_idx,
-                        "lyric_line": None,
-                        "notes_in": len(phrase_notes),
-                        "notes_out": len(phrase_notes),
-                        "syllables": 0,
-                        "assignments": [],
-                    }
-                )
+            alignment.append(
+                {
+                    "phrase": phrase_idx,
+                    "lyric_line": None,
+                    "notes_in": len(phrase_notes),
+                    "notes_out": len(phrase_notes),
+                    "syllables": 0,
+                    "assignments": [],
+                    "uncovered": True,
+                    "warning": (
+                        f"No lyric line for phrase {phrase_idx} — lyrics.txt has only "
+                        f"{len(lyric_lines)} line(s) for this section but the approved "
+                        "MIDI has more phrases. The MIDI may have changed since lyrics "
+                        "were generated; consider re-running the lyric pipeline."
+                    ),
+                }
+            )
             continue
 
         line = lyric_lines[phrase_idx]
@@ -286,6 +299,7 @@ def auto_split_melody(
                 "notes_out": len(phrase_output),
                 "syllables": len(all_sylls),
                 "assignments": [syl or "(melisma)" for _, syl in assignments],
+                "uncovered": False,
             }
         )
 
@@ -332,14 +346,21 @@ def auto_split_all_instances(
             min_split_ticks=min_split_ticks,
             output_path=output_path,
         )
-        results.append(
-            {
-                "section": section_key,
-                "skipped": False,
-                "split_midi": str(out),
-                "alignment": alignment,
-            }
-        )
+        uncovered_count = sum(1 for a in alignment if a.get("uncovered"))
+        result_entry = {
+            "section": section_key,
+            "skipped": False,
+            "split_midi": str(out),
+            "alignment": alignment,
+            "uncovered_phrase_count": uncovered_count,
+        }
+        if uncovered_count:
+            result_entry["warning"] = (
+                f"{section_key}: {uncovered_count} phrase(s) have no lyric coverage — "
+                "the approved MIDI may have changed since lyrics were generated for "
+                "this section."
+            )
+        results.append(result_entry)
 
     return results
 
@@ -447,4 +468,70 @@ def assemble_melody_midi(
 
     track.append(mido.MetaMessage("end_of_track", time=0))
     out_mid.save(str(output_path))
+    return output_path
+
+
+def assemble_lyrics_text(
+    arrangement_path: Path,
+    lyrics_path: Path,
+    melody_channel: int = 4,
+) -> str:
+    """Build lyric text matching assembled_melody.mid's real instance order.
+
+    `lyrics.txt` only contains one block for EXACT-repeat sections (e.g. a chorus
+    that plays 4 times has a single `[chorus]` block, meant to be reused verbatim).
+    `assemble_melody_midi` concatenates the *real* repeated notes, so comparing the
+    single lyric block against the assembled MIDI's note count looks like a large
+    mismatch. This walks the same arrangement-order clip list `assemble_melody_midi`
+    uses and repeats each instance's lyric block — reusing the instance's own block
+    if `lyrics.txt` has one (`verse_2`, `verse_3`, ...), otherwise falling back to the
+    base label's block (`chorus` reused for `chorus_2`, `chorus_3`, `chorus_4`).
+    """
+    clips = parse_arrangement(arrangement_path)
+    resolved_channel = _detect_melody_channel(clips, fallback=melody_channel)
+    melody_clips = [c for c in clips if c["channel"] == resolved_channel]
+
+    text = lyrics_path.read_text(encoding="utf-8")
+    sections = _parse_sections(text)
+
+    label_seen: dict[str, int] = {}
+    blocks: list[str] = []
+    for clip in melody_clips:
+        label = clip["clip_name"]
+        label_seen[label] = label_seen.get(label, 0) + 1
+        n = label_seen[label]
+        instance_key = label if n == 1 else f"{label}_{n}"
+
+        block = sections.get(instance_key)
+        if block is None:
+            block = sections.get(label)
+
+        if block is None:
+            blocks.append(
+                f"[{instance_key}]\n"
+                f"# NO LYRIC BLOCK FOUND for '{label}' "
+                f"(checked '{instance_key}' and '{label}')"
+            )
+        else:
+            blocks.append(f"[{instance_key}]\n{block}")
+
+    return "\n\n".join(blocks) + "\n"
+
+
+def write_assembled_lyrics(
+    arrangement_path: Path,
+    lyrics_path: Path,
+    output_path: Optional[Path] = None,
+    melody_channel: int = 4,
+) -> Path:
+    """Write assemble_lyrics_text()'s output to <melody_dir>/assembled_lyrics.txt."""
+    if output_path is None:
+        output_path = lyrics_path.parent / "assembled_lyrics.txt"
+    output_path = Path(output_path)
+    output_path.write_text(
+        assemble_lyrics_text(
+            arrangement_path, lyrics_path, melody_channel=melody_channel
+        ),
+        encoding="utf-8",
+    )
     return output_path

--- a/packages/generation/src/white_generation/pipelines/melody_auto_split.py
+++ b/packages/generation/src/white_generation/pipelines/melody_auto_split.py
@@ -497,7 +497,9 @@ def assemble_lyrics_text(
     label_seen: dict[str, int] = {}
     blocks: list[str] = []
     for clip in melody_clips:
-        label = clip["clip_name"]
+        # Match _parse_sections()'s header normalization so clip names that differ
+        # only in case/spacing (common from Logic) still resolve to the right block.
+        label = clip["clip_name"].strip().lower().replace(" ", "_")
         label_seen[label] = label_seen.get(label, 0) + 1
         n = label_seen[label]
         instance_key = label if n == 1 else f"{label}_{n}"

--- a/packages/generation/src/white_generation/pipelines/quartet_pipeline.py
+++ b/packages/generation/src/white_generation/pipelines/quartet_pipeline.py
@@ -653,6 +653,123 @@ _VIOLA_RANGE = SingerRange(
 )
 
 
+# ---------------------------------------------------------------------------
+# Label resolution + voice-length alignment
+# ---------------------------------------------------------------------------
+
+
+def _resolve_chord_label(label_key: str, available_labels: list[str]) -> Optional[str]:
+    """Find the best-matching chord/harmonic-rhythm label for a melody label.
+
+    Melody labels often carry suffixes the chord phase never sees (_split from
+    auto-split, _2/_3/... repeat instances, _alt/_inst variants). Tries an exact
+    match first, then the longest available label that is a prefix of label_key
+    (so 'verse_alt_2_split' resolves to 'verse', 'bridge_inst' to 'bridge').
+    Returns None if nothing matches even by prefix.
+    """
+    if label_key in available_labels:
+        return label_key
+    candidates = [lbl for lbl in available_labels if label_key.startswith(lbl)]
+    if not candidates:
+        return None
+    return max(candidates, key=len)
+
+
+def _voice_length_beats(midi_bytes: bytes) -> float:
+    """Return a single-voice MIDI's total length in beats (resolution-independent)."""
+    mid = mido.MidiFile(file=io.BytesIO(midi_bytes))
+    tpb = mid.ticks_per_beat or 480
+    max_tick = 0
+    for track in mid.tracks:
+        abs_tick = 0
+        for msg in track:
+            abs_tick += msg.time
+            if msg.type in ("note_on", "note_off"):
+                max_tick = max(max_tick, abs_tick)
+    return max_tick / tpb
+
+
+def _parse_voice_notes_with_velocity(
+    midi_bytes: bytes,
+) -> tuple[list[tuple[int, int, int, int]], int]:
+    """Parse (abs_tick, pitch, duration_ticks, velocity) from a single-voice MIDI."""
+    mid = mido.MidiFile(file=io.BytesIO(midi_bytes))
+    tpb = mid.ticks_per_beat or 480
+    pending: dict[int, list[tuple[int, int]]] = {}
+    notes: list[tuple[int, int, int, int]] = []
+    for track in mid.tracks:
+        abs_tick = 0
+        for msg in track:
+            abs_tick += msg.time
+            if msg.type == "note_on" and msg.velocity > 0:
+                pending.setdefault(msg.note, []).append((abs_tick, msg.velocity))
+            elif msg.type == "note_off" or (
+                msg.type == "note_on" and msg.velocity == 0
+            ):
+                stack = pending.get(msg.note)
+                if stack:
+                    start, vel = stack.pop(0)
+                    notes.append((start, msg.note, abs_tick - start, vel))
+    notes.sort(key=lambda n: n[0])
+    return notes, tpb
+
+
+def _align_voice_length(midi_bytes: bytes, target_beats: float) -> bytes:
+    """Pad (sustain final note) or trim a single-voice MIDI to exactly target_beats.
+
+    Violin II, viola, and cello are regenerated independently from harmonic-rhythm
+    durations that don't always agree with the soprano's real length, previously
+    surfacing as a voice ending short (a gap before the section's end) or with an
+    extra dangling measure. This reconciles every voice to the soprano's actual
+    length after generation, regardless of what the harmonic-rhythm data said.
+    """
+    notes, tpb = _parse_voice_notes_with_velocity(midi_bytes)
+    if not notes:
+        return midi_bytes
+
+    target_ticks = round(target_beats * tpb)
+
+    trimmed: list[tuple[int, int, int, int]] = []
+    for tick, pitch, dur, vel in notes:
+        if tick >= target_ticks:
+            continue
+        end = tick + dur
+        if end > target_ticks:
+            dur = target_ticks - tick
+        trimmed.append((tick, pitch, dur, vel))
+
+    if not trimmed:
+        return midi_bytes
+
+    current_end = max(tick + dur for tick, _, dur, _ in trimmed)
+    if current_end < target_ticks:
+        last_tick, last_pitch, _last_dur, last_vel = trimmed[-1]
+        trimmed[-1] = (last_tick, last_pitch, target_ticks - last_tick, last_vel)
+
+    out = mido.MidiFile(ticks_per_beat=tpb)
+    track = mido.MidiTrack()
+    out.tracks.append(track)
+    track.append(mido.MetaMessage("set_tempo", tempo=mido.bpm2tempo(120), time=0))
+
+    raw: list[tuple[int, mido.Message]] = []
+    for tick, pitch, dur, vel in trimmed:
+        raw.append((tick, mido.Message("note_on", note=pitch, velocity=vel, time=0)))
+        raw.append(
+            (tick + dur, mido.Message("note_off", note=pitch, velocity=0, time=0))
+        )
+    raw.sort(key=lambda e: (e[0], 0 if e[1].type == "note_off" else 1))
+
+    prev = 0
+    for abs_tick, msg in raw:
+        track.append(msg.copy(time=abs_tick - prev))
+        prev = abs_tick
+    track.append(mido.MetaMessage("end_of_track", time=0))
+
+    buf = io.BytesIO()
+    out.save(file=buf)
+    return buf.getvalue()
+
+
 def _generate_string_voice(
     instrument: str,
     voicings: list[list[int]],
@@ -802,10 +919,15 @@ def generate_quartet(
     time_sig: tuple[int, int] = (int(ts_parts[0]), int(ts_parts[1]))
 
     soprano_midi_bytes = midi_path.read_bytes()
+    soprano_length_beats = _voice_length_beats(soprano_midi_bytes)
 
-    # Harmonic rhythm: per-chord bar durations so lower voices match the soprano length
+    # Harmonic rhythm: per-chord bar durations so lower voices match the soprano length.
+    # Voices are also hard-aligned to soprano_length_beats after generation (see
+    # _align_voice_length below), so a missing/unmatched entry here only affects the
+    # pacing of chord changes within the section, not the final total length.
     _hr = read_approved_harmonic_rhythm(production_dir)
-    section_durations: list[float] | None = _hr.get(label_key)
+    _hr_label = _resolve_chord_label(label_key, list(_hr.keys()))
+    section_durations: list[float] | None = _hr.get(_hr_label) if _hr_label else None
 
     # Diatonic scale pitch classes for out-of-key snapping on melodic voices
     scale_pcs = _compute_scale_pcs(str(ctx.get("key", "")))
@@ -896,21 +1018,22 @@ def generate_quartet(
         candidates.sort(key=lambda c: c["composite_score"], reverse=True)
         return candidates[:top_k]
 
-    # --- Main path: melody patterns for violin II/viola, bass patterns for cello ---
+    # --- Main path: violin II/viola melody patterns, cello bass pattern ---
 
-    # Load chord voicings for this section (needed by violin II, viola, cello generators)
-    try:
-        chord_data, _ = extract_section_chord_data(production_dir)
-        voicings = chord_data.get(label_key)
-        if not voicings:
-            # Try the first available section as a fallback
-            voicings = next(iter(chord_data.values()), None)
-    except Exception:
-        voicings = None
-
-    if not voicings:
-        # Last resort: single C major triad
-        voicings = [[48, 52, 55]]
+    # Load chord voicings for this section (needed by violin II, viola, cello generators).
+    # Resolution must find a real match for this label (exact or prefix) -- silently
+    # substituting an unrelated section's chords produced musically wrong harmony.
+    chord_data, _ = extract_section_chord_data(production_dir)
+    chord_label = _resolve_chord_label(label_key, list(chord_data.keys()))
+    if chord_label is None:
+        raise ValueError(
+            f"No chord data found for melody section '{label_key}' in "
+            f"{production_dir / 'chords' / 'review.yml'} — checked exact match and "
+            f"prefix match against approved chord labels {sorted(chord_data.keys())}. "
+            "Approve chords for this section (or its base section) before generating "
+            "the quartet."
+        )
+    voicings = chord_data[chord_label]
 
     if section_durations is not None and len(section_durations) < len(voicings):
         section_durations = section_durations + [1.0] * (
@@ -947,6 +1070,12 @@ def generate_quartet(
         vc_bytes, vc_pat = _generate_cello_voice(
             voicings, energy, time_sig, bpm, rng, durations=section_durations
         )
+
+        # Reconcile all 3 generated voices to the soprano's real length — their
+        # harmonic-rhythm-derived duration can drift short or long otherwise.
+        vii_bytes = _align_voice_length(vii_bytes, soprano_length_beats)
+        va_bytes = _align_voice_length(va_bytes, soprano_length_beats)
+        vc_bytes = _align_voice_length(vc_bytes, soprano_length_beats)
 
         midi_bytes = merge_voices_to_quartet_midi(
             [

--- a/packages/generation/tests/test_melody_auto_split.py
+++ b/packages/generation/tests/test_melody_auto_split.py
@@ -225,3 +225,194 @@ def test_auto_split_output_path_convention(tmp_path: Path):
     output_path, _ = auto_split_melody(midi_path=midi_path, lyrics_path=lyrics_path)
     assert output_path == tmp_path / "chorus_split.mid"
     assert output_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# Uncovered-phrase flagging (more MIDI phrases than lyric lines)
+# ---------------------------------------------------------------------------
+
+
+def test_uncovered_phrase_flagged(tmp_path: Path):
+    """A phrase beyond the lyric line count is flagged, not silently dropped."""
+    # 3 separate phrases (gap > 0.5 beat between each), only 1 lyric line.
+    note_data = [
+        (0, 60, TICKS),
+        (TICKS * 4, 61, TICKS),
+        (TICKS * 8, 62, TICKS),
+    ]
+    midi_bytes = make_melody_midi(note_data)
+    midi_path = tmp_path / "verse_alt.mid"
+    midi_path.write_bytes(midi_bytes)
+
+    lyrics_path = tmp_path / "lyrics.txt"
+    lyrics_path.write_text("[verse_alt]\nhi\n")
+
+    _output_path, alignment = auto_split_melody(
+        midi_path=midi_path, lyrics_path=lyrics_path, section="verse_alt"
+    )
+
+    assert len(alignment) == 3
+    assert alignment[0]["uncovered"] is False
+    assert alignment[0]["lyric_line"] == "hi"
+    assert alignment[1]["uncovered"] is True
+    assert alignment[1]["lyric_line"] is None
+    assert "warning" in alignment[1]
+    assert alignment[2]["uncovered"] is True
+
+    # Notes for uncovered phrases are still preserved in the output MIDI.
+    output_bytes = _output_path.read_bytes()
+    assert count_note_ons(output_bytes) == 3
+
+
+def test_fully_covered_phrases_marked_not_uncovered(tmp_path: Path):
+    note_data = [(0, 60, TICKS)]
+    midi_bytes = make_melody_midi(note_data)
+    midi_path = tmp_path / "verse.mid"
+    midi_path.write_bytes(midi_bytes)
+
+    lyrics_path = tmp_path / "lyrics.txt"
+    lyrics_path.write_text("[verse]\nhi\n")
+
+    _output_path, alignment = auto_split_melody(
+        midi_path=midi_path, lyrics_path=lyrics_path, section="verse"
+    )
+    assert len(alignment) == 1
+    assert alignment[0]["uncovered"] is False
+
+
+# ---------------------------------------------------------------------------
+# auto_split_all_instances — uncovered_phrase_count / warning surfacing
+# ---------------------------------------------------------------------------
+
+
+def test_auto_split_all_instances_surfaces_warning(tmp_path: Path):
+    from white_generation.pipelines.melody_auto_split import auto_split_all_instances
+
+    approved_dir = tmp_path / "approved"
+    approved_dir.mkdir()
+
+    note_data = [(0, 60, TICKS), (TICKS * 4, 61, TICKS)]
+    (approved_dir / "verse_alt.mid").write_bytes(make_melody_midi(note_data))
+
+    lyrics_path = tmp_path / "lyrics.txt"
+    lyrics_path.write_text("[verse_alt]\nhi\n")
+
+    results = auto_split_all_instances(
+        lyrics_path=lyrics_path, approved_dir=approved_dir
+    )
+    assert len(results) == 1
+    assert results[0]["uncovered_phrase_count"] == 1
+    assert "warning" in results[0]
+    assert "verse_alt" in results[0]["warning"]
+
+
+def test_auto_split_all_instances_no_warning_when_fully_covered(tmp_path: Path):
+    from white_generation.pipelines.melody_auto_split import auto_split_all_instances
+
+    approved_dir = tmp_path / "approved"
+    approved_dir.mkdir()
+    (approved_dir / "verse.mid").write_bytes(make_melody_midi([(0, 60, TICKS)]))
+
+    lyrics_path = tmp_path / "lyrics.txt"
+    lyrics_path.write_text("[verse]\nhi\n")
+
+    results = auto_split_all_instances(
+        lyrics_path=lyrics_path, approved_dir=approved_dir
+    )
+    assert results[0]["uncovered_phrase_count"] == 0
+    assert "warning" not in results[0]
+
+
+# ---------------------------------------------------------------------------
+# assemble_lyrics_text — EXACT-repeat expansion to match assembled_melody.mid
+# ---------------------------------------------------------------------------
+
+
+def _make_arrangement(clips: list[tuple[str, float, float]], channel: int = 4) -> str:
+    """clips: list of (clip_name, start_secs, duration_secs)."""
+
+    def _tc(t: float) -> str:
+        h = int(t // 3600)
+        t %= 3600
+        m = int(t // 60)
+        t %= 60
+        frames = (t - int(t)) * 30
+        return f"{h:02d}:{m:02d}:{int(t):02d}:{frames:05.2f}"
+
+    lines = [
+        f"{_tc(start)}\t{name}\t{channel}\t{_tc(dur)}" for name, start, dur in clips
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def test_assemble_lyrics_repeats_exact_block_verbatim(tmp_path: Path):
+    from white_generation.pipelines.melody_auto_split import assemble_lyrics_text
+
+    arrangement_path = tmp_path / "arrangement.txt"
+    arrangement_path.write_text(
+        _make_arrangement(
+            [("chorus", 0.0, 8.0), ("chorus", 8.0, 8.0), ("chorus", 16.0, 8.0)]
+        )
+    )
+
+    lyrics_path = tmp_path / "lyrics.txt"
+    lyrics_path.write_text("[chorus]\nsay everything\nfile it wrong\n")
+
+    text = assemble_lyrics_text(arrangement_path, lyrics_path)
+
+    assert "[chorus]" in text
+    assert "[chorus_2]" in text
+    assert "[chorus_3]" in text
+    # The repeated blocks carry the same lyric content as the first.
+    assert text.count("say everything") == 3
+    assert text.count("file it wrong") == 3
+
+
+def test_assemble_lyrics_uses_each_variation_instances_own_block(tmp_path: Path):
+    from white_generation.pipelines.melody_auto_split import assemble_lyrics_text
+
+    arrangement_path = tmp_path / "arrangement.txt"
+    arrangement_path.write_text(
+        _make_arrangement([("verse", 0.0, 8.0), ("verse", 8.0, 8.0)])
+    )
+
+    lyrics_path = tmp_path / "lyrics.txt"
+    lyrics_path.write_text(
+        "[verse]\nfirst verse line\n\n[verse_2]\nsecond verse line\n"
+    )
+
+    text = assemble_lyrics_text(arrangement_path, lyrics_path)
+
+    assert "first verse line" in text
+    assert "second verse line" in text
+    # Each instance keeps its own distinct content, not a repeat of the other.
+    assert text.count("first verse line") == 1
+    assert text.count("second verse line") == 1
+
+
+def test_assemble_lyrics_flags_missing_block(tmp_path: Path):
+    from white_generation.pipelines.melody_auto_split import assemble_lyrics_text
+
+    arrangement_path = tmp_path / "arrangement.txt"
+    arrangement_path.write_text(_make_arrangement([("bridge", 0.0, 8.0)]))
+
+    lyrics_path = tmp_path / "lyrics.txt"
+    lyrics_path.write_text("[chorus]\nunrelated\n")
+
+    text = assemble_lyrics_text(arrangement_path, lyrics_path)
+    assert "NO LYRIC BLOCK FOUND" in text
+
+
+def test_write_assembled_lyrics_creates_file(tmp_path: Path):
+    from white_generation.pipelines.melody_auto_split import write_assembled_lyrics
+
+    arrangement_path = tmp_path / "arrangement.txt"
+    arrangement_path.write_text(_make_arrangement([("chorus", 0.0, 8.0)]))
+
+    lyrics_path = tmp_path / "lyrics.txt"
+    lyrics_path.write_text("[chorus]\nhello\n")
+
+    output_path = write_assembled_lyrics(arrangement_path, lyrics_path)
+    assert output_path == tmp_path / "assembled_lyrics.txt"
+    assert output_path.exists()
+    assert "hello" in output_path.read_text()

--- a/packages/generation/tests/test_melody_auto_split.py
+++ b/packages/generation/tests/test_melody_auto_split.py
@@ -368,6 +368,23 @@ def test_assemble_lyrics_repeats_exact_block_verbatim(tmp_path: Path):
     assert text.count("file it wrong") == 3
 
 
+def test_assemble_lyrics_clip_name_case_insensitive(tmp_path: Path):
+    """Arrangement clip names from Logic can differ in case from lyrics.txt headers
+    (which _parse_sections always lowercases) -- normalization must still match them."""
+    from white_generation.pipelines.melody_auto_split import assemble_lyrics_text
+
+    arrangement_path = tmp_path / "arrangement.txt"
+    arrangement_path.write_text(_make_arrangement([("Chorus", 0.0, 8.0)]))
+
+    lyrics_path = tmp_path / "lyrics.txt"
+    lyrics_path.write_text("[chorus]\nsay everything\n")
+
+    text = assemble_lyrics_text(arrangement_path, lyrics_path)
+
+    assert "NO LYRIC BLOCK FOUND" not in text
+    assert "say everything" in text
+
+
 def test_assemble_lyrics_uses_each_variation_instances_own_block(tmp_path: Path):
     from white_generation.pipelines.melody_auto_split import assemble_lyrics_text
 

--- a/packages/generation/tests/test_quartet_pipeline.py
+++ b/packages/generation/tests/test_quartet_pipeline.py
@@ -65,7 +65,7 @@ def _write_chords_review(prod_dir: Path, label: str) -> Path:
     }
     path = chords_dir / "review.yml"
     with open(path, "w") as f:
-        yaml.dump(review, f)
+        yaml.dump(review, f, sort_keys=False, allow_unicode=True, width=float("inf"))
     return path
 
 

--- a/packages/generation/tests/test_quartet_pipeline.py
+++ b/packages/generation/tests/test_quartet_pipeline.py
@@ -46,6 +46,29 @@ def _write_melody_approved(prod_dir: Path, section: str, notes: list[int]) -> Pa
     return path
 
 
+def _write_chords_review(prod_dir: Path, label: str) -> Path:
+    """Write a minimal approved chords/review.yml for `generate_quartet`'s chord lookup."""
+    chords_dir = prod_dir / "chords"
+    chords_dir.mkdir(parents=True, exist_ok=True)
+    review = {
+        "time_sig": "4/4",
+        "candidates": [
+            {
+                "label": label,
+                "status": "approved",
+                "chords": [
+                    {"notes": ["C3", "E3", "G3"]},
+                    {"notes": ["F3", "A3", "C4"]},
+                ],
+            }
+        ],
+    }
+    path = chords_dir / "review.yml"
+    with open(path, "w") as f:
+        yaml.dump(review, f)
+    return path
+
+
 # ---------------------------------------------------------------------------
 # 1. extract_soprano_notes
 # ---------------------------------------------------------------------------
@@ -135,6 +158,105 @@ def _make_mock_scorer():
 
 
 # ---------------------------------------------------------------------------
+# 2b. _resolve_chord_label
+# ---------------------------------------------------------------------------
+
+
+class TestResolveChordLabel:
+    def test_exact_match(self):
+        from white_generation.pipelines.quartet_pipeline import _resolve_chord_label
+
+        assert _resolve_chord_label("verse", ["verse", "chorus"]) == "verse"
+
+    def test_prefix_match_for_split_suffix(self):
+        from white_generation.pipelines.quartet_pipeline import _resolve_chord_label
+
+        assert _resolve_chord_label("chorus_split", ["verse", "chorus"]) == "chorus"
+
+    def test_prefix_match_for_numbered_and_split_suffix(self):
+        from white_generation.pipelines.quartet_pipeline import _resolve_chord_label
+
+        assert _resolve_chord_label("verse_alt_2_split", ["verse", "bridge"]) == "verse"
+
+    def test_prefix_match_for_inst_suffix(self):
+        from white_generation.pipelines.quartet_pipeline import _resolve_chord_label
+
+        assert _resolve_chord_label("bridge_inst", ["bridge", "verse"]) == "bridge"
+
+    def test_no_match_returns_none(self):
+        from white_generation.pipelines.quartet_pipeline import _resolve_chord_label
+
+        assert _resolve_chord_label("mystery", ["verse", "chorus"]) is None
+
+    def test_prefers_longest_prefix_match(self):
+        from white_generation.pipelines.quartet_pipeline import _resolve_chord_label
+
+        assert (
+            _resolve_chord_label("verse_alt_split", ["verse", "verse_alt"])
+            == "verse_alt"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2c. _voice_length_beats / _align_voice_length
+# ---------------------------------------------------------------------------
+
+
+class TestAlignVoiceLength:
+    def test_voice_length_beats_matches_note_span(self):
+        from white_generation.pipelines.quartet_pipeline import _voice_length_beats
+
+        midi_bytes = _make_melody_midi([60, 62, 64, 65])  # 4 quarter notes = 4 beats
+        assert _voice_length_beats(midi_bytes) == 4.0
+
+    def test_pads_short_voice_by_sustaining_last_note(self):
+        from white_generation.pipelines.quartet_pipeline import (
+            _align_voice_length,
+            _parse_voice_notes_with_velocity,
+            _voice_length_beats,
+        )
+
+        midi_bytes = _make_melody_midi([60, 62])  # 2 beats
+        aligned = _align_voice_length(midi_bytes, target_beats=4.0)
+        assert _voice_length_beats(aligned) == 4.0
+        # Still the same 2 notes — no notes invented, just the last one sustained.
+        notes, _ = _parse_voice_notes_with_velocity(aligned)
+        assert len(notes) == 2
+
+    def test_trims_long_voice(self):
+        from white_generation.pipelines.quartet_pipeline import (
+            _align_voice_length,
+            _voice_length_beats,
+        )
+
+        midi_bytes = _make_melody_midi([60, 62, 64, 65, 67, 69])  # 6 beats
+        aligned = _align_voice_length(midi_bytes, target_beats=4.0)
+        assert _voice_length_beats(aligned) == 4.0
+
+    def test_already_aligned_voice_unchanged_length(self):
+        from white_generation.pipelines.quartet_pipeline import (
+            _align_voice_length,
+            _voice_length_beats,
+        )
+
+        midi_bytes = _make_melody_midi([60, 62, 64, 65])  # 4 beats
+        aligned = _align_voice_length(midi_bytes, target_beats=4.0)
+        assert _voice_length_beats(aligned) == 4.0
+
+    def test_empty_midi_returned_unchanged(self):
+        from white_generation.pipelines.quartet_pipeline import _align_voice_length
+
+        mid = mido.MidiFile(ticks_per_beat=480)
+        track = mido.MidiTrack()
+        mid.tracks.append(track)
+        track.append(mido.MetaMessage("end_of_track", time=0))
+        buf = io.BytesIO()
+        mid.save(file=buf)
+        empty_bytes = buf.getvalue()
+        assert _align_voice_length(empty_bytes, target_beats=4.0) == empty_bytes
+
+
+# ---------------------------------------------------------------------------
 # 3. generate_quartet (integration)
 # ---------------------------------------------------------------------------
 
@@ -147,6 +269,7 @@ class TestGenerateQuartet:
         prod.mkdir(parents=True)
         _write_song_context(prod)
         _write_melody_approved(prod, "chorus", [60, 62, 64, 65, 67, 65, 64, 62])
+        _write_chords_review(prod, "chorus")
 
         candidates = generate_quartet(
             prod, "chorus", top_k=2, seed=42, scorer=_make_mock_scorer()
@@ -160,6 +283,7 @@ class TestGenerateQuartet:
         prod.mkdir(parents=True)
         _write_song_context(prod)
         _write_melody_approved(prod, "verse", [60, 62, 64, 65])
+        _write_chords_review(prod, "verse")
 
         candidates = generate_quartet(
             prod, "verse", top_k=1, seed=0, scorer=_make_mock_scorer()
@@ -180,6 +304,7 @@ class TestGenerateQuartet:
         prod.mkdir(parents=True)
         _write_song_context(prod)
         _write_melody_approved(prod, "bridge", [60, 62, 64, 65, 64, 62])
+        _write_chords_review(prod, "bridge")
 
         candidates = generate_quartet(
             prod, "bridge", top_k=3, seed=7, scorer=_make_mock_scorer()
@@ -206,12 +331,75 @@ class TestGenerateQuartet:
         prod.mkdir(parents=True)
         _write_song_context(prod)
         _write_melody_approved(prod, "verse", [60, 62, 64, 65])
+        _write_chords_review(prod, "verse")
 
         with patch.dict("sys.modules", {"white_analysis.refractor": None}):
             candidates = generate_quartet(prod, "verse", top_k=1, seed=0, scorer=None)
         c = candidates[0]
         assert c["composite_score"] == c["scores"]["counterpoint"]
         assert c["scores"]["chromatic"] is None
+
+    def test_unmatched_chord_label_raises_clear_error(self, tmp_path):
+        from white_generation.pipelines.quartet_pipeline import generate_quartet
+
+        prod = tmp_path / "production" / "test_song"
+        prod.mkdir(parents=True)
+        _write_song_context(prod)
+        _write_melody_approved(prod, "mystery_section", [60, 62, 64, 65])
+        _write_chords_review(prod, "verse")  # unrelated to 'mystery_section'
+
+        with pytest.raises(ValueError, match="No chord data found"):
+            generate_quartet(
+                prod, "mystery_section", top_k=1, scorer=_make_mock_scorer()
+            )
+
+    def test_split_suffix_label_resolves_to_base_chord(self, tmp_path):
+        """A melody label with a _split suffix (from melody_auto_split) should still
+        resolve to its base chord section instead of raising or grabbing an
+        unrelated section's harmony."""
+        from white_generation.pipelines.quartet_pipeline import generate_quartet
+
+        prod = tmp_path / "production" / "test_song"
+        prod.mkdir(parents=True)
+        _write_song_context(prod)
+        _write_melody_approved(prod, "verse_split", [60, 62, 64, 65])
+        _write_chords_review(prod, "verse")
+
+        candidates = generate_quartet(
+            prod, "verse_split", top_k=1, seed=0, scorer=_make_mock_scorer()
+        )
+        assert len(candidates) == 1
+
+    def test_all_voices_match_soprano_length(self, tmp_path):
+        """Regression: violin_ii/viola/cello must end at the same tick as the
+        soprano, not drift short (a dangling gap) or long (an extra measure) from
+        their independently-derived harmonic-rhythm durations."""
+        from white_generation.pipelines.quartet_pipeline import generate_quartet
+
+        prod = tmp_path / "production" / "test_song"
+        prod.mkdir(parents=True)
+        _write_song_context(prod)
+        _write_melody_approved(prod, "verse", [60, 62, 64, 65, 67, 69, 71, 72])
+        _write_chords_review(prod, "verse")
+
+        candidates = generate_quartet(
+            prod, "verse", top_k=1, seed=3, scorer=_make_mock_scorer()
+        )
+        midi_bytes = candidates[0]["midi_bytes"]
+        mid = mido.MidiFile(file=io.BytesIO(midi_bytes))
+
+        end_tick_by_channel: dict[int, int] = {}
+        for track in mid.tracks:
+            abs_tick = 0
+            for msg in track:
+                abs_tick += msg.time
+                if msg.type in ("note_on", "note_off"):
+                    end_tick_by_channel[msg.channel] = max(
+                        end_tick_by_channel.get(msg.channel, 0), abs_tick
+                    )
+
+        assert len(end_tick_by_channel) == 4
+        assert len(set(end_tick_by_channel.values())) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Lyric/note-count mismatch for repeated & undercovered melody phrases**: EXACT-repeat sections (e.g. a chorus playing 4x in the arrangement) only got one lyric block written, but `assemble_melody_midi()` concatenates the real repeated notes — comparing the single block against the assembled track's note count looked like a huge mismatch. New `assemble_lyrics_text()`/`write_assembled_lyrics()` mirror the assembled MIDI's real arrangement order and produce `melody/assembled_lyrics.txt`, wired into the same "Assemble Melody" action. Also surfaces previously-silent "uncovered phrase" warnings when an approved MIDI has more phrases than lyric lines (stale MIDI vs. lyrics generation), and fixes a pre-existing client bug where the auto-split status message always showed "undefined" due to a `label`/`section` field mismatch.
- **Auto-split crash guard**: `handleAutoSplit` read `res.results.length`/`res.warnings.length` directly, which throws if either field is missing from the API response (e.g. a stale backend process). Both now default to empty arrays.
- **Sample export landing in the wrong folder**: `export_sample()` recomputed the Logic project folder path independently from `resolve_song_dir()` (the single source of truth used everywhere else), using a different, staler title field. When a song's title is revised and only one of two metadata files gets updated, exports silently landed in the wrong (newly-created) folder instead of the real Logic project directory. Fixed by reusing `resolve_song_dir()` directly.
- **Quartet voice length drift + arbitrary-section chord fallback**: violin II/viola/cello were regenerated independently from harmonic-rhythm durations with nothing reconciling their length back to the soprano's real length (reported as a "dangling" voice not reaching the end of a section). Now every generated voice is aligned to the soprano's actual length after generation. Separately, when a melody label didn't exactly match a chords label (common once `melody_auto_split` has run, e.g. `verse_2_split`, `bridge_inst`), the code silently substituted an **arbitrary unrelated section's chords** as harmony — now resolved via prefix matching (`verse_alt_2_split` → `verse`), raising a clear error if truly unmatched instead of guessing.

## Test plan
- [x] `pytest` across `packages/generation`, `packages/composition`, `packages/api` — all green, including new regression tests for each fix
- [x] `ruff check` on all touched Python files
- [x] `tsc --noEmit` and `next build` on the client — clean
- [x] Verified the melody/lyrics fix live against the real production directory that surfaced it (`form_b_minor_stamp_notarizes_hand_v4`) — assembled lyrics now correctly repeat the chorus block across all 4 real occurrences
- [x] Verified the sample-export fix with a regression test reproducing the exact title-drift scenario (`song_context.yml` vs `manifest_bootstrap.yml` diverging)
- [x] Verified the quartet fix live against the real production directory that surfaced it (`wisconsin_year_erasure_v1`) — all 4 voices now end at the identical tick for `verse_2_split`, which previously had no matching chords label at all

**Note**: the quartet length-alignment fix only applies to newly-generated quartets going forward — a broader scan found ~120 already-generated quartet MIDI candidates across the catalog with real length drift baked in (up to 2.9 bars short); those would need regenerating to pick up the fix if already approved/promoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)