### PR TITLE
Candidate browser quality-of-life fixes + second UX brief

### DIFF
--- a/packages/client/app/board/page.tsx
+++ b/packages/client/app/board/page.tsx
@@ -775,6 +775,9 @@ export default function BoardPage() {
               ) : (
                 <>
                   <span className="text-[10px] font-mono text-zinc-500">{activeSong.bpm} BPM</span>
+                  {activeSong.time_sig && (
+                    <span className="text-[10px] font-mono text-zinc-600">· {activeSong.time_sig}</span>
+                  )}
                   <button
                     onClick={() => { setBpmInput(String(activeSong.bpm)); setEditingBpm(true); }}
                     className="text-[10px] font-sans text-zinc-600 hover:text-zinc-400 transition-colors"

--- a/packages/client/app/board/page.tsx
+++ b/packages/client/app/board/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import {
   fetchSongs, fetchActiveSong, fetchComposition, activateSong, advanceStage, addVersion,
@@ -12,6 +12,7 @@ import {
 import { Collaborator, CompositionEntry, LifecycleStatus, LyricCandidate, LyricsResponse, MIX_STAGES, MixStage, RegressionInfo, RunJob, SongEntry, WorkOrder } from "@/lib/types";
 import WorkOrderHud from "@/components/WorkOrderHud";
 import WorkOrderDrawer from "@/components/WorkOrderDrawer";
+import { Combobox, ComboboxOption } from "@/components/Combobox";
 
 const STAGE_LABELS: Record<MixStage, string> = {
   structure:          "Structure",
@@ -347,6 +348,32 @@ export default function BoardPage() {
   const [selectedPartsFrom, setSelectedPartsFrom] = useState<string[]>([]);
   const [savingPartsFrom, setSavingPartsFrom] = useState(false);
   const lyricsPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const lifecycleScrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateLifecycleScrollState = useCallback(() => {
+    const el = lifecycleScrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 4);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 4);
+  }, []);
+
+  useEffect(() => {
+    updateLifecycleScrollState();
+    window.addEventListener("resize", updateLifecycleScrollState);
+    return () => window.removeEventListener("resize", updateLifecycleScrollState);
+  }, [updateLifecycleScrollState, composition]);
+
+  const songOptions: ComboboxOption<string>[] = useMemo(() => {
+    const sorted = [...songs].sort((a, b) => a.title.localeCompare(b.title) || a.thread_slug.localeCompare(b.thread_slug));
+    return sorted.map(s => ({
+      value: s.id,
+      label: s.title,
+      secondary: `${s.thread_slug} · ${s.id}`,
+      keywords: [s.thread_slug, s.id],
+    }));
+  }, [songs]);
 
   const refreshLyrics = useCallback(async () => {
     try {
@@ -667,18 +694,12 @@ export default function BoardPage() {
           sides
         </Link>
         <h1 className="text-lg font-bold text-white tracking-tight">Composition Board</h1>
-        {activeSong && (
-          <Link href="/" className="text-zinc-500 hover:text-zinc-300 text-xs font-sans ml-2 truncate transition-colors" title="Switch song">
-            {activeSong.title}
-          </Link>
-        )}
         <div className="ml-auto flex items-center gap-3">
-          {songs.length > 0 && (
-            <select
-              className="text-xs font-sans bg-zinc-900 border border-zinc-700 rounded px-2 py-1.5 text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
+          {songOptions.length > 0 && (
+            <Combobox
+              options={songOptions}
               value={activeSong?.id ?? ""}
-              onChange={async (e) => {
-                const id = e.target.value;
+              onChange={async (id) => {
                 if (!id || id === activeSong?.id) return;
                 setLoadState("loading");
                 try {
@@ -689,12 +710,10 @@ export default function BoardPage() {
                   setLoadState("error");
                 }
               }}
-              disabled={loadState === "loading"}
-            >
-              {songs.map(s => (
-                <option key={s.id} value={s.id}>{s.title}</option>
-              ))}
-            </select>
+              triggerLabel={activeSong?.title ?? "Select song…"}
+              placeholder="Search song title or thread…"
+              className={loadState === "loading" ? "opacity-50 pointer-events-none" : ""}
+            />
           )}
           {composition && (
             <button
@@ -791,6 +810,9 @@ export default function BoardPage() {
 
           {mixFile ? (
             <div className="flex items-center gap-3 bg-zinc-900 border border-zinc-800 rounded-lg px-3 py-2 mb-4">
+              <span className="text-[10px] font-sans uppercase tracking-wide text-zinc-600 whitespace-nowrap" title="Full song mix, separate from any per-stage take shown below">
+                Song mix
+              </span>
               <audio
                 key={mixFile}
                 controls
@@ -1029,7 +1051,15 @@ export default function BoardPage() {
       )}
 
       {loadState === "ready" && composition && (
-        <div className="overflow-x-auto px-6 py-6">
+        <div className="relative">
+          {canScrollLeft && (
+            <div className="pointer-events-none absolute left-0 top-0 bottom-0 w-12 z-10 bg-gradient-to-r from-zinc-950 to-transparent" />
+          )}
+          <div
+            ref={lifecycleScrollRef}
+            onScroll={updateLifecycleScrollState}
+            className="overflow-x-auto px-6 py-6"
+          >
           <div className="flex gap-3 min-w-max">
             {MIX_STAGES.map((stage, idx) => {
               const isCurrent = stage === composition.current_stage;
@@ -1063,11 +1093,13 @@ export default function BoardPage() {
                     <div className="flex items-center gap-2">
                       {isPast && !isFinalMix && (
                         <svg className="w-3 h-3 text-green-500 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
+                          <title>Phase reached — cards inside may still be in draft</title>
                           <path fillRule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clipRule="evenodd" />
                         </svg>
                       )}
                       {isFinalMix && (isCurrent || isPast) && (
                         <svg className="w-3 h-3 text-green-400 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
+                          <title>Phase reached — cards inside may still be in draft</title>
                           <path fillRule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clipRule="evenodd" />
                         </svg>
                       )}
@@ -1278,7 +1310,12 @@ export default function BoardPage() {
               );
             })}
           </div>
-
+          </div>
+          {canScrollRight && (
+            <div className="pointer-events-none absolute right-0 top-0 bottom-0 w-12 z-10 bg-gradient-to-l from-zinc-950 to-transparent flex items-center justify-end pr-1">
+              <span className="text-zinc-500 text-sm">›</span>
+            </div>
+          )}
         </div>
       )}
 

--- a/packages/client/app/candidates/page.tsx
+++ b/packages/client/app/candidates/page.tsx
@@ -331,7 +331,11 @@ export default function CandidatesPage() {
           <Link href="/" className="hover:text-zinc-300 transition-colors">← Songs</Link>
           <span>/</span>
           <span className="text-zinc-300">{activeSong.title}</span>
-          {activeSong.bpm && <span className="text-zinc-600">{activeSong.bpm} BPM</span>}
+          {activeSong.bpm && (
+            <span className="text-zinc-600">
+              {activeSong.bpm} BPM{activeSong.time_sig ? ` · ${activeSong.time_sig}` : ""}
+            </span>
+          )}
           <span>/</span>
           <Link href="/sides" className="hover:text-zinc-300 transition-colors">Sides</Link>
         </div>

--- a/packages/client/app/candidates/page.tsx
+++ b/packages/client/app/candidates/page.tsx
@@ -331,6 +331,7 @@ export default function CandidatesPage() {
           <Link href="/" className="hover:text-zinc-300 transition-colors">← Songs</Link>
           <span>/</span>
           <span className="text-zinc-300">{activeSong.title}</span>
+          {activeSong.bpm && <span className="text-zinc-600">{activeSong.bpm} BPM</span>}
           <span>/</span>
           <Link href="/sides" className="hover:text-zinc-300 transition-colors">Sides</Link>
         </div>

--- a/packages/client/app/candidates/page.tsx
+++ b/packages/client/app/candidates/page.tsx
@@ -328,16 +328,16 @@ export default function CandidatesPage() {
       {/* Breadcrumb */}
       {activeSong && (
         <div className="flex items-center gap-2 text-xs text-zinc-500 mb-3 font-sans">
-          <Link href="/" className="hover:text-zinc-300 transition-colors">← Songs</Link>
+          <Link href="/" className="text-zinc-400 underline decoration-zinc-700 underline-offset-2 hover:text-zinc-200 hover:decoration-zinc-500 transition-colors">← Songs</Link>
           <span>/</span>
-          <span className="text-zinc-300">{activeSong.title}</span>
+          <span className="text-zinc-300 font-medium">{activeSong.title}</span>
           {activeSong.bpm && (
             <span className="text-zinc-600">
               {activeSong.bpm} BPM{activeSong.time_sig ? ` · ${activeSong.time_sig}` : ""}
             </span>
           )}
           <span>/</span>
-          <Link href="/sides" className="hover:text-zinc-300 transition-colors">Sides</Link>
+          <Link href="/sides" className="text-zinc-400 underline decoration-zinc-700 underline-offset-2 hover:text-zinc-200 hover:decoration-zinc-500 transition-colors">Sides</Link>
         </div>
       )}
 
@@ -400,20 +400,32 @@ export default function CandidatesPage() {
         </div>
       </div>
 
-      {/* Pipeline status */}
+      {/* Pipeline status — check / current / upcoming, matching the Board's lifecycle columns */}
       {pipeline && (
         <div className="flex items-center gap-3 mb-4 flex-wrap">
           {pipeline.phase_order.filter(p => PIPELINE_PHASES.includes(p)).map(phase => {
             const status = pipeline.phases[phase] ?? "pending";
             const isNext = pipeline.next_phase === phase;
-            const color =
-              status === "promoted" ? "text-emerald-400" :
-              status === "generated" ? "text-blue-400" :
-              status === "in_progress" ? "text-yellow-400" :
-              isNext ? "text-zinc-300" : "text-zinc-600";
+            const isComplete = status === "promoted";
+            const isCurrent = !isComplete && (isNext || status === "in_progress" || status === "generated");
             return (
-              <span key={phase} className={`text-xs font-sans ${color}`}>
-                {status === "promoted" ? "✓" : status === "generated" ? "●" : status === "in_progress" ? "⟳" : isNext ? "→" : "·"} {phase}
+              <span
+                key={phase}
+                className={`flex items-center gap-1.5 text-xs font-sans ${
+                  isComplete ? "text-emerald-400" : isCurrent ? "text-blue-300" : "text-zinc-600"
+                }`}
+              >
+                {isComplete ? (
+                  <svg className="w-3 h-3 text-emerald-500 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
+                    <title>Phase complete</title>
+                    <path fillRule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clipRule="evenodd" />
+                  </svg>
+                ) : isCurrent ? (
+                  <span className="w-2 h-2 rounded-full bg-blue-500 flex-shrink-0" />
+                ) : (
+                  <span className="w-2 h-2 rounded-full border border-zinc-700 flex-shrink-0" />
+                )}
+                {phase}
               </span>
             );
           })}
@@ -666,12 +678,14 @@ export default function CandidatesPage() {
         )}
       </div>
 
-      <div className="mt-3 text-xs text-zinc-600 flex gap-4 font-sans flex-wrap">
-        <span><kbd className="bg-zinc-800 px-1 rounded font-mono">a</kbd> approve focused row</span>
-        <span><kbd className="bg-zinc-800 px-1 rounded font-mono">r</kbd> reject</span>
-        <span><kbd className="bg-zinc-800 px-1 rounded font-mono">p</kbd> play / stop</span>
-        <span>click row to expand score detail</span>
-      </div>
+      {visible.length > 0 && (
+        <div className={`mt-3 text-xs flex gap-4 font-sans flex-wrap transition-opacity ${focused ? "text-zinc-600" : "text-zinc-800"}`}>
+          <span><kbd className="bg-zinc-800 px-1 rounded font-mono">a</kbd> approve focused row</span>
+          <span><kbd className="bg-zinc-800 px-1 rounded font-mono">r</kbd> reject</span>
+          <span><kbd className="bg-zinc-800 px-1 rounded font-mono">p</kbd> play / stop</span>
+          <span>click row to expand score detail</span>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/client/app/layout.tsx
+++ b/packages/client/app/layout.tsx
@@ -4,6 +4,7 @@
 
 import type { Metadata } from "next";
 import Script from "next/script";
+import { NuqsAdapter } from "nuqs/adapters/next/app";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -25,7 +26,9 @@ export default function RootLayout({
           {`try{Typekit.load({async:true});}catch(e){}`}
         </Script>
       </head>
-      <body className="min-h-full flex flex-col bg-zinc-950 text-zinc-200">{children}</body>
+      <body className="min-h-full flex flex-col bg-zinc-950 text-zinc-200">
+        <NuqsAdapter>{children}</NuqsAdapter>
+      </body>
     </html>
   );
 }

--- a/packages/client/app/page.tsx
+++ b/packages/client/app/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { parseAsString, parseAsStringLiteral, useQueryState } from "nuqs";
 import { fetchSongs, activateSong, initSong } from "@/lib/api";
 import { SongEntry } from "@/lib/types";
+import { Combobox, ComboboxOption } from "@/components/Combobox";
 
 const COLOR_MAP: Record<string, string> = {
   red: "#dc2626",    r: "#dc2626",
@@ -61,18 +63,46 @@ const STAGE_BADGE_CLS: Record<SongEntry["stage"], string> = {
 
 const ALL_SONG_STAGES = Object.keys(STAGE_LABELS) as SongEntry["stage"][];
 
+const STAGE_FILTER_VALUES = ["all", "stub", ...ALL_SONG_STAGES] as const;
+type StageFilter = (typeof STAGE_FILTER_VALUES)[number];
+
+const PLACEMENT_VALUES = ["candidate", "placed"] as const;
+
 type Toast = { kind: "success" | "error"; message: string };
-type StageFilter = SongEntry["stage"] | "all" | "stub";
 
 export default function SongBrowserPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-zinc-950 flex items-center justify-center text-zinc-500 font-sans">
+          Loading…
+        </div>
+      }
+    >
+      <SongBrowserContent />
+    </Suspense>
+  );
+}
+
+function SongBrowserContent() {
   const router = useRouter();
   const [songs, setSongs] = useState<SongEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [activatingId, setActivatingId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [toast, setToast] = useState<Toast | null>(null);
-  const [stageFilter, setStageFilter] = useState<StageFilter>("all");
-  const [lpFilter, setLpFilter] = useState<"" | "candidate" | "placed">("");
+  const [stageFilter, setStageFilter] = useQueryState(
+    "stage",
+    parseAsStringLiteral(STAGE_FILTER_VALUES).withDefault("all"),
+  );
+  const [placementFilter, setPlacementFilter] = useQueryState(
+    "placement",
+    parseAsStringLiteral(PLACEMENT_VALUES),
+  );
+  const [threadFilter, setThreadFilter] = useQueryState(
+    "thread",
+    parseAsString.withDefault(""),
+  );
 
   const activeSongs = useMemo(() => songs.filter(s => !LIFECYCLE_STAGES.has(s.stage)), [songs]);
 
@@ -85,6 +115,37 @@ export default function SongBrowserPage() {
   );
 
   const stubCount = useMemo(() => songs.filter(s => s.stub).length, [songs]);
+
+  const stageOptions: ComboboxOption<StageFilter>[] = useMemo(
+    () =>
+      STAGE_FILTER_VALUES.map(s => {
+        const count = s === "all" ? activeSongs.length : s === "stub" ? stubCount : (countsByStage[s as SongEntry["stage"]] ?? 0);
+        const label = s === "all" ? "All" : s === "stub" ? "Stub" : STAGE_LABELS[s as SongEntry["stage"]];
+        return { value: s, label: `${label} (${count})`, count };
+      }),
+    [activeSongs.length, stubCount, countsByStage],
+  );
+
+  const threadOptions: ComboboxOption<string>[] = useMemo(() => {
+    const byThread = new Map<string, string[]>();
+    for (const s of songs) {
+      const titles = byThread.get(s.thread_slug) ?? [];
+      titles.push(s.title);
+      byThread.set(s.thread_slug, titles);
+    }
+    const options: ComboboxOption<string>[] = [
+      { value: "", label: `All threads (${songs.length})` },
+    ];
+    for (const [thread, titles] of [...byThread.entries()].sort()) {
+      options.push({
+        value: thread,
+        label: `${thread} (${titles.length})`,
+        count: titles.length,
+        keywords: titles,
+      });
+    }
+    return options;
+  }, [songs]);
 
   const showToast = (kind: Toast["kind"], message: string) => {
     setToast({ kind, message });
@@ -138,23 +199,25 @@ export default function SongBrowserPage() {
     <div className="min-h-screen bg-zinc-950 text-zinc-200 p-6 font-mono">
       <div className="flex items-start justify-between gap-4 mb-1">
         <h1 className="text-xl font-bold text-white tracking-tight">Songs</h1>
-        <div className="flex items-center gap-2">
-          <Link
-            href="/sides"
-            className="px-3 py-1.5 text-xs font-sans rounded bg-zinc-800 border border-zinc-700 text-zinc-300 hover:bg-zinc-700 hover:border-zinc-600 transition-colors"
-          >
-            Sides
-          </Link>
-          <Link
-            href="/collaborators"
-            className="px-3 py-1.5 text-xs font-sans rounded bg-zinc-800 border border-zinc-700 text-zinc-300 hover:bg-zinc-700 hover:border-zinc-600 transition-colors"
-          >
-            Collaborators
-          </Link>
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
+            <Link
+              href="/sides"
+              className="px-3 py-1.5 text-xs font-sans rounded bg-zinc-800 border border-zinc-700 text-zinc-300 hover:bg-zinc-700 hover:border-zinc-600 transition-colors"
+            >
+              Sides
+            </Link>
+            <Link
+              href="/collaborators"
+              className="px-3 py-1.5 text-xs font-sans rounded bg-zinc-800 border border-zinc-700 text-zinc-300 hover:bg-zinc-700 hover:border-zinc-600 transition-colors"
+            >
+              Collaborators
+            </Link>
+          </div>
           {!error && (
             <Link
               href="/agent"
-              className="px-3 py-1.5 text-xs font-sans rounded bg-zinc-800 border border-zinc-700 text-zinc-300 hover:bg-zinc-700 hover:border-zinc-600 transition-colors"
+              className="px-3 py-1.5 text-xs font-sans font-medium rounded bg-[#EF7143] text-zinc-950 hover:bg-[#f08662] transition-colors"
             >
               Run Agent
             </Link>
@@ -163,54 +226,56 @@ export default function SongBrowserPage() {
       </div>
       <p className="text-zinc-500 text-xs font-sans mb-3">Select a song to continue</p>
 
-      {/* Stage filter */}
+      {/* Filters */}
       {!error && songs.length > 0 && (
-        <div className="flex gap-1.5 flex-wrap mb-4">
-          {(["all", ...ALL_SONG_STAGES.filter(s => s !== "invalid" && !LIFECYCLE_STAGES.has(s)), "stub", "merged", "abandoned", "scrapped", "invalid"] as StageFilter[]).map(s => {
-            const count = s === "all" ? activeSongs.length : s === "stub" ? stubCount : (countsByStage[s as SongEntry["stage"]] ?? 0);
-            const active = stageFilter === s;
-            return (
-              <button
-                key={s}
-                type="button"
-                aria-pressed={active}
-                onClick={() => setStageFilter(s)}
-                className={`px-2.5 py-1 text-[10px] font-sans border transition-colors ${
-                  active
-                    ? "bg-zinc-200 text-zinc-900 border-zinc-200"
-                    : "bg-zinc-900 text-zinc-400 border-zinc-700 hover:border-zinc-500 hover:text-zinc-200"
-                }`}
-              >
-                {s === "all" ? "all" : s === "stub" ? "stub" : STAGE_LABELS[s as SongEntry["stage"]].toLowerCase()} <span className="text-zinc-600">{count}</span>
-              </button>
-            );
-          })}
-        </div>
-      )}
-
-      {/* LP consideration filter */}
-      {!error && songs.length > 0 && (
-        <div className="flex gap-1.5 flex-wrap mb-4">
-          {(["candidate", "placed"] as const).map(lp => {
-            const count = songs.filter(s => s.lp_consideration === lp).length;
-            if (count === 0) return null;
-            const active = lpFilter === lp;
-            return (
-              <button
-                key={lp}
-                type="button"
-                aria-pressed={active}
-                onClick={() => setLpFilter(active ? "" : lp)}
-                className={`px-2.5 py-1 text-[10px] font-sans border transition-colors ${
-                  active
-                    ? "bg-blue-200 text-blue-950 border-blue-200"
-                    : "bg-zinc-900 text-zinc-400 border-zinc-700 hover:border-zinc-500 hover:text-zinc-200"
-                }`}
-              >
-                lp: {lp} <span className="text-zinc-600">{count}</span>
-              </button>
-            );
-          })}
+        <div className="flex flex-wrap items-end gap-4 mb-4">
+          <div className="flex flex-col gap-1">
+            <span className="text-[9px] uppercase tracking-wide text-zinc-600 font-sans">Stage</span>
+            <Combobox
+              options={stageOptions}
+              value={stageFilter}
+              onChange={setStageFilter}
+              triggerLabel={stageOptions.find(o => o.value === stageFilter)?.label ?? "All"}
+              placeholder="Filter by stage…"
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <span className="text-[9px] uppercase tracking-wide text-zinc-600 font-sans">Thread</span>
+            <Combobox
+              options={threadOptions}
+              value={threadFilter}
+              onChange={setThreadFilter}
+              triggerLabel={threadOptions.find(o => o.value === threadFilter)?.label ?? "All threads"}
+              placeholder="Search thread or song title…"
+            />
+          </div>
+          {(["candidate", "placed"] as const).some(lp => songs.some(s => s.lp_consideration === lp)) && (
+            <div className="flex flex-col gap-1">
+              <span className="text-[9px] uppercase tracking-wide text-zinc-600 font-sans">Placement</span>
+              <div className="flex gap-1.5">
+                {(["candidate", "placed"] as const).map(lp => {
+                  const count = songs.filter(s => s.lp_consideration === lp).length;
+                  if (count === 0) return null;
+                  const active = placementFilter === lp;
+                  return (
+                    <button
+                      key={lp}
+                      type="button"
+                      aria-pressed={active}
+                      onClick={() => setPlacementFilter(active ? null : lp)}
+                      className={`px-2.5 py-1 text-[10px] font-sans border transition-colors ${
+                        active
+                          ? "bg-blue-200 text-blue-950 border-blue-200"
+                          : "bg-zinc-900 text-zinc-400 border-zinc-700 hover:border-zinc-500 hover:text-zinc-200"
+                      }`}
+                    >
+                      {lp} <span className="text-zinc-600">{count}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
         </div>
       )}
 
@@ -240,7 +305,8 @@ export default function SongBrowserPage() {
 
       <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
         {songs.filter(s => {
-          if (lpFilter && s.lp_consideration !== lpFilter) return false;
+          if (placementFilter && s.lp_consideration !== placementFilter) return false;
+          if (threadFilter && s.thread_slug !== threadFilter) return false;
           if (stageFilter === "all") return !LIFECYCLE_STAGES.has(s.stage);
           if (stageFilter === "stub") return s.stub;
           return s.stage === stageFilter;

--- a/packages/client/app/page.tsx
+++ b/packages/client/app/page.tsx
@@ -121,7 +121,7 @@ function SongBrowserContent() {
       STAGE_FILTER_VALUES.map(s => {
         const count = s === "all" ? activeSongs.length : s === "stub" ? stubCount : (countsByStage[s as SongEntry["stage"]] ?? 0);
         const label = s === "all" ? "All" : s === "stub" ? "Stub" : STAGE_LABELS[s as SongEntry["stage"]];
-        return { value: s, label: `${label} (${count})`, count };
+        return { value: s, label: `${label} (${count})` };
       }),
     [activeSongs.length, stubCount, countsByStage],
   );
@@ -140,7 +140,6 @@ function SongBrowserContent() {
       options.push({
         value: thread,
         label: `${thread} (${titles.length})`,
-        count: titles.length,
         keywords: titles,
       });
     }

--- a/packages/client/app/sides/page.tsx
+++ b/packages/client/app/sides/page.tsx
@@ -323,6 +323,7 @@ export default function SidesPage() {
     .filter((s) => showUnmixed || s.has_mix)
     .filter((s) => !poolSearch || s.title.toLowerCase().includes(poolSearch.toLowerCase()));
   const unmixedHiddenCount = songs.filter((s) => !assignedIds.has(s.id) && !s.has_mix).length;
+  const allAssigned = songs.length > 0 && songs.every((s) => assignedIds.has(s.id));
 
   const totalUsedSeconds = sides
     ? SIDE_NAMES.reduce((sum, s) => sum + sides.sides[s].total_seconds, 0)
@@ -380,7 +381,7 @@ export default function SidesPage() {
                 ))}
                 {available.length === 0 && (
                   <div className="text-[11px] text-zinc-600 font-sans italic py-2">
-                    {songs.length === 0 ? "All songs are assigned to a side" : "No matching songs"}
+                    {allAssigned ? "All songs are assigned to a side" : "No matching songs"}
                   </div>
                 )}
               </div>

--- a/packages/client/app/sides/page.tsx
+++ b/packages/client/app/sides/page.tsx
@@ -214,6 +214,8 @@ export default function SidesPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [activeDrag, setActiveDrag] = useState<DragPayload | null>(null);
+  const [poolSearch, setPoolSearch] = useState("");
+  const [showUnmixed, setShowUnmixed] = useState(false);
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
 
@@ -316,7 +318,16 @@ export default function SidesPage() {
   const assignedIds = new Set(
     sides ? SIDE_NAMES.flatMap((s) => sides.sides[s].songs.map((song) => song.song_id)) : [],
   );
-  const available = songs.filter((s) => !assignedIds.has(s.id));
+  const available = songs
+    .filter((s) => !assignedIds.has(s.id))
+    .filter((s) => showUnmixed || s.has_mix)
+    .filter((s) => !poolSearch || s.title.toLowerCase().includes(poolSearch.toLowerCase()));
+  const unmixedHiddenCount = songs.filter((s) => !assignedIds.has(s.id) && !s.has_mix).length;
+
+  const totalUsedSeconds = sides
+    ? SIDE_NAMES.reduce((sum, s) => sum + sides.sides[s].total_seconds, 0)
+    : 0;
+  const totalTargetSeconds = sides ? sides.side_limit_seconds * SIDE_NAMES.length : 0;
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -325,6 +336,11 @@ export default function SidesPage() {
           ← home
         </Link>
         <h1 className="text-lg font-bold text-white tracking-tight">LP Side Sequencing</h1>
+        {sides && (
+          <span className="ml-auto text-xs font-sans text-zinc-500">
+            Total: <span className="text-zinc-300">{formatDuration(totalUsedSeconds)}</span> / {formatDuration(totalTargetSeconds)} across {SIDE_NAMES.length} sides
+          </span>
+        )}
       </div>
 
       {error && (
@@ -340,13 +356,31 @@ export default function SidesPage() {
           <div className="flex-1 flex gap-4 p-6">
             <div className="w-64 flex flex-col gap-2">
               <h2 className="text-sm font-bold text-white">Available</h2>
+              <input
+                type="text"
+                value={poolSearch}
+                onChange={(e) => setPoolSearch(e.target.value)}
+                placeholder="Search song title…"
+                className="w-full bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-xs font-sans text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500"
+              />
+              {unmixedHiddenCount > 0 && (
+                <label className="flex items-center gap-1.5 text-[11px] font-sans text-zinc-500 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={showUnmixed}
+                    onChange={(e) => setShowUnmixed(e.target.checked)}
+                    className="accent-blue-600"
+                  />
+                  Show {unmixedHiddenCount} without a mix
+                </label>
+              )}
               <div className="flex flex-col gap-1.5">
                 {available.map((song) => (
                   <AvailableSongRow key={song.id} song={song} />
                 ))}
                 {available.length === 0 && (
                   <div className="text-[11px] text-zinc-600 font-sans italic py-2">
-                    All songs are assigned to a side
+                    {songs.length === 0 ? "All songs are assigned to a side" : "No matching songs"}
                   </div>
                 )}
               </div>

--- a/packages/client/components/Combobox.tsx
+++ b/packages/client/components/Combobox.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Command } from "cmdk";
+
+export interface ComboboxOption<T extends string> {
+  value: T;
+  label: string;
+  count?: number;
+  /** Extra terms (e.g. song titles under a thread) that should also match this option. */
+  keywords?: string[];
+}
+
+interface ComboboxProps<T extends string> {
+  options: ComboboxOption<T>[];
+  value: T;
+  onChange: (value: T) => void;
+  placeholder?: string;
+  triggerLabel: string;
+  emptyMessage?: string;
+  className?: string;
+}
+
+export function Combobox<T extends string>({
+  options,
+  value,
+  onChange,
+  placeholder = "Search…",
+  triggerLabel,
+  emptyMessage = "No matches",
+  className = "",
+}: ComboboxProps<T>) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClickOutside = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onClickOutside);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onClickOutside);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className={`relative ${className}`}>
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className="px-2.5 py-1 text-[10px] font-sans border border-zinc-700 bg-zinc-900 text-zinc-300 hover:border-zinc-500 hover:text-zinc-100 rounded transition-colors flex items-center gap-1.5"
+      >
+        {triggerLabel}
+        <span className="text-zinc-600">▾</span>
+      </button>
+      {open && (
+        <div className="absolute z-20 mt-1 w-72 rounded border border-zinc-700 bg-zinc-900 shadow-xl overflow-hidden">
+          <Command className="flex flex-col" loop>
+            <Command.Input
+              autoFocus
+              placeholder={placeholder}
+              className="w-full px-2.5 py-2 text-xs font-sans bg-zinc-950 border-b border-zinc-800 text-zinc-200 placeholder:text-zinc-600 focus:outline-none"
+            />
+            <Command.List className="max-h-64 overflow-y-auto p-1">
+              <Command.Empty className="px-2.5 py-2 text-[11px] text-zinc-600 font-sans">
+                {emptyMessage}
+              </Command.Empty>
+              {options.map(opt => (
+                <Command.Item
+                  key={opt.value}
+                  value={opt.label}
+                  keywords={opt.keywords}
+                  onSelect={() => {
+                    onChange(opt.value);
+                    setOpen(false);
+                  }}
+                  className={`px-2.5 py-1.5 text-xs font-sans rounded cursor-pointer flex items-center justify-between gap-2 data-[selected=true]:bg-zinc-800 ${
+                    opt.value === value ? "text-white" : "text-zinc-300"
+                  }`}
+                >
+                  <span className="truncate">{opt.label}</span>
+                  {opt.count !== undefined && (
+                    <span className="text-zinc-600 shrink-0">{opt.count}</span>
+                  )}
+                </Command.Item>
+              ))}
+            </Command.List>
+          </Command>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/client/components/Combobox.tsx
+++ b/packages/client/components/Combobox.tsx
@@ -9,6 +9,8 @@ export interface ComboboxOption<T extends string> {
   count?: number;
   /** Extra terms (e.g. song titles under a thread) that should also match this option. */
   keywords?: string[];
+  /** Dimmed secondary text shown under the label — use to disambiguate duplicate labels. */
+  secondary?: string;
 }
 
 interface ComboboxProps<T extends string> {
@@ -88,7 +90,12 @@ export function Combobox<T extends string>({
                     opt.value === value ? "text-white" : "text-zinc-300"
                   }`}
                 >
-                  <span className="truncate">{opt.label}</span>
+                  <span className="flex flex-col min-w-0">
+                    <span className="truncate">{opt.label}</span>
+                    {opt.secondary && (
+                      <span className="truncate text-[10px] text-zinc-600">{opt.secondary}</span>
+                    )}
+                  </span>
                   {opt.count !== undefined && (
                     <span className="text-zinc-600 shrink-0">{opt.count}</span>
                   )}

--- a/packages/client/docs/white-candidate-browser-ux-brief.md
+++ b/packages/client/docs/white-candidate-browser-ux-brief.md
@@ -1,0 +1,47 @@
+# White — Candidate Browser: UX Refinements Brief
+
+**Scope:** usability only. Look-and-feel (palette/type/texture toward the Grouper/BoC/MBV register) is tracked separately against the Earthly Frames style guide abstraction — not part of this pass.
+
+**Target:** the song candidate browser served at `localhost:3000` (nav: Sides / Collaborators / Run Agent; routes `/sides`, `/collaborators`, `/agent`). Locate its source under `/Volumes/LucidNonsense/White/` — likely a `dashboard/`, `web/`, or top-level `app/` directory distinct from the Python pipeline. Confirm App Router vs Pages Router and check `package.json` for existing UI deps (Tailwind, shadcn/ui, cmdk) before adding new ones.
+
+---
+
+## 1. Replace stage-filter chips with a searchable combobox
+
+Current: 12 mutually-exclusive pill buttons in one row — `all / ideation / generation / composition / production / mixing / complete / stub / merged / abandoned / scrapped / invalid`, each with a count, single-select (`all` shown active). This has outgrown chip UI.
+
+Change to a combobox/command-palette control (cmdk-style if shadcn is already present, else a lightweight headless combobox — don't hand-roll a native `<select>` if avoidable, this will be used constantly and deserves type-ahead + arrow-key nav):
+
+- Options list each stage with its live count, e.g. `production (51)`
+- Single-select, type-ahead filter on the option list
+- Keep `lp: candidate` / `lp: placed` **separate** from this control — it's a different dimension (placement, not pipeline stage), not just overflow. Leave those two as a small toggle group, but label the two groups distinctly ("Stage" / "Placement") so they no longer read as one continuous filter list.
+
+## 2. Sync filter state to the URL
+
+Use `nuqs` if it's a reasonable add (typed searchParams state, handles arrays natively — useful for placement below) — otherwise hand-roll with `useSearchParams` + `router.replace` from `next/navigation`.
+
+- Params: `stage`, `placement`, `thread` (see #3)
+- Omit the param entirely at default value (`stage` unset = "all") — keep URLs clean and diffable
+- Use `router.replace(..., { scroll: false })`, not `push`, for filter changes — don't let every filter click eat a back-button history entry
+
+## 3. Add a thread filter
+
+The gray subtitle slug under each card title (e.g. `violet-fallback-defensive-violet-response`) appears to be the thread — cross-check against `chain_artifacts/<thread>/` per the pipeline's directory conventions. Confirm the card's slug field maps 1:1 to a `chain_artifacts` directory name before wiring the filter.
+
+- High cardinality, grows over time → same combobox pattern as #1, not chips
+- Nice-to-have: let this input fuzzy-match song titles too, so it doubles as the general search the page currently lacks entirely (right now there is no way to jump to a known song by name)
+
+## 4. Restyle "Run Agent"
+
+Currently identical ghost-pill styling to the two nav links beside it (Sides, Collaborators), despite being the one control that actually *does* something (triggers agent/generation work) rather than navigates.
+
+- Solid/filled style in a warm accent, distinct from the neutral nav pills — not red/destructive (it's not a delete), but should read as "action" not "navigation"
+- Separate it spatially from the Sides/Collaborators pair (extra margin or its own container) so it's not one fat-finger away from a harmless nav click
+- Consider a confirm step if it can fire with no song/thread selected
+
+---
+
+## Notes for implementer
+
+- Card buttons currently render with no accessible name (`button` elements, no text/aria-label) — flagged separately, not required for this brief but cheap to fix alongside #1 if touching this component anyway.
+- Don't scope-creep into the visual pass (colors, type, card borders, grain/texture) — that's a separate, already-planned effort.

--- a/packages/client/docs/white-candidates-board-sides-ux-brief.md
+++ b/packages/client/docs/white-candidates-board-sides-ux-brief.md
@@ -1,0 +1,32 @@
+# White — /candidates, /board, /sides: UX Kruft Brief
+
+**Scope:** usability only, same terms as the first brief. Note: the Stage/Thread/Placement combobox + query-param fix from that brief is live on the home page and works well — this brief covers three more views, and flags where that same fix needs to propagate.
+
+---
+
+## /candidates — per-song generation view
+
+1. **Breadcrumb mixes clickable and static segments with no visual distinction.** `← Songs / [Song Title] BPM / Sides` — "Songs" and "Sides" are links, the title and BPM are static text, but nothing (color, underline, weight) tells you which is which without hovering.
+2. **Pipeline stepper is plain text, not a real stepper.** `→ chords · drums · bass · melody` conveys current step with a leading arrow and dimming, but has none of the clarity of the Board's lifecycle columns (see below) — worth reusing that visual language here: check / current / upcoming.
+3. **9-column table (Phase/Section/ID/Template/Score/Status/Label/Use/Actions) untested at width** — I only saw the empty state ("No candidates found") for every song I opened. Worth a pass once populated to confirm it doesn't force the same undiscoverable horizontal scroll the Board has.
+4. Keyboard-shortcut hint row (`a` approve / `f` reject / `p` play-stop) shows even with an empty table and nothing focused — cheap to dim/hide until there's a row to act on.
+
+## /board — composition board
+
+1. **Song picker is a single flat native `<select>` with ~97 options, unsorted by song, with duplicate labels.** Multiple options share an identical visible label — e.g. two separate entries both titled "Form B-Minor: The Stamp That Notarizes the Hand (Black)", three variants of "32.4°C (The Temperature at Which Everything Dies)" — distinguishable only by an invisible internal slug in the option value. This is worse than the old homepage chip row: you cannot reliably pick the right one by reading the label. Needs the same combobox treatment as Stage/Thread — grouped by song → thread/version, with the candidate id shown as dimmed secondary text so duplicates are actually distinguishable.
+2. **Horizontal scroll on the lifecycle board is undiscoverable.** Nine columns exist — Structure, Lyrics, Vocal Placeholders, Recording, Augmentation, Cleaning, Rough Mix, Mix Candidate, Final Mix — only ~6 fit in view at a normal desktop width. The only hint is a clipped edge column and a barely-visible scrollbar sliver at the very bottom; no fade/gradient edge, no arrow. I didn't know the last three columns existed until I scrolled blind.
+3. **The column status language is the best in the app — reuse it elsewhere.** Green check = complete, blue outline + dot = current stage, dim gray = upcoming. This is clearer than anything on /candidates or the home page and should be the pattern the pipeline stepper (above) borrows.
+4. **Column checkmark can contradict the card inside it.** "Recording" shows a green ✓ at the column header, but the one card inside it is labeled "draft" — reads as contradictory unless you already know the checkmark tracks "phase reached" rather than "content finalized."
+5. **Top audio player shows 0:00 / 0:00 next to a column that clearly has a draft take attached** (Graham Hopkins, draft, "view work order"). Unclear if the player is supposed to reflect the selected column's asset or a separate master — as-is it reads as broken.
+6. Song title is shown twice in the header — once as a small gray label, once again as the selected value inside the picker immediately to its right. Redundant.
+
+## /sides — LP side sequencing
+
+1. **Same flat-list-no-search problem, one more place.** The "Available" pool on the left is a plain scroll of ~84 song rows, no search/filter, even though a chunk are permanently disabled with a trailing "no mix" label. This is the same problem the home page just fixed with the Stage/Thread combobox — worth applying here too, or at minimum, hide "no mix" entries behind a toggle instead of showing them inline-dimmed forever.
+2. Per-side time budget ("5:42 / 20:00") is clear and legible — no note, this is good as-is.
+3. No running total across all four sides. If the goal is sequencing a full LP, a top-line total runtime (used vs. remaining pool duration) would save doing the arithmetic by eye.
+4. "Drop a mixed song here" empty-state copy on Side D is a good, specific instruction — pairs well with the disabled "no mix" state in the pool. Keep this pattern.
+
+---
+
+**Net:** the fix already shipped for Stage/Thread/Placement needs to propagate two more places — the /board song picker and the /sides pool list — same root cause (long flat list, no search, in the picker's case actively ambiguous due to duplicate labels). Going the other direction, the /board lifecycle columns have the clearest status-communication pattern in the app and should be what /candidates' pipeline stepper is upgraded to match.

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
+        "cmdk": "^1.1.1",
         "next": "16.2.2",
+        "nuqs": "^2.9.0",
         "react": "19.2.4",
         "react-dom": "19.2.4"
       },
@@ -693,6 +695,324 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.5.tgz",
+      "integrity": "sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.0.tgz",
+      "integrity": "sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.19.tgz",
+      "integrity": "sha512-+HhbN2+YtkRgVirjZ2afMeutQRuGOrdkWR5+EFC58SJojGmtyNQwYzgi6tHBpOxvFHefMtPeHdgtjz0BOGxFQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.2.0",
+        "@radix-ui/react-dismissable-layer": "1.1.15",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.12",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-portal": "1.1.13",
+        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-slot": "1.3.0",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.15.tgz",
+      "integrity": "sha512-b0XaRlzn2QKuo10XyNgi2DAJDf5XC9d1nD3FJcuvCjbR7+4Ad28zmZsLsqx+hvDEzMnRuZaZxZm9gYObV6RmRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-effect-event": "0.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+      "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.12.tgz",
+      "integrity": "sha512-jjk/lqTeNL0azUx5ZYzVrl4NgaDIrdzTNE4mABV9yBFI7FQqN7pIgzV1bTleUezP2QiTGA1BFTqY8MegDgWX9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.13.tgz",
+      "integrity": "sha512-z3oXfmaHLJTF1wktbjgD6cn9jiEbq3WSondB10LIuIt2m2Ym4iJlrW04/euMwENDdWDdE7z+OuY7Qyp1YpRSwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.7",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.7.tgz",
+      "integrity": "sha512-zBZ4QM5XG3JRanDmqXYf3MD6th4AFXFmgU6KNMFzUaV6F3uw9I5/zjMUvFriSEn5ewo1nxuibvyxJdmLlDcslA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz",
+      "integrity": "sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -970,7 +1290,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -979,9 +1299,21 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -1019,11 +1351,27 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1033,6 +1381,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
@@ -1045,6 +1399,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/graceful-fs": {
@@ -1416,6 +1779,43 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/nuqs": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/nuqs/-/nuqs-2.9.0.tgz",
+      "integrity": "sha512-1ckQBhVHaQYjLZ3kWhhH40A32lPJ7TNTQMa2T+SUvl5azyVt7swCQfUXt9xOXJV3YidWq8VHIHcMzVAJ0knRsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/franky47"
+      },
+      "peerDependencies": {
+        "@remix-run/react": ">=2",
+        "@tanstack/react-router": "^1",
+        "next": ">=14.2.0",
+        "react": ">=18.2.0 || ^19.0.0-0",
+        "react-router": "^5 || ^6 || ^7 || ^8",
+        "react-router-dom": "^5 || ^6 || ^7"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@tanstack/react-router": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react-router": {
+          "optional": true
+        },
+        "react-router-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1466,6 +1866,75 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/scheduler": {
@@ -1601,6 +2070,49 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -9,7 +9,9 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
+    "cmdk": "^1.1.1",
     "next": "16.2.2",
+    "nuqs": "^2.9.0",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },

--- a/packages/composition/src/white_composition/logic_handoff.py
+++ b/packages/composition/src/white_composition/logic_handoff.py
@@ -96,10 +96,18 @@ def handoff(production_dir: Path) -> Path:
         for wav in samples_src.glob("*.wav"):
             shutil.copy2(wav, samples_dest / wav.name)
 
+    # 3c. Ensure a blank arrangement.txt exists in the Logic folder — a visible
+    # placeholder from the very first handoff, before the human exports a real
+    # arrangement from Logic.
+    logic_arrangement = song_dir / "arrangement.txt"
+    if not logic_arrangement.exists():
+        logic_arrangement.touch()
+
     # 4. Sync arrangement.txt back from Logic folder → production dir so that
     # lyric gen and drift report can read it after the human has arranged in Logic.
-    logic_arrangement = song_dir / "arrangement.txt"
-    if logic_arrangement.exists():
+    # Skip the blank placeholder so a not-yet-arranged song never overwrites a
+    # previously-synced real arrangement.txt already in the production directory.
+    if logic_arrangement.exists() and logic_arrangement.stat().st_size > 0:
         shutil.copy2(logic_arrangement, production_dir / "arrangement.txt")
         print(f"Synced arrangement.txt from Logic → {production_dir}")
 

--- a/packages/composition/tests/test_logic_handoff.py
+++ b/packages/composition/tests/test_logic_handoff.py
@@ -1,0 +1,88 @@
+"""Tests for logic_handoff.handoff() -- arrangement.txt placeholder + sync behavior."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+
+def _write_song_context(prod_dir: Path, title: str = "Test Song") -> None:
+    prod_dir.mkdir(parents=True, exist_ok=True)
+    with open(prod_dir / "song_context.yml", "w") as f:
+        yaml.dump(
+            {"title": title, "thread": ""},
+            f,
+            sort_keys=False,
+            allow_unicode=True,
+            width=float("inf"),
+        )
+
+
+class TestHandoffArrangementPlaceholder:
+    def test_creates_blank_arrangement_when_absent(self, tmp_path):
+        from white_composition.logic_handoff import handoff
+
+        prod_dir = tmp_path / "production" / "song_a"
+        _write_song_context(prod_dir)
+        logic_dir = tmp_path / "logic_output"
+
+        with patch.dict(os.environ, {"LOGIC_OUTPUT_DIR": str(logic_dir)}):
+            song_dir = handoff(prod_dir)
+
+        arrangement = song_dir / "arrangement.txt"
+        assert arrangement.exists()
+        assert arrangement.stat().st_size == 0
+
+    def test_does_not_overwrite_existing_logic_arrangement(self, tmp_path):
+        from white_composition.logic_handoff import handoff, resolve_song_dir
+
+        prod_dir = tmp_path / "production" / "song_a"
+        _write_song_context(prod_dir)
+        logic_dir = tmp_path / "logic_output"
+
+        with patch.dict(os.environ, {"LOGIC_OUTPUT_DIR": str(logic_dir)}):
+            song_dir = resolve_song_dir(prod_dir)
+            song_dir.mkdir(parents=True)
+            (song_dir / "arrangement.txt").write_text("real arrangement content\n")
+
+            handoff(prod_dir)
+
+        assert (
+            song_dir / "arrangement.txt"
+        ).read_text() == "real arrangement content\n"
+
+    def test_blank_placeholder_not_synced_to_production_dir(self, tmp_path):
+        """A freshly-created blank Logic arrangement.txt must not overwrite (or
+        create) production_dir/arrangement.txt."""
+        from white_composition.logic_handoff import handoff
+
+        prod_dir = tmp_path / "production" / "song_a"
+        _write_song_context(prod_dir)
+        logic_dir = tmp_path / "logic_output"
+
+        with patch.dict(os.environ, {"LOGIC_OUTPUT_DIR": str(logic_dir)}):
+            handoff(prod_dir)
+
+        assert not (prod_dir / "arrangement.txt").exists()
+
+    def test_real_logic_arrangement_still_syncs_back(self, tmp_path):
+        """Regression: a real (non-empty) Logic arrangement.txt must still sync
+        back into the production directory, as before."""
+        from white_composition.logic_handoff import handoff, resolve_song_dir
+
+        prod_dir = tmp_path / "production" / "song_a"
+        _write_song_context(prod_dir)
+        logic_dir = tmp_path / "logic_output"
+
+        with patch.dict(os.environ, {"LOGIC_OUTPUT_DIR": str(logic_dir)}):
+            song_dir = resolve_song_dir(prod_dir)
+            song_dir.mkdir(parents=True)
+            (song_dir / "arrangement.txt").write_text(
+                "01:00:00:00.00\tverse\t4\t00:00:08:00.00\n"
+            )
+
+            handoff(prod_dir)
+
+        assert (prod_dir / "arrangement.txt").exists()
+        assert "verse" in (prod_dir / "arrangement.txt").read_text()

--- a/packages/generation/src/white_generation/pipelines/white_rebracketing.py
+++ b/packages/generation/src/white_generation/pipelines/white_rebracketing.py
@@ -154,33 +154,54 @@ def extract_bars(
 ) -> list[bytes]:
     """Slice a MIDI file into individual bar chunks.
 
-    Each bar spans `ticks_per_beat * beats_per_bar` ticks.  Notes that start
-    within a bar but would extend past its end are truncated.  Tick offsets
-    within each bar are re-zeroed so bar 0 starts at tick 0.
+    Each bar spans `ticks_per_beat * beats_per_bar` ticks. Notes are first paired
+    into complete (start, end) spans across the *whole* file, then each span is
+    assigned to the bar its start falls in — a note that starts within a bar but
+    would extend past its end is truncated to the bar boundary.
+
+    Pairing globally first (rather than filtering raw note_on/note_off events per
+    bar) matters: a note held from the tail of one bar into the next has its real
+    note_off at exactly the next bar's start tick, which is inside that *next*
+    bar's tick range. Naively including that note_off in the next bar's own event
+    stream would let it pair with a same-pitch note_on that starts the next bar's
+    own chord — producing a spurious near-zero-length note there, while the first
+    note's true ending becomes an unpaired orphan. Resolving spans globally avoids
+    this: a note_off is only ever considered together with the note_on that
+    genuinely started it, regardless of which bar the pairing happens to straddle.
+
+    Tick offsets within each bar are re-zeroed so bar 0 starts at tick 0.
 
     Returns a list of MIDI byte strings, one per bar.
     """
     bar_ticks = int(ticks_per_beat * beats_per_bar)
     mid = mido.MidiFile(file=io.BytesIO(midi_bytes))
 
-    # Convert all tracks to absolute tick events, merge into one stream
-    events: list[tuple[int, mido.Message]] = []
+    # Pair note_on/note_off into complete spans using a per-(channel, pitch) queue,
+    # so retriggered notes are matched in chronological order.
+    pending: dict[tuple[int, int], list[tuple[int, int]]] = {}
+    spans: list[tuple[int, int, int, int, int]] = (
+        []
+    )  # (start, end, channel, pitch, velocity)
     for track in mid.tracks:
         abs_tick = 0
         for msg in track:
             abs_tick += msg.time
-            events.append((abs_tick, msg.copy(time=abs_tick)))
+            if msg.type == "note_on" and msg.velocity > 0:
+                pending.setdefault((msg.channel, msg.note), []).append(
+                    (abs_tick, msg.velocity)
+                )
+            elif msg.type == "note_off" or (
+                msg.type == "note_on" and msg.velocity == 0
+            ):
+                queue = pending.get((msg.channel, msg.note))
+                if queue:
+                    start, velocity = queue.pop(0)
+                    spans.append((start, abs_tick, msg.channel, msg.note, velocity))
 
-    if not events:
+    if not spans:
         return []
 
-    # Compute length from note events only — meta end_of_track can carry a huge
-    # accumulated delta on type-1 files (e.g. 307200 ticks when notes end at 16800)
-    # which would generate hundreds of empty bars and flood the bar pool.
-    non_meta_ticks = [t for t, msg in events if msg.type in ("note_on", "note_off")]
-    if not non_meta_ticks:
-        return []
-    total_ticks = max(non_meta_ticks)
+    total_ticks = max(end for _, end, *_ in spans)
     n_bars = max(1, (total_ticks + bar_ticks - 1) // bar_ticks)
 
     bars: list[bytes] = []
@@ -188,36 +209,39 @@ def extract_bars(
         bar_start = bar_idx * bar_ticks
         bar_end = bar_start + bar_ticks
 
-        bar_track = mido.MidiTrack()
-        prev_abs = bar_start
-        pending_note_offs: dict[tuple[int, int], int] = {}  # (channel, note) → end_tick
-
-        for abs_tick, msg in sorted(events, key=lambda x: x[0]):
-            if msg.is_meta:
+        bar_events: list[tuple[int, mido.Message]] = []
+        for start, end, channel, pitch, velocity in spans:
+            if start < bar_start or start >= bar_end:
                 continue
-            if abs_tick < bar_start or abs_tick >= bar_end:
-                continue
-
-            if msg.type == "note_on" and msg.velocity > 0:
-                # Track pending note-off within this bar
-                pending_note_offs[(msg.channel, msg.note)] = bar_end
-
-            rel_tick = abs_tick - bar_start
-            delta = rel_tick - (prev_abs - bar_start)
-            bar_track.append(msg.copy(time=delta))
-            prev_abs = abs_tick
-
-        # Truncate any open notes at bar end
-        for (ch, note), end in pending_note_offs.items():
-            off_rel = end - bar_start
-            delta = off_rel - (prev_abs - bar_start)
-            if delta >= 0:
-                bar_track.append(
+            clipped_end = min(end, bar_end)
+            bar_events.append(
+                (
+                    start - bar_start,
                     mido.Message(
-                        "note_off", channel=ch, note=note, velocity=0, time=delta
-                    )
+                        "note_on",
+                        channel=channel,
+                        note=pitch,
+                        velocity=velocity,
+                        time=0,
+                    ),
                 )
-                prev_abs = end
+            )
+            bar_events.append(
+                (
+                    clipped_end - bar_start,
+                    mido.Message(
+                        "note_off", channel=channel, note=pitch, velocity=0, time=0
+                    ),
+                )
+            )
+
+        bar_events.sort(key=lambda e: (e[0], 0 if e[1].type == "note_off" else 1))
+
+        bar_track = mido.MidiTrack()
+        prev_rel = 0
+        for rel_tick, msg in bar_events:
+            bar_track.append(msg.copy(time=rel_tick - prev_rel))
+            prev_rel = rel_tick
 
         bar_track.append(mido.MetaMessage("end_of_track", time=0))
 

--- a/packages/generation/tests/test_white_rebracketing.py
+++ b/packages/generation/tests/test_white_rebracketing.py
@@ -229,6 +229,60 @@ def test_extract_bars_note_in_correct_bar():
     assert sum(note_counts) == 1
 
 
+def _paired_notes(midi_bytes: bytes) -> list[tuple[int, int, int]]:
+    """Return (start_tick, pitch, duration_ticks) via FIFO note_on/note_off pairing."""
+    mid = mido.MidiFile(file=io.BytesIO(midi_bytes))
+    pending: dict[int, list[int]] = {}
+    notes = []
+    for track in mid.tracks:
+        abs_tick = 0
+        for msg in track:
+            abs_tick += msg.time
+            if msg.type == "note_on" and msg.velocity > 0:
+                pending.setdefault(msg.note, []).append(abs_tick)
+            elif msg.type == "note_off" or (
+                msg.type == "note_on" and msg.velocity == 0
+            ):
+                queue = pending.get(msg.note)
+                if queue:
+                    start = queue.pop(0)
+                    notes.append((start, msg.note, abs_tick - start))
+    return notes
+
+
+def test_extract_bars_no_spurious_short_note_across_bar_boundary():
+    """Regression: a chord sustained through the end of bar 0, immediately followed
+    by a new chord in bar 1 that reuses one of the same pitches, must not produce a
+    near-zero-length note for the shared pitch.
+
+    Previously, filtering raw note_on/note_off events per bar (rather than pairing
+    them into spans first) let bar 1's leftover-from-bar-0 note_off land in bar 1's
+    own event stream and pair with bar 1's fresh note_on for the same pitch.
+    """
+    tpb = 480
+    bpb = 4
+    bar_ticks = tpb * bpb  # 1920
+
+    # Bar 0: chord [60, 64, 67] held for the entire bar (ends exactly at bar_ticks).
+    # Bar 1: chord [60, 63, 67] starts immediately at bar_ticks, sharing 60 and 67.
+    notes = [
+        (0, 60, 0, bar_ticks),
+        (0, 64, 0, bar_ticks),
+        (0, 67, 0, bar_ticks),
+        (0, 60, bar_ticks, bar_ticks + 960),
+        (0, 63, bar_ticks, bar_ticks + 960),
+        (0, 67, bar_ticks, bar_ticks + 960),
+    ]
+    raw = _make_midi(notes, tpb=tpb)
+    bars = extract_bars(raw, tpb, bpb)
+
+    bar0_notes = _paired_notes(bars[0])
+    bar1_notes = _paired_notes(bars[1])
+
+    assert all(dur >= bar_ticks for _, _, dur in bar0_notes)
+    assert all(dur >= 960 for _, _, dur in bar1_notes)
+
+
 # ---------------------------------------------------------------------------
 # concatenate_bars
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Tempo/time-signature shown on candidate view + board; blank arrangement.txt scaffolding on Logic handoff
- Fixed quartet voice length drift and an arbitrary chord fallback bug in `quartet_pipeline.py`
- Fixed near-zero-length notes in White chord cut-up chopping (`white_rebracketing.py`)
- Implemented first UX brief: combobox stage filter, URL state sync via nuqs, thread filter with fuzzy song-title search, Run Agent button restyle
- Implemented second UX brief (`packages/client/docs/white-candidates-board-sides-ux-brief.md`):
  - **Board**: searchable song combobox disambiguates duplicate titles (thread/id shown as secondary text), horizontal-scroll fade affordance on the 9-column lifecycle board, tooltips clarifying "phase reached" vs "content finalized", removed duplicate song title, labeled the mix player
  - **Candidates**: breadcrumb now visually distinguishes links from static text, pipeline stepper upgraded to match the Board's check/current/upcoming iconography, keyboard-hint row hides when the table is empty
  - **Sides**: search + "show unmixed" toggle for the Available pool, running total across all four sides
  - Investigated the reported 0:00/0:00 mix player symptom — confirmed via curl/fetch/Safari that the backend streams correctly; the earlier repro was a browser-automation-tooling artifact, not an app bug

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] Verified all three views (`/board`, `/candidates`, `/sides`) live in browser against real production data
- [x] Backend `pytest` suite unaffected (client-only changes this round)