### PR TITLE
Sides candidate UX, unified diary notes, and backend fixes

### DIFF
--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "white-api"
-version = "0.2.0"
+version = "0.2.1"
 description = "Candidate browser server and song dashboard for White project"
 requires-python = ">=3.12"
 dependencies = [

--- a/packages/api/src/white_api/candidate_browser.py
+++ b/packages/api/src/white_api/candidate_browser.py
@@ -18,9 +18,12 @@ Keymap:
 """
 
 import argparse
+import contextlib
+import os
 import shutil
 import subprocess
 import sys
+import tempfile
 import termios
 import tty
 from dataclasses import dataclass, field
@@ -153,18 +156,24 @@ def _update_review_yml(review_yml: Path, candidate_id: str, **fields) -> None:
         if c.get("id") == candidate_id:
             c.update(fields)
             break
-    # Atomic write: dump to a temp file then rename so a mid-write crash
-    # never leaves review.yml empty or truncated.
-    tmp = review_yml.with_suffix(".yml.tmp")
-    with open(tmp, "w") as f:
-        yaml.dump(
-            data,
-            f,
-            allow_unicode=True,
-            sort_keys=False,
-            width=float("inf"),
-        )
-    tmp.replace(review_yml)
+    # Atomic write: dump to a uniquely-named temp file then rename so a
+    # mid-write crash (or a concurrent approve/reject on the same file)
+    # never leaves review.yml empty, truncated, or racing another writer.
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=review_yml.parent, suffix=".yml.tmp")
+    try:
+        with os.fdopen(tmp_fd, "w") as f:
+            yaml.dump(
+                data,
+                f,
+                allow_unicode=True,
+                sort_keys=False,
+                width=float("inf"),
+            )
+        os.replace(tmp_path, review_yml)
+    except Exception:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_path)
+        raise
 
 
 def approve_candidate(entry: CandidateEntry) -> None:

--- a/packages/api/src/white_api/candidate_server.py
+++ b/packages/api/src/white_api/candidate_server.py
@@ -1175,12 +1175,23 @@ def create_app(
                 rv = _yaml.safe_load(f) or {}
             if "bpm" in rv:
                 rv["bpm"] = new_bpm
-                tmp = review_path.with_suffix(".yml.tmp")
-                with open(tmp, "w") as f:
-                    _yaml.dump(
-                        rv, f, allow_unicode=True, sort_keys=False, width=float("inf")
-                    )
-                tmp.replace(review_path)
+                tmp_fd, tmp_path = tempfile.mkstemp(
+                    dir=review_path.parent, suffix=".yml.tmp"
+                )
+                try:
+                    with os.fdopen(tmp_fd, "w") as f:
+                        _yaml.dump(
+                            rv,
+                            f,
+                            allow_unicode=True,
+                            sort_keys=False,
+                            width=float("inf"),
+                        )
+                    os.replace(tmp_path, review_path)
+                except Exception:
+                    with contextlib.suppress(OSError):
+                        os.unlink(tmp_path)
+                    raise
                 updated_files.append(str(review_path.relative_to(prod)))
 
         # 3. Retime all approved MIDI files
@@ -2113,19 +2124,25 @@ def create_app(
         decided_ids = {c["id"] for c in decided}
         new_candidates = [c for c in new_candidates if c.get("id") not in decided_ids]
         review["candidates"] = decided + new_candidates
-        # Atomic write so a mid-dump crash can't leave review.yml empty.
+        # Atomic write so a mid-dump crash (or a concurrent writer) can't
+        # leave review.yml empty or racing another writer's temp file.
         review_path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = review_path.with_suffix(".yml.tmp")
-        with open(tmp, "w") as f:
-            yaml.dump(
-                review,
-                f,
-                default_flow_style=False,
-                sort_keys=False,
-                allow_unicode=True,
-                width=float("inf"),
-            )
-        tmp.replace(review_path)
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=review_path.parent, suffix=".yml.tmp")
+        try:
+            with os.fdopen(tmp_fd, "w") as f:
+                yaml.dump(
+                    review,
+                    f,
+                    default_flow_style=False,
+                    sort_keys=False,
+                    allow_unicode=True,
+                    width=float("inf"),
+                )
+            os.replace(tmp_path, review_path)
+        except Exception:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
+            raise
         return len(decided)
 
     class EvolveBody(BaseModel):

--- a/packages/client/app/board/page.tsx
+++ b/packages/client/app/board/page.tsx
@@ -5,14 +5,15 @@ import Link from "next/link";
 import {
   fetchSongs, fetchActiveSong, fetchComposition, activateSong, advanceStage, addVersion,
   runNextPhase, getRunStatus, fetchLyrics, approveLyric, promotePhase,
-  autoSplitMelody, assembleMelody, syncArrangement, fetchMixInfo, setMixFile, mixStreamUrl, setBpm,
-  fetchWorkOrders, fetchCollaborators, createDiaryEntry, regressStage,
+  autoSplitMelody, assembleMelody, syncArrangement, fetchSongMixInfo, setMixFile, songMixStreamUrl, setBpm,
+  fetchWorkOrders, fetchCollaborators, regressStage,
   setLifecycleStatus, fetchScrappedSongs, setUsesPartsFrom,
 } from "@/lib/api";
 import { Collaborator, CompositionEntry, LifecycleStatus, LyricCandidate, LyricsResponse, MIX_STAGES, MixStage, RegressionInfo, RunJob, SongEntry, WorkOrder } from "@/lib/types";
 import WorkOrderHud from "@/components/WorkOrderHud";
 import WorkOrderDrawer from "@/components/WorkOrderDrawer";
 import { Combobox, ComboboxOption } from "@/components/Combobox";
+import { NotesButton, SongNotesModal } from "@/components/SongNotes";
 
 const STAGE_LABELS: Record<MixStage, string> = {
   structure:          "Structure",
@@ -102,121 +103,6 @@ function LyricModal({
             </button>
           </div>
         )}
-      </div>
-    </div>
-  );
-}
-
-function DiaryModal({
-  songSlug,
-  defaultPhase,
-  onClose,
-}: {
-  songSlug: string;
-  defaultPhase: string;
-  onClose: () => void;
-}) {
-  const [author, setAuthor] = useState("");
-  const [phase, setPhase] = useState(defaultPhase);
-  const [title, setTitle] = useState("");
-  const [body, setBody] = useState("");
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setSaving(true);
-    setError(null);
-    try {
-      await createDiaryEntry(songSlug, {
-        song_slug: songSlug,
-        author,
-        phase: phase || null,
-        title: title || null,
-        body,
-        tags: [],
-        metadata: {},
-      });
-      onClose();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Save failed");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm"
-      onClick={onClose}
-    >
-      <div
-        className="relative bg-zinc-900 border border-zinc-700 rounded-xl w-full max-w-lg mx-4 flex flex-col shadow-2xl"
-        onClick={e => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between px-5 py-3.5 border-b border-zinc-800 flex-shrink-0">
-          <span className="text-sm font-semibold text-white font-sans">New diary entry</span>
-          <button
-            onClick={onClose}
-            className="text-zinc-500 hover:text-zinc-200 text-lg leading-none transition-colors"
-            aria-label="Close"
-          >
-            ×
-          </button>
-        </div>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-3 px-5 py-4">
-          <div className="flex gap-3">
-            <label className="flex flex-col gap-1 flex-1">
-              <span className="text-[10px] font-sans text-zinc-500 uppercase tracking-wider">Author</span>
-              <input
-                type="text"
-                value={author}
-                onChange={e => setAuthor(e.target.value)}
-                required
-                placeholder="gabriel"
-                className="bg-zinc-800 border border-zinc-700 rounded px-2.5 py-1.5 text-xs font-sans text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500 transition-colors"
-              />
-            </label>
-            <label className="flex flex-col gap-1 flex-1">
-              <span className="text-[10px] font-sans text-zinc-500 uppercase tracking-wider">Phase</span>
-              <input
-                type="text"
-                value={phase}
-                onChange={e => setPhase(e.target.value)}
-                className="bg-zinc-800 border border-zinc-700 rounded px-2.5 py-1.5 text-xs font-sans text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500 transition-colors"
-              />
-            </label>
-          </div>
-          <label className="flex flex-col gap-1">
-            <span className="text-[10px] font-sans text-zinc-500 uppercase tracking-wider">Title</span>
-            <input
-              type="text"
-              value={title}
-              onChange={e => setTitle(e.target.value)}
-              placeholder="optional headline"
-              className="bg-zinc-800 border border-zinc-700 rounded px-2.5 py-1.5 text-xs font-sans text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500 transition-colors"
-            />
-          </label>
-          <label className="flex flex-col gap-1">
-            <span className="text-[10px] font-sans text-zinc-500 uppercase tracking-wider">Body</span>
-            <textarea
-              value={body}
-              onChange={e => setBody(e.target.value)}
-              required
-              rows={4}
-              placeholder="what happened?"
-              className="bg-zinc-800 border border-zinc-700 rounded px-2.5 py-1.5 text-xs font-sans text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500 resize-none transition-colors"
-            />
-          </label>
-          {error && <p className="text-[10px] font-sans text-red-400">{error}</p>}
-          <button
-            type="submit"
-            disabled={saving}
-            className="w-full py-2 text-sm font-sans font-semibold rounded-lg bg-violet-700 hover:bg-violet-600 text-white disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-          >
-            {saving ? "Saving…" : "Save entry"}
-          </button>
-        </form>
       </div>
     </div>
   );
@@ -332,7 +218,7 @@ export default function BoardPage() {
   const [workOrders, setWorkOrders] = useState<WorkOrder[]>([]);
   const [collaborators, setCollaborators] = useState<Collaborator[]>([]);
   const [workOrderDrawerOpen, setWorkOrderDrawerOpen] = useState(false);
-  const [diaryModal, setDiaryModal] = useState<{ stage: MixStage } | null>(null);
+  const [notesOpen, setNotesOpen] = useState(false);
   const [regressionModal, setRegressionModal] = useState<{ targetStage: MixStage; info: RegressionInfo } | null>(null);
   const [confirmingRegress, setConfirmingRegress] = useState(false);
   // Lifecycle panel state
@@ -387,14 +273,19 @@ export default function BoardPage() {
 
   const refresh = useCallback(async () => {
     try {
-      const [comp, active, mixInfo] = await Promise.all([fetchComposition(), fetchActiveSong(), fetchMixInfo()]);
+      const [comp, active] = await Promise.all([fetchComposition(), fetchActiveSong()]);
       if ("status" in comp && comp.status === "not_initialized") {
         setLoadState("not_initialized");
         return;
       }
       setComposition(comp as CompositionEntry);
       setActiveSong(active.active);
-      setMixFileState(mixInfo.has_mix ? mixInfo.mix_file : null);
+      if (active.active) {
+        const mixInfo = await fetchSongMixInfo(active.active.id);
+        setMixFileState(mixInfo.has_mix ? mixInfo.mix_file : null);
+      } else {
+        setMixFileState(null);
+      }
       setLoadState("ready");
       // Load work orders + collaborators in the background (non-blocking)
       fetchWorkOrders().then(setWorkOrders).catch(() => {});
@@ -651,13 +542,9 @@ export default function BoardPage() {
 
   return (
     <div className="min-h-screen bg-zinc-950 text-zinc-200 font-mono">
-      {/* Diary modal */}
-      {diaryModal && composition && (
-        <DiaryModal
-          songSlug={composition.production_slug}
-          defaultPhase={STAGE_LABELS[diaryModal.stage]}
-          onClose={() => setDiaryModal(null)}
-        />
+      {/* Diary / notes modal */}
+      {notesOpen && activeSong && (
+        <SongNotesModal song={activeSong} onClose={() => setNotesOpen(false)} onUpdated={refresh} />
       )}
 
       {/* Regression modal */}
@@ -723,6 +610,9 @@ export default function BoardPage() {
             >
               {addingVersion ? "Adding…" : `+ Version (v${composition.current_version})`}
             </button>
+          )}
+          {activeSong && (
+            <NotesButton title={activeSong.title} onOpen={() => setNotesOpen(true)} label="Diary" />
           )}
         </div>
       </div>
@@ -808,7 +698,7 @@ export default function BoardPage() {
             </div>
           )}
 
-          {mixFile ? (
+          {mixFile && activeSong ? (
             <div className="flex items-center gap-3 bg-zinc-900 border border-zinc-800 rounded-lg px-3 py-2 mb-4">
               <span className="text-[10px] font-sans uppercase tracking-wide text-zinc-600 whitespace-nowrap" title="Full song mix, separate from any per-stage take shown below">
                 Song mix
@@ -816,7 +706,7 @@ export default function BoardPage() {
               <audio
                 key={mixFile}
                 controls
-                src={mixStreamUrl()}
+                src={songMixStreamUrl(activeSong.id)}
                 className="h-8 flex-1 min-w-0"
                 style={{ colorScheme: "dark" }}
               />
@@ -1140,7 +1030,7 @@ export default function BoardPage() {
                             isCurrent ? "bg-zinc-800 border-zinc-700" : "bg-zinc-900 border-zinc-800 opacity-70"
                           }`}
                         >
-                          <div className="flex items-center justify-between gap-1 mb-1.5">
+                          <div className="flex items-center justify-between gap-1">
                             <span className={`text-xs font-semibold ${isCurrent ? "text-zinc-300" : "text-zinc-500"}`}>
                               v{v.version}
                             </span>
@@ -1148,12 +1038,6 @@ export default function BoardPage() {
                               {new Date(v.created).toLocaleDateString()}
                             </span>
                           </div>
-                          <button
-                            onClick={() => setDiaryModal({ stage })}
-                            className="text-[10px] font-sans text-zinc-600 hover:text-zinc-400 transition-colors"
-                          >
-                            + diary entry
-                          </button>
                         </div>
                       ))
                     }

--- a/packages/client/app/sides/page.tsx
+++ b/packages/client/app/sides/page.tsx
@@ -14,10 +14,10 @@ import {
   useSensors,
 } from "@dnd-kit/core";
 import {
-  assignSongToSide, createDiaryEntry, fetchDiaryEntries, fetchSides, fetchSongMixInfo,
-  fetchSongs, moveSongBetweenSides, removeSongFromSide, songMixStreamUrl,
+  assignSongToSide, fetchSides, fetchSongs, moveSongBetweenSides, removeSongFromSide,
 } from "@/lib/api";
-import { DiaryEntry, SideEntry, SideName, SideSong, SidesResponse, SongEntry } from "@/lib/types";
+import { SideEntry, SideName, SideSong, SidesResponse, SongEntry } from "@/lib/types";
+import { NotesButton, SongNotesModal } from "@/components/SongNotes";
 
 const SIDE_NAMES: SideName[] = ["A", "B", "C", "D"];
 
@@ -81,200 +81,6 @@ interface DragPayload {
   fromSide: SideName | null;
 }
 
-function SongNotesModal({ song, onClose }: { song: SongEntry; onClose: () => void }) {
-  const [mixInfo, setMixInfo] = useState<{
-    has_mix: boolean;
-    mix_file: string | null;
-    duration_seconds: number | null;
-  } | null>(null);
-  const [entries, setEntries] = useState<DiaryEntry[]>([]);
-  const [loadingEntries, setLoadingEntries] = useState(true);
-  const [author, setAuthor] = useState("");
-  const [phase, setPhase] = useState("");
-  const [title, setTitle] = useState("");
-  const [body, setBody] = useState("");
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    setMixInfo(null);
-    setLoadingEntries(true);
-
-    fetchSongMixInfo(song.id).then((info) => {
-      if (!cancelled) setMixInfo(info);
-    });
-    fetchDiaryEntries(song.production_slug)
-      .then((fetched) => {
-        if (!cancelled) setEntries([...fetched].reverse());
-      })
-      .catch(() => {
-        if (!cancelled) setEntries([]);
-      })
-      .finally(() => {
-        if (!cancelled) setLoadingEntries(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [song.id, song.production_slug]);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setSaving(true);
-    setError(null);
-    try {
-      const created = await createDiaryEntry(song.production_slug, {
-        song_slug: song.production_slug,
-        author,
-        phase: phase || null,
-        title: title || null,
-        body,
-        tags: [],
-        metadata: {},
-      });
-      setEntries((prev) => [created, ...prev]);
-      setAuthor("");
-      setPhase("");
-      setTitle("");
-      setBody("");
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Save failed");
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm"
-      onClick={onClose}
-    >
-      <div
-        className="relative bg-zinc-900 border border-zinc-700 rounded-xl w-full max-w-lg mx-4 flex flex-col max-h-[85vh] shadow-2xl"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between px-5 py-3.5 border-b border-zinc-800 flex-shrink-0">
-          <span className="text-sm font-semibold text-white font-sans truncate">{song.title}</span>
-          <button
-            onClick={onClose}
-            className="text-zinc-500 hover:text-zinc-200 text-lg leading-none transition-colors"
-            aria-label="Close"
-          >
-            ×
-          </button>
-        </div>
-
-        <div className="px-5 py-3 border-b border-zinc-800/60 flex-shrink-0">
-          {mixInfo === null ? (
-            <p className="text-[11px] font-sans text-zinc-600 italic">Loading mix…</p>
-          ) : mixInfo.has_mix ? (
-            <audio controls src={songMixStreamUrl(song.id)} className="w-full h-9" />
-          ) : (
-            <p className="text-[11px] font-sans text-zinc-600 italic">No mix file yet</p>
-          )}
-        </div>
-
-        <div className="flex-1 overflow-y-auto px-5 py-3 flex flex-col gap-2">
-          {loadingEntries ? (
-            <p className="text-[11px] font-sans text-zinc-600 italic">Loading entries…</p>
-          ) : entries.length === 0 ? (
-            <p className="text-[11px] font-sans text-zinc-600 italic">No diary entries yet</p>
-          ) : (
-            entries.map((entry) => (
-              <div key={entry.id} className="border border-zinc-800 rounded px-3 py-2">
-                <div className="flex items-center justify-between gap-2 text-[10px] font-sans text-zinc-500">
-                  <span>
-                    {entry.author}
-                    {entry.phase ? ` · ${entry.phase}` : ""}
-                  </span>
-                  <span>{new Date(entry.created_at).toLocaleString()}</span>
-                </div>
-                {entry.title && (
-                  <p className="text-xs font-sans font-semibold text-zinc-200 mt-1">{entry.title}</p>
-                )}
-                <p className="text-xs font-sans text-zinc-300 mt-1 whitespace-pre-wrap">{entry.body}</p>
-              </div>
-            ))
-          )}
-        </div>
-
-        <form onSubmit={handleSubmit} className="flex flex-col gap-3 px-5 py-4 border-t border-zinc-800 flex-shrink-0">
-          <div className="flex gap-3">
-            <label className="flex flex-col gap-1 flex-1">
-              <span className="text-[10px] font-sans text-zinc-500 uppercase tracking-wider">Author</span>
-              <input
-                type="text"
-                value={author}
-                onChange={(e) => setAuthor(e.target.value)}
-                required
-                placeholder="gabriel"
-                className="bg-zinc-800 border border-zinc-700 rounded px-2.5 py-1.5 text-xs font-sans text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500 transition-colors"
-              />
-            </label>
-            <label className="flex flex-col gap-1 flex-1">
-              <span className="text-[10px] font-sans text-zinc-500 uppercase tracking-wider">Phase</span>
-              <input
-                type="text"
-                value={phase}
-                onChange={(e) => setPhase(e.target.value)}
-                className="bg-zinc-800 border border-zinc-700 rounded px-2.5 py-1.5 text-xs font-sans text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500 transition-colors"
-              />
-            </label>
-          </div>
-          <label className="flex flex-col gap-1">
-            <span className="text-[10px] font-sans text-zinc-500 uppercase tracking-wider">Title</span>
-            <input
-              type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder="optional headline"
-              className="bg-zinc-800 border border-zinc-700 rounded px-2.5 py-1.5 text-xs font-sans text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500 transition-colors"
-            />
-          </label>
-          <label className="flex flex-col gap-1">
-            <span className="text-[10px] font-sans text-zinc-500 uppercase tracking-wider">Body</span>
-            <textarea
-              value={body}
-              onChange={(e) => setBody(e.target.value)}
-              required
-              rows={4}
-              placeholder="what happened?"
-              className="bg-zinc-800 border border-zinc-700 rounded px-2.5 py-1.5 text-xs font-sans text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500 resize-none transition-colors"
-            />
-          </label>
-          {error && <p className="text-[10px] font-sans text-red-400">{error}</p>}
-          <button
-            type="submit"
-            disabled={saving}
-            className="w-full py-2 text-sm font-sans font-semibold rounded-lg bg-violet-700 hover:bg-violet-600 text-white disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-          >
-            {saving ? "Saving…" : "Save entry"}
-          </button>
-        </form>
-      </div>
-    </div>
-  );
-}
-
-function NotesButton({ title, onOpen }: { title: string; onOpen: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={(e) => {
-        e.stopPropagation();
-        onOpen();
-      }}
-      aria-label={`Listen and add notes for ${title}`}
-      title="Listen / diary notes"
-      className="w-[34px] h-[34px] shrink-0 flex items-center justify-center border border-[var(--ef-gray)] bg-transparent text-[#c9c9c9] hover:text-[var(--ef-orange)] hover:border-[var(--ef-orange)] transition-[color,border-color] duration-500 ease-in-out"
-    >
-      <i className="fa-solid fa-feather-pointed text-[15px]" aria-hidden="true" />
-    </button>
-  );
-}
-
 function AvailableSongRow({
   song,
   onOpenNotes,
@@ -283,6 +89,7 @@ function AvailableSongRow({
   onOpenNotes: (songId: string) => void;
 }) {
   const disabled = !song.has_mix;
+  const considered = song.lp_consideration !== "not_considered";
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `avail:${song.id}`,
     data: { songId: song.id, title: song.title, fromSide: null } satisfies DragPayload,
@@ -296,7 +103,9 @@ function AvailableSongRow({
       className={`px-3 py-2 rounded border text-xs font-sans flex items-center justify-between gap-2 ${
         disabled
           ? "border-zinc-800 text-zinc-600 cursor-not-allowed"
-          : "border-zinc-700 text-zinc-200 cursor-grab hover:border-zinc-500"
+          : considered
+            ? "border-blue-700 bg-blue-800 text-white cursor-grab hover:border-blue-500"
+            : "border-zinc-700 text-zinc-200 cursor-grab hover:border-zinc-500"
       } ${isDragging ? "opacity-40" : ""}`}
       title={disabled ? "No mix file — cannot be sequenced" : "Drag onto a side"}
     >
@@ -341,8 +150,8 @@ function SideSongRow({
       ref={setRefs}
       {...attributes}
       {...listeners}
-      className={`px-3 py-2 rounded border bg-zinc-900 text-xs font-sans text-zinc-200 flex items-center justify-between gap-2 cursor-grab ${
-        isOver ? "border-blue-500" : "border-zinc-700 hover:border-zinc-500"
+      className={`px-3 py-2 rounded border bg-blue-900/10 text-xs font-sans text-zinc-200 flex items-center justify-between gap-2 cursor-grab ${
+        isOver ? "border-blue-400" : "border-blue-800 hover:border-blue-600"
       } ${isDragging ? "opacity-40" : ""}`}
     >
       <span className="truncate">{title}</span>
@@ -533,6 +342,7 @@ export default function SidesPage() {
   );
   const available = songs
     .filter((s) => !assignedIds.has(s.id))
+    .filter((s) => s.lifecycle_status !== "abandoned")
     .filter((s) => showUnmixed || s.has_mix)
     .filter((s) => !poolSearch || s.title.toLowerCase().includes(poolSearch.toLowerCase()));
   const unmixedHiddenCount = songs.filter((s) => !assignedIds.has(s.id) && !s.has_mix).length;
@@ -630,7 +440,7 @@ export default function SidesPage() {
         (() => {
           const notesSong = songs.find((s) => s.id === notesSongId);
           return notesSong ? (
-            <SongNotesModal song={notesSong} onClose={() => setNotesSongId(null)} />
+            <SongNotesModal song={notesSong} onClose={() => setNotesSongId(null)} onUpdated={refresh} />
           ) : null;
         })()}
     </div>

--- a/packages/client/app/sides/page.tsx
+++ b/packages/client/app/sides/page.tsx
@@ -345,7 +345,9 @@ export default function SidesPage() {
     .filter((s) => s.lifecycle_status !== "abandoned")
     .filter((s) => showUnmixed || s.has_mix)
     .filter((s) => !poolSearch || s.title.toLowerCase().includes(poolSearch.toLowerCase()));
-  const unmixedHiddenCount = songs.filter((s) => !assignedIds.has(s.id) && !s.has_mix).length;
+  const unmixedHiddenCount = songs.filter(
+    (s) => !assignedIds.has(s.id) && s.lifecycle_status !== "abandoned" && !s.has_mix,
+  ).length;
   const allAssigned = songs.length > 0 && songs.every((s) => assignedIds.has(s.id));
 
   const totalUsedSeconds = sides

--- a/packages/client/components/SongNotes.tsx
+++ b/packages/client/components/SongNotes.tsx
@@ -224,8 +224,8 @@ export function NotesButton({
         e.stopPropagation();
         onOpen();
       }}
-      aria-label={`Listen and add notes for ${title}`}
-      title="Listen / diary notes"
+      aria-label={label ? `${label} for ${title}` : `Listen and add notes for ${title}`}
+      title={label ? `${label} / diary notes` : "Listen / diary notes"}
       className={`shrink-0 flex items-center justify-center gap-2 border border-[var(--ef-gray)] bg-transparent text-[#c9c9c9] hover:text-[var(--ef-orange)] hover:border-[var(--ef-orange)] transition-[color,border-color] duration-500 ease-in-out ${
         label ? "h-[34px] px-3 text-xs font-sans" : "w-[34px] h-[34px]"
       }`}

--- a/packages/client/components/SongNotes.tsx
+++ b/packages/client/components/SongNotes.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  createDiaryEntry, fetchDiaryEntries, fetchSongMixInfo, setLpConsideration, songMixStreamUrl,
+} from "@/lib/api";
+import { DiaryEntry, SongEntry } from "@/lib/types";
+
+export function SongNotesModal({
+  song,
+  onClose,
+  onUpdated,
+}: {
+  song: SongEntry;
+  onClose: () => void;
+  onUpdated: () => void;
+}) {
+  const [mixInfo, setMixInfo] = useState<{
+    has_mix: boolean;
+    mix_file: string | null;
+    duration_seconds: number | null;
+  } | null>(null);
+  const [entries, setEntries] = useState<DiaryEntry[]>([]);
+  const [loadingEntries, setLoadingEntries] = useState(true);
+  const [phase, setPhase] = useState("");
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [candidatePending, setCandidatePending] = useState(false);
+
+  const handleToggleCandidate = async () => {
+    setCandidatePending(true);
+    try {
+      await setLpConsideration(song.id, song.lp_consideration === "candidate" ? "not_considered" : "candidate");
+      onUpdated();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update candidate status");
+    } finally {
+      setCandidatePending(false);
+    }
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    setMixInfo(null);
+    setLoadingEntries(true);
+
+    fetchSongMixInfo(song.id).then((info) => {
+      if (!cancelled) setMixInfo(info);
+    });
+    fetchDiaryEntries(song.production_slug)
+      .then((fetched) => {
+        if (!cancelled) setEntries([...fetched].reverse());
+      })
+      .catch(() => {
+        if (!cancelled) setEntries([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingEntries(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [song.id, song.production_slug]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    try {
+      const created = await createDiaryEntry(song.production_slug, {
+        song_slug: song.production_slug,
+        author: "gabriel",
+        phase: phase || null,
+        title: title || null,
+        body,
+        tags: [],
+        metadata: {},
+      });
+      setEntries((prev) => [created, ...prev]);
+      setPhase("");
+      setTitle("");
+      setBody("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="relative bg-zinc-900 border border-zinc-700 rounded-xl w-full max-w-lg mx-4 flex flex-col max-h-[85vh] shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-5 py-3.5 border-b border-zinc-800 flex-shrink-0">
+          <span className="text-sm font-semibold text-white font-sans truncate">{song.title}</span>
+          <button
+            onClick={onClose}
+            className="text-zinc-500 hover:text-zinc-200 text-lg leading-none transition-colors"
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="px-5 py-3 border-b border-zinc-800/60 flex-shrink-0 flex items-center gap-3">
+          <div className="flex-1 min-w-0">
+            {mixInfo === null ? (
+              <p className="text-[11px] font-sans text-zinc-600 italic">Loading mix…</p>
+            ) : mixInfo.has_mix ? (
+              <audio controls src={songMixStreamUrl(song.id)} className="w-full h-9" />
+            ) : (
+              <p className="text-[11px] font-sans text-zinc-600 italic">No mix file yet</p>
+            )}
+          </div>
+          {song.lp_consideration === "placed" ? (
+            <span className="text-[10px] font-sans px-2 py-1 rounded border border-blue-800 bg-blue-900/30 text-blue-400 shrink-0">
+              Placed
+            </span>
+          ) : (
+            <button
+              onClick={handleToggleCandidate}
+              disabled={candidatePending}
+              className={`text-[10px] font-sans px-2 py-1 rounded border shrink-0 transition-colors disabled:opacity-50 ${
+                song.lp_consideration === "candidate"
+                  ? "border-blue-800 bg-blue-900/30 text-blue-400 hover:bg-blue-900/50"
+                  : "border-zinc-700 text-zinc-400 hover:border-zinc-500 hover:text-zinc-200"
+              }`}
+            >
+              {song.lp_consideration === "candidate" ? "★ Candidate" : "Mark as Candidate"}
+            </button>
+          )}
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-3 flex flex-col gap-2">
+          {loadingEntries ? (
+            <p className="text-[11px] font-sans text-zinc-600 italic">Loading entries…</p>
+          ) : entries.length === 0 ? (
+            <p className="text-[11px] font-sans text-zinc-600 italic">No diary entries yet</p>
+          ) : (
+            entries.map((entry) => (
+              <div key={entry.id} className="border border-zinc-800 rounded px-3 py-2">
+                <div className="flex items-center justify-between gap-2 text-[10px] font-sans text-zinc-500">
+                  <span>
+                    {entry.author}
+                    {entry.phase ? ` · ${entry.phase}` : ""}
+                  </span>
+                  <span>{new Date(entry.created_at).toLocaleString()}</span>
+                </div>
+                {entry.title && (
+                  <p className="text-xs font-sans font-semibold text-zinc-200 mt-1">{entry.title}</p>
+                )}
+                <p className="text-xs font-sans text-zinc-300 mt-1 whitespace-pre-wrap">{entry.body}</p>
+              </div>
+            ))
+          )}
+        </div>
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-3 px-5 py-4 border-t border-zinc-800 flex-shrink-0">
+          <label className="flex flex-col gap-1">
+            <span className="text-[10px] font-sans text-zinc-500 uppercase tracking-wider">Phase</span>
+            <input
+              type="text"
+              value={phase}
+              onChange={(e) => setPhase(e.target.value)}
+              className="bg-zinc-800 border border-zinc-700 rounded px-2.5 py-1.5 text-xs font-sans text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500 transition-colors"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-[10px] font-sans text-zinc-500 uppercase tracking-wider">Title</span>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="optional headline"
+              className="bg-zinc-800 border border-zinc-700 rounded px-2.5 py-1.5 text-xs font-sans text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500 transition-colors"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-[10px] font-sans text-zinc-500 uppercase tracking-wider">Body</span>
+            <textarea
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              required
+              rows={4}
+              placeholder="what happened?"
+              className="bg-zinc-800 border border-zinc-700 rounded px-2.5 py-1.5 text-xs font-sans text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500 resize-none transition-colors"
+            />
+          </label>
+          {error && <p className="text-[10px] font-sans text-red-400">{error}</p>}
+          <button
+            type="submit"
+            disabled={saving}
+            className="w-full py-2 text-sm font-sans font-semibold rounded-lg bg-violet-700 hover:bg-violet-600 text-white disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            {saving ? "Saving…" : "Save entry"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export function NotesButton({
+  title,
+  onOpen,
+  label,
+}: {
+  title: string;
+  onOpen: () => void;
+  label?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onOpen();
+      }}
+      aria-label={`Listen and add notes for ${title}`}
+      title="Listen / diary notes"
+      className={`shrink-0 flex items-center justify-center gap-2 border border-[var(--ef-gray)] bg-transparent text-[#c9c9c9] hover:text-[var(--ef-orange)] hover:border-[var(--ef-orange)] transition-[color,border-color] duration-500 ease-in-out ${
+        label ? "h-[34px] px-3 text-xs font-sans" : "w-[34px] h-[34px]"
+      }`}
+    >
+      <i className="fa-solid fa-feather-pointed text-[15px]" aria-hidden="true" />
+      {label && <span>{label}</span>}
+    </button>
+  );
+}

--- a/packages/composition/pyproject.toml
+++ b/packages/composition/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "white-composition"
-version = "0.1.1"
+version = "0.2.0"
 description = "Production orchestration, pipeline runner, and candidate review for White project"
 requires-python = ">=3.12"
 dependencies = [

--- a/packages/composition/src/white_composition/shrinkwrap_chain_artifacts.py
+++ b/packages/composition/src/white_composition/shrinkwrap_chain_artifacts.py
@@ -466,9 +466,11 @@ def _extract_time_sig(proposal: dict) -> str:
     "N/N" tempo string, or a flat time_sig field. Defaults to 4/4 when none
     of those are present.
     """
-    tempo = proposal.get("tempo", {})
+    tempo = proposal.get("tempo") or {}
     if isinstance(tempo, dict) and tempo:
-        return f"{tempo.get('numerator', 4)}/{tempo.get('denominator', 4)}"
+        numerator = tempo.get("numerator") or 4
+        denominator = tempo.get("denominator") or 4
+        return f"{numerator}/{denominator}"
     if isinstance(tempo, str) and "/" in tempo:
         return tempo
     time_sig = proposal.get("time_sig")

--- a/packages/composition/src/white_composition/shrinkwrap_chain_artifacts.py
+++ b/packages/composition/src/white_composition/shrinkwrap_chain_artifacts.py
@@ -458,6 +458,25 @@ _SKIP_PROPOSALS = {"evp.yml", "all_song_proposals.yml"}
 _PROPOSAL_REQUIRED_KEYS = {"bpm", "key", "rainbow_color"}
 
 
+def _extract_time_sig(proposal: dict) -> str:
+    """Derive a "N/N" time signature string from a raw proposal dict.
+
+    Mirrors the tempo-parsing in production_plan.load_song_proposal(): a
+    proposal may carry a nested {numerator, denominator} tempo dict, a flat
+    "N/N" tempo string, or a flat time_sig field. Defaults to 4/4 when none
+    of those are present.
+    """
+    tempo = proposal.get("tempo", {})
+    if isinstance(tempo, dict) and tempo:
+        return f"{tempo.get('numerator', 4)}/{tempo.get('denominator', 4)}"
+    if isinstance(tempo, str) and "/" in tempo:
+        return tempo
+    time_sig = proposal.get("time_sig")
+    if isinstance(time_sig, str) and "/" in time_sig:
+        return time_sig
+    return "4/4"
+
+
 def scaffold_song_productions(
     thread_dest_dir: Path, yml_dir: Path, force: bool = False
 ) -> list[str]:
@@ -498,8 +517,10 @@ def scaffold_song_productions(
         bootstrap = {
             "schema_version": SHRINKWRAP_SCHEMA_VERSION,
             "title": proposal.get("title") or slug,
+            "thread_slug": thread_dest_dir.name,
             "key": proposal.get("key"),
             "bpm": proposal.get("bpm"),
+            "time_sig": _extract_time_sig(proposal),
             "rainbow_color": rainbow_color,
             "singer": proposal.get("singer") or None,
             "sounds_like": proposal.get("sounds_like") or [],
@@ -649,9 +670,11 @@ def _synthesize_bootstrap_stub(prod_dir: Path) -> dict:
         "schema_version": SHRINKWRAP_SCHEMA_VERSION,
         "stub": True,
         "title": title,
+        "thread_slug": prod_dir.parent.parent.name,
         "rainbow_color": rainbow_color,
         "bpm": None,
         "key": None,
+        "time_sig": None,
         "singer": None,
     }
     manifest_path = prod_dir / "manifest_bootstrap.yml"

--- a/uv.lock
+++ b/uv.lock
@@ -7525,7 +7525,7 @@ requires-dist = [
 
 [[package]]
 name = "white-api"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "packages/api" }
 dependencies = [
     { name = "fastapi" },
@@ -7558,7 +7558,7 @@ requires-dist = [
 
 [[package]]
 name = "white-composition"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "packages/composition" }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- **Sides screen**: hide abandoned songs from the available-song bank; give candidate/placed songs a shared blue treatment across the available list and ABCD columns (no separate star icon); add a one-click "Mark as Candidate" toggle in the notes modal instead of requiring a drag-in/drag-out round trip; diary entries always attribute to "gabriel".
- **Diary notes**: extracted `SongNotesModal`/`NotesButton` into `components/SongNotes.tsx` and reused on the Board screen, replacing the old per-stage, create-only "+ diary entry" button with a persistent, labeled "Diary" button that shows full history for the active song from any stage.
- **Board mix player fix**: switched to the song-scoped mix endpoints (`/songs/{id}/mix`), which resolve from disk via song_id instead of the server's volatile in-memory active-song state — the old endpoint broke silently whenever the API process restarted.
- **Backend race condition**: fixed `_update_review_yml()` and two similar call sites that wrote their atomic-save temp file to a fixed name instead of a unique one, which could crash concurrent approve/reject requests on the same `review.yml` with `FileNotFoundError`.
- **manifest_bootstrap.yml gaps**: `scaffold_song_productions()` now writes `thread_slug` and a parsed `time_sig` (previously only `song_context.yml` had these, forcing a manual search through the larger file); also backfilled the ~97 existing production manifests on disk (not tracked by git — `shrink_wrapped/` is gitignored).

## Test plan
- [x] `packages/client`: `tsc --noEmit` clean, full `next build` clean
- [x] `uv run pytest -q` (full suite): all green aside from one pre-existing, unrelated flaky Hypothesis test (`test_evp_transmigrational_mode_properties`, passes in isolation)
- [x] `ruff check` clean on all modified Python files
- [x] Manually verified Sides candidate badge/toggle, Board diary button, and Board mix player in-browser

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VW4M971nGo51SnGkVPgD3A