### PR TITLE
Fix melody dedup, MIDI caching, 5/8 templates, lyric/melody generation bugs, and add listening-playlist sync

### DIFF
--- a/openspec/changes/add-listening-playlist-sync/design.md
+++ b/openspec/changes/add-listening-playlist-sync/design.md
@@ -1,0 +1,98 @@
+## Context
+`scan_songs()` in `candidate_server.py` already returns, per song, everything needed to
+classify it: `has_mix`, `lifecycle_status` (`None`/`merged`/`abandoned`/`scrapped`),
+`lp_consideration` (`not_considered`/`candidate`/`placed`), `title`, `production_path`.
+`lp_sides.py`'s `load_sides()` gives the ordered per-side (A–D) song_id list needed for
+WiP sequencing. `song_context.yml`'s `mix_file` field is the absolute path to the actual
+audio file to copy — set via the existing `/songs/{song_id}/mix/set` endpoint, arbitrary
+format (`.mp3`/`.wav`/`.aiff`/`.m4a`).
+
+There is no existing "export to external directory" pattern in the codebase — everything
+so far reads/writes inside `$SHRINKWRAP_OUTPUT_DIR`. This is the first feature that
+writes real files *outside* the repo/album tree, onto the user's Music-import folder.
+
+## Goals / Non-Goals
+- Goals: classify every song with a mix into exactly one of Rejects/Review/WiP (or none,
+  if it has no mix); on each sync, make each destination folder's contents exactly match
+  the current classification (add what's newly matching, remove what no longer is);
+  preserve Side A→D + position order for WiP via filename prefixing so Music/Finder sort
+  order matches intended playback order.
+- Non-Goals: no audio transcoding/format conversion (files are copied byte-for-byte, kept
+  in their original format); no actual Apple Music / iTunes Library API integration —
+  the user drags/imports the synced folders themselves; no incremental/diffed copy
+  (every sync recomputes and rewrites full folder contents, per user's explicit choice);
+  no dedup across the three folders (a song can only ever match one bucket by
+  construction, since the three classifications are mutually exclusive and exhaustive
+  over "has a mix").
+
+## Decisions
+
+- **Decision: classification is computed fresh from `scan_songs()` on every sync, not
+  cached.** There's no new persisted "which bucket is this song in" state — bucket
+  membership is fully derived from existing `lifecycle_status`/`lp_consideration`/
+  `has_mix` fields already on disk. This keeps `playlist_sync.py` a pure
+  classify-then-rebuild function with no state of its own beyond the configurable
+  `output_dir`.
+
+- **Decision: full deterministic rebuild per folder, not incremental.** Each of the 3
+  subfolders (`Rejects/`, `Review/`, `White Album WiP/`) is fully recomputed: existing
+  files not in the new computed set are deleted, files in the new set not yet present
+  are copied. This means a song moving from Review → Rejects (e.g. getting marked
+  Abandoned) cleanly disappears from Review and appears in Rejects on the next sync,
+  with no manual cleanup. Confirmed with the user as the desired behavior over an
+  additive-only approach.
+  - Risk: if `output_dir` is misconfigured to point at a folder containing unrelated
+    files, those files get deleted on sync. Mitigated by scoping deletion to only the 3
+    named subfolders under `output_dir` (never deleting `output_dir` itself or sibling
+    content), and by only ever deleting files this tool itself would have created
+    (matched by extension against known audio formats, to avoid nuking e.g. a stray
+    `.DS_Store` — though harmless, or a user's own unrelated file if they pointed the
+    config at an existing folder).
+
+- **Decision: copy real files, not symlinks.** Confirmed with the user — reliability for
+  phone/car listening (works even if the source production directory is later moved or
+  cleaned up, and definitely resolves correctly when synced via Finder/iCloud/USB to a
+  phone) outweighs the disk-space cost.
+
+- **Decision: WiP filenames get a zero-padded global sequence prefix** —
+  `{seq:02d}_{side}_{sanitized_title}{ext}`, where `seq` runs 1..N across the full
+  Side A→D + in-side-position order (not reset per side), e.g. `01_A_song_one.mp3`,
+  `02_A_song_two.mp3`, `09_B_song_nine.mp3`. This guarantees Finder/Music's default
+  alphabetical file sort exactly matches the intended play order without needing an
+  audio-tagging dependency. Confirmed with the user over writing ID3 track-number tags.
+  - A WiP song not yet assigned to any side (i.e. `lp_consideration == placed` but
+    absent from `sides.yml`) is classified as WiP but placed after all sequenced songs,
+    prefixed `99_unsequenced_{title}{ext}`, so it's still synced (nothing with
+    `lp_consideration == placed` is silently dropped) without corrupting the numbering
+    of songs that *are* sequenced.
+
+- **Decision: `playlist_config.yml` at the album root**, sibling to `sides.yml`, storing
+  only `{output_dir: <path>}`. Not `.env` — confirmed with the user, since `.env` holds
+  secrets and this is a UI-configurable, per-checkout path setting. Created with the
+  default path on first read if absent (same "materialize on first use" pattern as
+  `sides.yml`).
+
+- **Decision: filename collisions within a folder are disambiguated by appending a short
+  suffix from the song's `production_slug`.** Song titles aren't guaranteed unique
+  (two versions/attempts of a song can share a title); sanitized-title-only filenames
+  would silently overwrite each other during copy. Suffix is only appended when a
+  collision is actually detected within that sync's file set, so the common case stays
+  a clean `songtitle.mp3`.
+
+## Risks / Trade-offs
+- Full-rebuild-with-deletion is a destructive operation on a directory outside the repo.
+  Mitigated by scoping to the 3 named subfolders and by validating `output_dir` is set
+  (non-empty, not `/` or the user's home directory root) before any deletion runs.
+- No incremental copy means large libraries re-copy unchanged files' bytes are *not*
+  re-copied — sync only touches files that are new/changed (compares mtime+size before
+  copying) or need deletion; only the *decision* of what belongs in each folder is fully
+  recomputed each time, not the file I/O itself.
+
+## Migration Plan
+Net-new feature; no existing data migrates. `playlist_config.yml` is created with the
+default `output_dir` on first sync if absent, mirroring `sides.yml`'s creation pattern.
+The three destination subfolders are created under `output_dir` on first sync if absent.
+
+## Open Questions
+None outstanding — sync behavior, file placement, WiP ordering mechanism, and config
+location were all confirmed with the user before scaffolding.

--- a/openspec/changes/add-listening-playlist-sync/proposal.md
+++ b/openspec/changes/add-listening-playlist-sync/proposal.md
@@ -1,0 +1,41 @@
+# Change: Add listening-playlist sync (Rejects / Review / White Album WiP)
+
+## Why
+The pipeline now generates a large volume of candidate mixes, and there's no way to
+listen to them away from the desktop — on a phone or in the car — without manually
+copying files around. The user wants a one-button sync that buckets every song with a
+finished mix into 3 folders by its current triage status, so those folders can be
+dragged into Apple Music (or synced via Finder/iCloud) for offline listening.
+
+## What Changes
+- New `playlist_config.yml` at the album root (`$SHRINKWRAP_OUTPUT_DIR/playlist_config.yml`,
+  alongside `sides.yml`/`index.yml`), storing a single configurable `output_dir` (default
+  `/Users/gabrielwalsh/Documents/Music Production/Earthly Frames/White/Listening`).
+- New `packages/composition/src/white_composition/playlist_sync.py` module (mirroring the
+  `lp_sides.py` pattern): reads/writes `playlist_config.yml`, classifies songs into
+  Rejects / Review / White Album WiP per the rules below, and performs a full
+  deterministic rebuild of each of the 3 destination subfolders (copy real mix files in,
+  remove anything no longer matching).
+  - **Rejects**: `lifecycle_status in {scrapped, abandoned}` AND `has_mix`.
+  - **Review**: `lp_consideration != placed` AND `lifecycle_status not in {scrapped,
+    abandoned}` AND `has_mix`.
+  - **White Album WiP**: `lp_consideration == placed`. Ordered by `sides.yml`'s Side
+    A→D order and in-side position; filenames get a zero-padded sequence prefix
+    (`01_A_songtitle.mp3`) so Music/Finder sort matches the intended play order.
+- New `candidate_server.py` endpoints: `GET /playlists/config`, `POST /playlists/config`
+  (update `output_dir`), `POST /playlists/sync` (runs the rebuild, returns per-folder
+  counts).
+- New "Sync to Playlists" button plus an inline output-directory field on the existing
+  Sides page (`packages/client/app/sides/page.tsx`), showing a result summary
+  (`Rejects: 5, Review: 12, White Album WiP: 9`) after sync.
+
+## Impact
+- Affected specs: `listening-playlist-sync` (new capability)
+- Affected code: `packages/api/src/white_api/candidate_server.py` (new endpoints), new
+  `packages/composition/src/white_composition/playlist_sync.py`, new
+  `packages/client/lib/api.ts` additions, `packages/client/app/sides/page.tsx`
+- No changes to `lp-side-sequencing` behavior — this change only *reads* `sides.yml`,
+  it doesn't write to it.
+- Branch: stays on the current feature branch (`feature/dupes` — see note below) per
+  user instruction; treated as part of this in-flight feature branch rather than a new
+  one.

--- a/openspec/changes/add-listening-playlist-sync/specs/listening-playlist-sync/spec.md
+++ b/openspec/changes/add-listening-playlist-sync/specs/listening-playlist-sync/spec.md
@@ -1,0 +1,102 @@
+## ADDED Requirements
+
+### Requirement: Playlist Output Configuration
+The system SHALL persist a configurable playlist output directory in
+`playlist_config.yml` at the album root (`$SHRINKWRAP_OUTPUT_DIR/playlist_config.yml`),
+defaulting to `/Users/gabrielwalsh/Documents/Music Production/Earthly Frames/White/Listening`
+when unset.
+
+#### Scenario: Default config on first read
+- **WHEN** no `playlist_config.yml` exists and the config is read
+- **THEN** the default `output_dir` is returned and the file is materialized on disk
+  with that default
+
+#### Scenario: Config update persists
+- **WHEN** `POST /playlists/config` is called with a new `output_dir`
+- **THEN** subsequent reads (and subsequent syncs) use the new directory
+
+### Requirement: Song Classification Into Three Buckets
+The system SHALL classify every song with `has_mix: true` into exactly one of three
+mutually-exclusive buckets — Rejects, Review, or White Album WiP — based on
+`lifecycle_status` and `lp_consideration`. Songs without a mix are excluded from all
+three buckets.
+
+#### Scenario: Rejects bucket
+- **WHEN** a song has `has_mix: true` and `lifecycle_status` is `scrapped` or
+  `abandoned`
+- **THEN** it is classified into Rejects
+
+#### Scenario: Review bucket
+- **WHEN** a song has `has_mix: true`, `lp_consideration` is not `placed`, and
+  `lifecycle_status` is neither `scrapped` nor `abandoned`
+- **THEN** it is classified into Review
+
+#### Scenario: White Album WiP bucket
+- **WHEN** a song has `has_mix: true` and `lp_consideration` is `placed`
+- **THEN** it is classified into White Album WiP, regardless of `lifecycle_status`
+
+#### Scenario: No mix excludes from all buckets
+- **WHEN** a song has `has_mix: false`
+- **THEN** it does not appear in Rejects, Review, or White Album WiP regardless of its
+  other status fields
+
+### Requirement: White Album WiP Sequencing
+White Album WiP files SHALL be named so that a default alphabetical file sort (as used
+by Finder and Apple Music folder import) matches the Side A→D, in-side-position order
+recorded in `sides.yml`.
+
+#### Scenario: Sequenced song numeric prefix
+- **WHEN** a WiP song is present in `sides.yml` at side `S` and position `P`
+- **THEN** its synced filename is prefixed `{seq:02d}_{S}_`, where `seq` is a global
+  1-based counter across all sides in A→D, in-side-position order
+
+#### Scenario: Unsequenced placed song
+- **WHEN** a song has `lp_consideration == placed` but is absent from every side in
+  `sides.yml`
+- **THEN** it is still synced into White Album WiP, with a filename prefix that sorts
+  after every sequenced song (e.g. `99_unsequenced_`)
+
+### Requirement: Full Deterministic Folder Rebuild
+Each sync SHALL make each of the 3 destination subfolders under `output_dir` exactly
+match the current classification: copying in newly-matching songs' mix files and
+deleting any existing file in that subfolder no longer classified into it.
+
+#### Scenario: New match is copied in
+- **WHEN** a song newly matches a bucket's criteria that it didn't match on the
+  previous sync
+- **THEN** its mix file is copied into that bucket's subfolder on the next sync
+
+#### Scenario: Stale file is removed
+- **WHEN** a song no longer matches the criteria for the bucket its file currently sits
+  in (e.g. a Review song is later marked Abandoned)
+- **THEN** its file is removed from that bucket's subfolder on the next sync (it may
+  reappear in a different bucket's subfolder if it now matches that bucket)
+
+#### Scenario: Unrelated content outside the 3 subfolders is untouched
+- **WHEN** a sync runs
+- **THEN** only files inside the `Rejects/`, `Review/`, and `White Album WiP/`
+  subfolders of `output_dir` are added or removed; nothing else under `output_dir`, and
+  nothing outside it, is modified
+
+#### Scenario: Unchanged files are not re-copied
+- **WHEN** a song's target file already exists in its bucket's subfolder with a
+  matching size and an mtime no older than the source mix file
+- **THEN** the file is left in place rather than being re-copied
+
+### Requirement: Sync Trigger and Result Reporting
+The system SHALL expose a sync action via `POST /playlists/sync` returning per-bucket
+counts, and the client SHALL expose this as a button on the Sides page.
+
+#### Scenario: Sync returns counts
+- **WHEN** `POST /playlists/sync` completes
+- **THEN** the response includes `{"rejects": <int>, "review": <int>, "wip": <int>}`
+  reflecting the number of files present in each subfolder after the rebuild
+
+#### Scenario: Button triggers sync from the Sides page
+- **WHEN** the user clicks "Sync to Playlists" on the Sides page
+- **THEN** `POST /playlists/sync` is called and the returned counts are displayed to
+  the user
+
+#### Scenario: Misconfigured output directory refuses to sync
+- **WHEN** `output_dir` is empty, `/`, or a user's home directory root
+- **THEN** the sync is refused with an error rather than performing any file deletion

--- a/openspec/changes/add-listening-playlist-sync/tasks.md
+++ b/openspec/changes/add-listening-playlist-sync/tasks.md
@@ -1,0 +1,56 @@
+## 1. Playlist config
+- [x] 1.1 Define `playlist_config.yml` read/write helpers in
+      `packages/composition/src/white_composition/playlist_sync.py`:
+      `load_playlist_config(album_dir)`, `save_playlist_config(album_dir, config)`,
+      materializing the default `output_dir` if the file is absent
+- [x] 1.2 Unit tests: default config on first read, round-trip save/load, updating
+      `output_dir`
+
+## 2. Classification
+- [x] 2.1 Implement `classify_songs(songs, sides_doc) -> dict[str, list[SongEntry]]`
+      returning `{"rejects": [...], "review": [...], "wip": [...]}` per the rules in
+      `proposal.md`, given `scan_songs()` output and a loaded `SidesDocument`
+- [x] 2.2 WiP ordering: songs present in `sides.yml` ordered by Side A→D + in-side
+      position; songs with `lp_consideration == placed` but absent from `sides.yml`
+      appended at the end (unsequenced)
+- [x] 2.3 Unit tests: each of the 3 buckets' membership rules (including the "has no
+      mix" exclusion and the mutual-exclusivity of the 3 buckets), WiP ordering with a
+      mix of sequenced/unsequenced placed songs
+
+## 3. Filesystem rebuild
+- [x] 3.1 Implement `sync_playlists(songs, sides_doc, output_dir) -> dict[str, int]`:
+      for each of the 3 subfolders, compute the target filename set (sanitized title +
+      collision-suffix rule for Rejects/Review, numeric-prefix rule for WiP per
+      `design.md`), copy any file whose target doesn't yet exist or whose source has a
+      newer mtime/different size, delete any existing file in the subfolder not in the
+      target set, and return per-folder synced counts
+- [x] 3.2 Filename sanitization helper (strip characters invalid in filenames, preserve
+      source extension)
+- [x] 3.3 Guard against a misconfigured `output_dir` (empty, `/`, or home directory
+      root) — refuse to sync rather than deleting broadly
+- [x] 3.4 Unit tests against a temp directory: full rebuild adds new files, removes
+      stale ones, leaves unrelated files/folders outside the 3 subfolders untouched,
+      collision suffixing, WiP numeric prefixing order
+
+## 4. API endpoints
+- [x] 4.1 `GET /playlists/config` — return current `output_dir`
+- [x] 4.2 `POST /playlists/config` — update `output_dir` (body: `{output_dir}`)
+- [x] 4.3 `POST /playlists/sync` — run classification + rebuild, return
+      `{"rejects": n, "review": n, "wip": n}`
+- [x] 4.4 Integration tests in `packages/api/tests` covering the above against a temp
+      album dir with fixture manifests/mixes across all 3 buckets
+
+## 5. Client UI
+- [x] 5.1 `lib/api.ts` additions: `fetchPlaylistConfig`, `setPlaylistConfig`,
+      `syncPlaylists`
+- [x] 5.2 Sides page (`packages/client/app/sides/page.tsx`): inline editable
+      output-directory field (loads current value, saves via `setPlaylistConfig`) and
+      a "Sync to Playlists" button
+- [x] 5.3 Post-sync result display: per-folder counts (`Rejects: 5, Review: 12, White
+      Album WiP: 9`) and an error state if sync fails (e.g. misconfigured directory)
+- [x] 5.4 Manual verification: verified against a fixture album (not real data) via
+      direct API calls through the running server/client stack — confirmed correct
+      bucketing and Side A→D WiP filename ordering on disk (`01_A_...`, `02_B_...`).
+      The Chrome browser extension wasn't connected this session, so the actual button
+      click wasn't exercised visually in a real browser tab — worth a quick manual
+      click-through against real data before considering this fully done end-to-end.

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "white-api"
-version = "0.2.1"
+version = "0.3.0"
 description = "Candidate browser server and song dashboard for White project"
 requires-python = ">=3.12"
 dependencies = [

--- a/packages/api/src/white_api/candidate_server.py
+++ b/packages/api/src/white_api/candidate_server.py
@@ -1390,15 +1390,13 @@ def create_app(
     class MixFileBody(BaseModel):
         path: str
 
-    @app.post("/production/mix/set")
-    def set_mix_file(body: MixFileBody):
-        prod = _require_production_dir()
+    def _write_mix_file(prod: Path, path: str) -> None:
         ctx_path = prod / "song_context.yml"
         if not ctx_path.exists():
             raise HTTPException(status_code=404, detail="song_context.yml not found")
         with open(ctx_path) as f:
             ctx = yaml.safe_load(f) or {}
-        ctx["mix_file"] = body.path
+        ctx["mix_file"] = path
         with open(ctx_path, "w") as f:
             yaml.dump(
                 ctx,
@@ -1408,6 +1406,21 @@ def create_app(
                 allow_unicode=True,
                 width=float("inf"),
             )
+
+    @app.post("/production/mix/set")
+    def set_mix_file(body: MixFileBody):
+        prod = _require_production_dir()
+        _write_mix_file(prod, body.path)
+        return {"ok": True, "mix_file": body.path}
+
+    @app.post("/songs/{song_id}/mix/set")
+    def set_song_mix_file(song_id: str, body: MixFileBody):
+        """Song-scoped mix write — resolves the production dir from song_id
+        directly rather than the mutable `_production_dir` global, so a
+        stale/desynced active-song pointer can't attach a mix to the wrong song.
+        """
+        _, prod_dir = _resolve_song(song_id)
+        _write_mix_file(prod_dir, body.path)
         return {"ok": True, "mix_file": body.path}
 
     @app.get("/production/mix")
@@ -1635,6 +1648,44 @@ def create_app(
         return FileResponse(str(mix_path), media_type=media_type)
 
     # ------------------------------------------------------------------
+    # Listening-playlist sync
+    # ------------------------------------------------------------------
+
+    @app.get("/playlists/config")
+    def get_playlist_config():
+        from white_composition.playlist_sync import load_playlist_config
+
+        album_dir = _require_shrink_wrapped_dir()
+        config = load_playlist_config(album_dir)
+        return {"output_dir": config.output_dir}
+
+    class PlaylistConfigBody(BaseModel):
+        output_dir: str
+
+    @app.post("/playlists/config")
+    def set_playlist_config(body: PlaylistConfigBody):
+        from white_composition.playlist_sync import PlaylistConfig, save_playlist_config
+
+        album_dir = _require_shrink_wrapped_dir()
+        save_playlist_config(album_dir, PlaylistConfig(output_dir=body.output_dir))
+        return {"ok": True, "output_dir": body.output_dir}
+
+    @app.post("/playlists/sync")
+    def sync_playlists_endpoint():
+        from white_composition.lp_sides import load_sides
+        from white_composition.playlist_sync import load_playlist_config, sync_playlists
+
+        album_dir = _require_shrink_wrapped_dir()
+        config = load_playlist_config(album_dir)
+        sides_doc = load_sides(album_dir)
+        songs = scan_songs(album_dir)
+        try:
+            counts = sync_playlists(songs, sides_doc, config.output_dir)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        return counts
+
+    # ------------------------------------------------------------------
     # Lyrics review
     # ------------------------------------------------------------------
 
@@ -1806,6 +1857,29 @@ def create_app(
             path=str(entry.midi_file),
             media_type="audio/midi",
             filename=entry.midi_file.name,
+            headers={"Cache-Control": "no-store"},
+        )
+
+    @app.get("/songs/{song_id}/midi/{candidate_id}")
+    def get_song_midi(song_id: str, candidate_id: str):
+        """Song-scoped MIDI lookup — bypasses the mutable `_production_dir`
+        global so candidate ids that repeat across songs (e.g. chord_001..010)
+        can't resolve against whichever song was last activated.
+        """
+        _, prod_dir = _resolve_song(song_id)
+        entries = load_all_candidates(prod_dir)
+        entry = next((e for e in entries if e.candidate_id == candidate_id), None)
+        if entry is None:
+            raise HTTPException(
+                status_code=404, detail=f"Candidate '{candidate_id}' not found"
+            )
+        if not entry.midi_file.exists():
+            raise HTTPException(status_code=404, detail="MIDI file not found")
+        return FileResponse(
+            path=str(entry.midi_file),
+            media_type="audio/midi",
+            filename=entry.midi_file.name,
+            headers={"Cache-Control": "no-store"},
         )
 
     @app.get("/production-dir")

--- a/packages/api/tests/test_sides_api.py
+++ b/packages/api/tests/test_sides_api.py
@@ -22,11 +22,18 @@ def _make_song(
     production_slug: str,
     *,
     mix_seconds: float | None = None,
+    lifecycle_status: str | None = None,
+    lp_consideration: str | None = None,
 ) -> str:
     prod_dir = root / thread_slug / "production" / production_slug
     prod_dir.mkdir(parents=True, exist_ok=True)
+    manifest: dict = {"title": production_slug, "rainbow_color": "Red"}
+    if lifecycle_status is not None:
+        manifest["lifecycle_status"] = lifecycle_status
+    if lp_consideration is not None:
+        manifest["lp_consideration"] = lp_consideration
     with open(prod_dir / "manifest_bootstrap.yml", "w") as f:
-        yaml.dump({"title": production_slug, "rainbow_color": "Red"}, f)
+        yaml.dump(manifest, f)
 
     if mix_seconds is not None:
         mix_path = prod_dir / "mix.wav"
@@ -282,3 +289,189 @@ class TestLpConsiderationAutoTransitions:
         (sw_dir / "thread-a" / "production" / "song_one" / "mix.wav").unlink()
         client.delete(f"/sides/A/songs/{song_id}")
         assert _lp_consideration(client, song_id) == "not_considered"
+
+
+def _write_chord_candidate(
+    prod_dir: Path, candidate_id: str, midi_bytes: bytes
+) -> None:
+    """Write a minimal chords/review.yml + matching candidate MIDI file.
+
+    Used to reproduce candidate id collisions across songs — every song's
+    chord candidates are literally named chord_001..chord_010, so two
+    different songs can share the exact same candidate_id.
+    """
+    review_dir = prod_dir / "chords"
+    review_dir.mkdir(parents=True, exist_ok=True)
+    with open(review_dir / "review.yml", "w") as f:
+        yaml.dump(
+            {
+                "candidates": [
+                    {
+                        "id": candidate_id,
+                        "midi_file": f"candidates/{candidate_id}.mid",
+                        "rank": 1,
+                        "status": "pending",
+                        "scores": {"composite": 0.5, "theory": {}, "chromatic": {}},
+                    }
+                ]
+            },
+            f,
+        )
+    midi_path = review_dir / "candidates" / f"{candidate_id}.mid"
+    midi_path.parent.mkdir(parents=True, exist_ok=True)
+    midi_path.write_bytes(midi_bytes)
+
+
+class TestSongScopedMidi:
+    """The unscoped /midi/{candidate_id} route resolves against whichever
+    song the server's global `_production_dir` currently points at — since
+    candidate ids like chord_001 repeat across every song, that route can't
+    disambiguate. /songs/{song_id}/midi/{candidate_id} resolves directly from
+    the URL instead.
+    """
+
+    def test_distinguishes_same_candidate_id_across_songs(self, sw_dir, client):
+        song_a = _make_song(sw_dir, "thread-a", "song_one")
+        song_b = _make_song(sw_dir, "thread-b", "song_two")
+        _write_chord_candidate(
+            sw_dir / "thread-a" / "production" / "song_one", "chord_001", b"AAAA"
+        )
+        _write_chord_candidate(
+            sw_dir / "thread-b" / "production" / "song_two", "chord_001", b"BBBB"
+        )
+
+        resp_a = client.get(f"/songs/{song_a}/midi/chord_001")
+        resp_b = client.get(f"/songs/{song_b}/midi/chord_001")
+        assert resp_a.status_code == 200
+        assert resp_b.status_code == 200
+        assert resp_a.content == b"AAAA"
+        assert resp_b.content == b"BBBB"
+
+    def test_ignores_stale_active_song_global(self, sw_dir, client):
+        song_a = _make_song(sw_dir, "thread-a", "song_one")
+        song_b = _make_song(sw_dir, "thread-b", "song_two")
+        _write_chord_candidate(
+            sw_dir / "thread-a" / "production" / "song_one", "chord_001", b"AAAA"
+        )
+        _write_chord_candidate(
+            sw_dir / "thread-b" / "production" / "song_two", "chord_001", b"BBBB"
+        )
+
+        # Activate song A globally, then request song B's candidate by URL —
+        # the response must reflect the URL, not the stale active-song global.
+        assert client.post("/songs/activate", json={"id": song_a}).status_code == 200
+        resp = client.get(f"/songs/{song_b}/midi/chord_001")
+        assert resp.content == b"BBBB"
+
+    def test_unknown_song_returns_404(self, sw_dir, client):
+        resp = client.get("/songs/does-not-exist/midi/chord_001")
+        assert resp.status_code == 404
+
+    def test_unknown_candidate_returns_404(self, sw_dir, client):
+        song_a = _make_song(sw_dir, "thread-a", "song_one")
+        _write_chord_candidate(
+            sw_dir / "thread-a" / "production" / "song_one", "chord_001", b"AAAA"
+        )
+        resp = client.get(f"/songs/{song_a}/midi/ghost_candidate")
+        assert resp.status_code == 404
+
+    def test_response_has_no_store_cache_control(self, sw_dir, client):
+        song_a = _make_song(sw_dir, "thread-a", "song_one")
+        _write_chord_candidate(
+            sw_dir / "thread-a" / "production" / "song_one", "chord_001", b"AAAA"
+        )
+        resp = client.get(f"/songs/{song_a}/midi/chord_001")
+        assert resp.headers.get("cache-control") == "no-store"
+
+
+class TestSongScopedMixSet:
+    """POST /production/mix/set writes into whichever production dir the
+    server's global `_production_dir` currently points at.
+    /songs/{song_id}/mix/set resolves the production dir from the URL
+    instead, so it can't attach a mix to the wrong song when the global is
+    stale or was never pointed at the right song in the first place.
+    """
+
+    def test_writes_only_to_the_targeted_song(self, sw_dir, client):
+        _make_song(sw_dir, "thread-a", "song_one", mix_seconds=1.0)
+        song_b = _make_song(sw_dir, "thread-b", "song_two", mix_seconds=1.0)
+
+        resp = client.post(f"/songs/{song_b}/mix/set", json={"path": "/tmp/new_b.mp3"})
+        assert resp.status_code == 200
+
+        prod_a = sw_dir / "thread-a" / "production" / "song_one"
+        prod_b = sw_dir / "thread-b" / "production" / "song_two"
+        with open(prod_b / "song_context.yml") as f:
+            assert yaml.safe_load(f)["mix_file"] == "/tmp/new_b.mp3"
+        with open(prod_a / "song_context.yml") as f:
+            assert yaml.safe_load(f)["mix_file"] != "/tmp/new_b.mp3"
+
+    def test_ignores_stale_active_song_global(self, sw_dir, client):
+        song_a = _make_song(sw_dir, "thread-a", "song_one", mix_seconds=1.0)
+        song_b = _make_song(sw_dir, "thread-b", "song_two", mix_seconds=1.0)
+
+        # Activate song A globally, then write a mix for song B via URL — it
+        # must land in song B's context, not the globally-active song A's.
+        assert client.post("/songs/activate", json={"id": song_a}).status_code == 200
+        client.post(f"/songs/{song_b}/mix/set", json={"path": "/tmp/new_b.mp3"})
+
+        prod_a = sw_dir / "thread-a" / "production" / "song_one"
+        prod_b = sw_dir / "thread-b" / "production" / "song_two"
+        with open(prod_b / "song_context.yml") as f:
+            assert yaml.safe_load(f)["mix_file"] == "/tmp/new_b.mp3"
+        with open(prod_a / "song_context.yml") as f:
+            assert yaml.safe_load(f)["mix_file"] != "/tmp/new_b.mp3"
+
+    def test_unknown_song_returns_404(self, client):
+        resp = client.post("/songs/does-not-exist/mix/set", json={"path": "/tmp/x.mp3"})
+        assert resp.status_code == 404
+
+
+class TestPlaylistEndpoints:
+    def test_config_defaults_and_materializes(self, sw_dir, client):
+        resp = client.get("/playlists/config")
+        assert resp.status_code == 200
+        assert "Listening" in resp.json()["output_dir"]
+        assert (sw_dir / "playlist_config.yml").exists()
+
+    def test_config_update_persists(self, sw_dir, client, tmp_path):
+        new_dir = str(tmp_path / "MyListening")
+        resp = client.post("/playlists/config", json={"output_dir": new_dir})
+        assert resp.status_code == 200
+
+        resp = client.get("/playlists/config")
+        assert resp.json()["output_dir"] == new_dir
+
+    def test_sync_buckets_songs_correctly(self, sw_dir, client, tmp_path):
+        _make_song(
+            sw_dir,
+            "thread-a",
+            "rejected_song",
+            mix_seconds=10.0,
+            lifecycle_status="scrapped",
+        )
+        _make_song(sw_dir, "thread-a", "review_song", mix_seconds=10.0)
+        placed_id = _make_song(
+            sw_dir,
+            "thread-a",
+            "placed_song",
+            mix_seconds=10.0,
+            lp_consideration="placed",
+        )
+        _make_song(sw_dir, "thread-a", "no_mix_song")
+
+        output_dir = tmp_path / "Listening"
+        client.post("/playlists/config", json={"output_dir": str(output_dir)})
+        client.post("/sides/A/assign", json={"song_id": placed_id, "position": 0})
+
+        resp = client.post("/playlists/sync")
+        assert resp.status_code == 200
+        assert resp.json() == {"rejects": 1, "review": 1, "wip": 1}
+        assert (output_dir / "Rejects" / "REJECT_rejected_song.wav").exists()
+        assert (output_dir / "Review" / "review_song.wav").exists()
+        assert (output_dir / "White Album WiP" / "01_A_placed_song.wav").exists()
+
+    def test_sync_rejects_unsafe_output_dir(self, sw_dir, client):
+        client.post("/playlists/config", json={"output_dir": ""})
+        resp = client.post("/playlists/sync")
+        assert resp.status_code == 400

--- a/packages/client/app/board/page.tsx
+++ b/packages/client/app/board/page.tsx
@@ -450,7 +450,7 @@ export default function BoardPage() {
     setSettingMix(true);
     setError(null);
     try {
-      await setMixFile(mixPathInput.trim());
+      await setMixFile(mixPathInput.trim(), activeSong?.id);
       setMixFileState(mixPathInput.trim());
       setMixPathInput("");
       setShowMixInput(false);

--- a/packages/client/app/candidates/page.tsx
+++ b/packages/client/app/candidates/page.tsx
@@ -596,7 +596,7 @@ export default function CandidatesPage() {
                 {playingId === c.id && (
                   <tr key={`${c.id}-player`} className="bg-zinc-900/60 border-b border-zinc-800/60">
                     <td colSpan={9} className="px-4 py-3">
-                      <MidiPlayer url={midiUrl(c.id)} />
+                      <MidiPlayer url={midiUrl(c.id, activeSong?.id)} />
                     </td>
                   </tr>
                 )}

--- a/packages/client/app/sides/page.tsx
+++ b/packages/client/app/sides/page.tsx
@@ -14,7 +14,8 @@ import {
   useSensors,
 } from "@dnd-kit/core";
 import {
-  assignSongToSide, fetchSides, fetchSongs, moveSongBetweenSides, removeSongFromSide,
+  assignSongToSide, fetchPlaylistConfig, fetchSides, fetchSongs, moveSongBetweenSides,
+  removeSongFromSide, setPlaylistConfig, syncPlaylists,
 } from "@/lib/api";
 import { SideEntry, SideName, SideSong, SidesResponse, SongEntry } from "@/lib/types";
 import { NotesButton, SongNotesModal } from "@/components/SongNotes";
@@ -238,8 +239,46 @@ export default function SidesPage() {
   const [poolSearch, setPoolSearch] = useState("");
   const [showUnmixed, setShowUnmixed] = useState(false);
   const [notesSongId, setNotesSongId] = useState<string | null>(null);
+  const [playlistDirInput, setPlaylistDirInput] = useState("");
+  const [savingPlaylistDir, setSavingPlaylistDir] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [syncResult, setSyncResult] = useState<{ rejects: number; review: number; wip: number } | null>(null);
+  const [syncError, setSyncError] = useState<string | null>(null);
 
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 4 } }));
+
+  useEffect(() => {
+    fetchPlaylistConfig()
+      .then((config) => setPlaylistDirInput(config.output_dir))
+      .catch(() => {});
+  }, []);
+
+  const handleSavePlaylistDir = async () => {
+    if (!playlistDirInput.trim()) return;
+    setSavingPlaylistDir(true);
+    setSyncError(null);
+    try {
+      await setPlaylistConfig(playlistDirInput.trim());
+    } catch (e) {
+      setSyncError(e instanceof Error ? e.message : "Failed to save output directory");
+    } finally {
+      setSavingPlaylistDir(false);
+    }
+  };
+
+  const handleSync = async () => {
+    setSyncing(true);
+    setSyncError(null);
+    setSyncResult(null);
+    try {
+      const result = await syncPlaylists();
+      setSyncResult(result);
+    } catch (e) {
+      setSyncError(e instanceof Error ? e.message : "Sync failed");
+    } finally {
+      setSyncing(false);
+    }
+  };
 
   const refresh = useCallback(() => {
     Promise.all([fetchSongs(), fetchSides()])
@@ -367,6 +406,34 @@ export default function SidesPage() {
             Total: <span className="text-zinc-300">{formatDuration(totalUsedSeconds)}</span> / {formatDuration(totalTargetSeconds)} across {SIDE_NAMES.length} sides
           </span>
         )}
+      </div>
+
+      <div className="border-b border-zinc-800 px-6 py-3 flex items-center gap-3">
+        <span className="text-xs font-sans text-zinc-500 shrink-0">Playlist output:</span>
+        <input
+          type="text"
+          value={playlistDirInput}
+          onChange={(e) => setPlaylistDirInput(e.target.value)}
+          onBlur={handleSavePlaylistDir}
+          placeholder="/path/to/Listening"
+          className="flex-1 max-w-xl bg-zinc-900 border border-zinc-700 rounded px-2 py-1 text-xs font-sans text-zinc-200 placeholder-zinc-600 focus:outline-none focus:border-zinc-500"
+        />
+        {savingPlaylistDir && <span className="text-[11px] text-zinc-600 font-sans">saving…</span>}
+        <button
+          onClick={handleSync}
+          disabled={syncing}
+          className="px-3 py-1 rounded border border-blue-700 bg-blue-950/40 text-xs font-sans text-blue-300 hover:bg-blue-950/70 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {syncing ? "Syncing…" : "Sync to Playlists"}
+        </button>
+        {syncResult && (
+          <span className="text-xs font-sans text-zinc-400">
+            Rejects: <span className="text-zinc-200">{syncResult.rejects}</span>, Review:{" "}
+            <span className="text-zinc-200">{syncResult.review}</span>, White Album WiP:{" "}
+            <span className="text-zinc-200">{syncResult.wip}</span>
+          </span>
+        )}
+        {syncError && <span className="text-xs font-sans text-red-400">{syncError}</span>}
       </div>
 
       {error && (

--- a/packages/client/app/sides/page.tsx
+++ b/packages/client/app/sides/page.tsx
@@ -271,6 +271,14 @@ export default function SidesPage() {
     setSyncError(null);
     setSyncResult(null);
     try {
+      // Clicking this button blurs the directory input, which also fires
+      // handleSavePlaylistDir (onBlur) — that save and this sync would race
+      // if we didn't also save here first: awaiting it before syncing
+      // guarantees the sync always uses the latest typed directory rather
+      // than whatever was last persisted.
+      if (playlistDirInput.trim()) {
+        await setPlaylistConfig(playlistDirInput.trim());
+      }
       const result = await syncPlaylists();
       setSyncResult(result);
     } catch (e) {

--- a/packages/client/lib/api.ts
+++ b/packages/client/lib/api.ts
@@ -41,7 +41,13 @@ export async function setLabel(id: string, label: string) {
   return res.json();
 }
 
-export function midiUrl(id: string) {
+export function midiUrl(id: string, songId?: string) {
+  // Song-scoped when possible: candidate ids (e.g. chord_001) repeat across
+  // every song, so the unscoped route can resolve against whichever song the
+  // server last activated. Scoping by songId gives each song a distinct URL.
+  if (songId) {
+    return `${BASE}/songs/${encodeURIComponent(songId)}/midi/${encodeURIComponent(id)}`;
+  }
   return `${BASE}/midi/${encodeURIComponent(id)}`;
 }
 
@@ -449,8 +455,15 @@ export async function fetchMixInfo(): Promise<{ has_mix: boolean; mix_file: stri
   return res.json();
 }
 
-export async function setMixFile(path: string): Promise<void> {
-  const res = await fetch(`${BASE}/production/mix/set`, {
+export async function setMixFile(path: string, songId?: string): Promise<void> {
+  // Song-scoped when possible: the unscoped route writes into whichever
+  // production dir the server's global "active song" currently points at,
+  // which can desync from what's on screen. Scoping by songId resolves the
+  // production dir directly from the request instead.
+  const url = songId
+    ? `${BASE}/songs/${encodeURIComponent(songId)}/mix/set`
+    : `${BASE}/production/mix/set`;
+  const res = await fetch(url, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ path }),
@@ -475,6 +488,34 @@ export async function fetchSongMixInfo(
 
 export function songMixStreamUrl(songId: string): string {
   return `${BASE}/songs/${encodeURIComponent(songId)}/mix`;
+}
+
+export async function fetchPlaylistConfig(): Promise<{ output_dir: string }> {
+  const res = await fetch(`${BASE}/playlists/config`, { cache: "no-store" });
+  if (!res.ok) throw new Error("Failed to fetch playlist config");
+  return res.json();
+}
+
+export async function setPlaylistConfig(outputDir: string): Promise<{ ok: boolean; output_dir: string }> {
+  const res = await fetch(`${BASE}/playlists/config`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ output_dir: outputDir }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error((err as { detail?: string }).detail ?? "Failed to set playlist config");
+  }
+  return res.json();
+}
+
+export async function syncPlaylists(): Promise<{ rejects: number; review: number; wip: number }> {
+  const res = await fetch(`${BASE}/playlists/sync`, { method: "POST" });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error((err as { detail?: string }).detail ?? "Sync failed");
+  }
+  return res.json();
 }
 
 export async function fetchSamples(topN?: number): Promise<import("./types").SampleEntry[]> {

--- a/packages/composition/pyproject.toml
+++ b/packages/composition/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "white-composition"
-version = "0.2.0"
+version = "0.3.0"
 description = "Production orchestration, pipeline runner, and candidate review for White project"
 requires-python = ">=3.12"
 dependencies = [

--- a/packages/composition/src/white_composition/playlist_sync.py
+++ b/packages/composition/src/white_composition/playlist_sync.py
@@ -183,14 +183,21 @@ def _plain_bucket_filenames(songs: list[dict], prefix: str = "") -> dict[str, st
 
 
 def _wip_filenames(wip_songs: list[dict]) -> dict[str, str]:
+    """Sequenced entries are already unique via their index prefix. Unsequenced
+    entries all share the "99_unsequenced_" prefix, so — unlike the sequenced
+    ones — they need the same collision-suffix handling as the Rejects/Review
+    buckets to avoid two same-titled unsequenced songs overwriting each other.
+    """
     names: dict[str, str] = {}
+    unsequenced_entries: list[tuple[dict, str, str]] = []
     for i, song in enumerate(wip_songs):
         stem = _sanitize_filename(song["title"])
         ext = _mix_extension(song)
         if song.get("_side") is not None:
             names[song["id"]] = f"{i + 1:02d}_{song['_side']}_{stem}{ext}"
         else:
-            names[song["id"]] = f"99_unsequenced_{stem}{ext}"
+            unsequenced_entries.append((song, f"99_unsequenced_{stem}", ext))
+    names.update(_dedupe_filenames(unsequenced_entries))
     return names
 
 

--- a/packages/composition/src/white_composition/playlist_sync.py
+++ b/packages/composition/src/white_composition/playlist_sync.py
@@ -1,0 +1,268 @@
+"""Listening-playlist sync — bucket songs with finished mixes into Rejects /
+Review / White Album WiP folders for Apple Music import.
+
+Classification is derived fresh from `scan_songs()` output and `sides.yml` on every
+sync; no bucket membership is persisted. Only the output directory setting persists,
+in `playlist_config.yml` at the album root (sibling to `sides.yml`).
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel
+
+from white_composition.lp_sides import SIDE_NAMES, SidesDocument
+
+PLAYLIST_CONFIG_FILENAME = "playlist_config.yml"
+DEFAULT_OUTPUT_DIR = (
+    "/Users/gabrielwalsh/Documents/Music Production/Earthly Frames/White/Listening"
+)
+
+REJECTS_DIRNAME = "Rejects"
+REVIEW_DIRNAME = "Review"
+WIP_DIRNAME = "White Album WiP"
+
+_LIFECYCLE_REJECT_STATUSES = {"scrapped", "abandoned"}
+_AUDIO_EXTENSIONS = {".mp3", ".wav", ".aiff", ".aif", ".m4a"}
+_DEFAULT_EXTENSION = ".mp3"
+
+
+class PlaylistConfig(BaseModel):
+    output_dir: str = DEFAULT_OUTPUT_DIR
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def load_playlist_config(album_dir: Path) -> PlaylistConfig:
+    """Load playlist_config.yml from the album root, materializing defaults if absent."""
+    path = Path(album_dir) / PLAYLIST_CONFIG_FILENAME
+    if not path.exists():
+        config = PlaylistConfig()
+        save_playlist_config(album_dir, config)
+        return config
+    with open(path) as f:
+        data = yaml.safe_load(f) or {}
+    return PlaylistConfig(**data)
+
+
+def save_playlist_config(album_dir: Path, config: PlaylistConfig) -> Path:
+    """Write playlist_config.yml to the album root."""
+    path = Path(album_dir) / PLAYLIST_CONFIG_FILENAME
+    with open(path, "w") as f:
+        yaml.dump(
+            config.model_dump(),
+            f,
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+            width=float("inf"),
+        )
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def _is_rejected(song: dict) -> bool:
+    return song.get("lifecycle_status") in _LIFECYCLE_REJECT_STATUSES
+
+
+def classify_songs(
+    songs: list[dict], sides_doc: SidesDocument
+) -> dict[str, list[dict]]:
+    """Classify songs (from `scan_songs()`) into rejects/review/wip buckets.
+
+    Only songs with `has_mix: true` are considered; each song lands in at most one
+    bucket. WiP songs are ordered by Side A-D + in-side position, each annotated with
+    a `_side` key; a placed song absent from `sides.yml` is appended at the end with
+    `_side: None` (unsequenced) rather than dropped.
+    """
+    rejects: list[dict] = []
+    review: list[dict] = []
+    wip_by_id: dict[str, dict] = {}
+
+    for song in songs:
+        if not song.get("has_mix"):
+            continue
+        if song.get("lp_consideration") == "placed":
+            wip_by_id[song["id"]] = song
+        elif _is_rejected(song):
+            rejects.append(song)
+        else:
+            review.append(song)
+
+    wip_sequenced: list[dict] = []
+    seen_ids: set[str] = set()
+    for side_name in SIDE_NAMES:
+        side = sides_doc.sides.get(side_name)
+        if side is None:
+            continue
+        for side_song in side.songs:
+            song = wip_by_id.get(side_song.song_id)
+            if song is not None and side_song.song_id not in seen_ids:
+                wip_sequenced.append({**song, "_side": side_name})
+                seen_ids.add(side_song.song_id)
+
+    wip_unsequenced = [
+        {**song, "_side": None}
+        for song_id, song in wip_by_id.items()
+        if song_id not in seen_ids
+    ]
+
+    return {
+        "rejects": rejects,
+        "review": review,
+        "wip": wip_sequenced + wip_unsequenced,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Filesystem rebuild
+# ---------------------------------------------------------------------------
+
+
+def _sanitize_filename(name: str) -> str:
+    """Strip characters invalid in filenames, leaving a reasonable stem."""
+    name = re.sub(r'[\/:*?"<>|\x00-\x1f]', "_", name).strip()
+    return name or "untitled"
+
+
+def read_mix_path(production_path: str) -> Path | None:
+    """Return the song's mix file path from song_context.yml, if set and present."""
+    ctx_path = Path(production_path) / "song_context.yml"
+    if not ctx_path.exists():
+        return None
+    try:
+        with open(ctx_path) as f:
+            ctx = yaml.safe_load(f) or {}
+    except Exception:
+        return None
+    mix = ctx.get("mix_file")
+    if not mix:
+        return None
+    mix_path = Path(mix)
+    return mix_path if mix_path.exists() else None
+
+
+def _mix_extension(song: dict) -> str:
+    mix_path = read_mix_path(song["production_path"])
+    return mix_path.suffix if mix_path else _DEFAULT_EXTENSION
+
+
+def _dedupe_filenames(entries: list[tuple[dict, str, str]]) -> dict[str, str]:
+    """entries: (song, stem, ext) triples. Returns {song_id: filename}, suffixing
+    stems that collide with the song's production_slug."""
+    stem_counts: dict[str, int] = {}
+    for _song, stem, _ext in entries:
+        stem_counts[stem] = stem_counts.get(stem, 0) + 1
+    result: dict[str, str] = {}
+    for song, stem, ext in entries:
+        if stem_counts[stem] > 1:
+            suffix = song.get("production_slug") or song["id"]
+            result[song["id"]] = f"{stem}_{suffix}{ext}"
+        else:
+            result[song["id"]] = f"{stem}{ext}"
+    return result
+
+
+def _plain_bucket_filenames(songs: list[dict], prefix: str = "") -> dict[str, str]:
+    entries = [
+        (song, f"{prefix}{_sanitize_filename(song['title'])}", _mix_extension(song))
+        for song in songs
+    ]
+    return _dedupe_filenames(entries)
+
+
+def _wip_filenames(wip_songs: list[dict]) -> dict[str, str]:
+    names: dict[str, str] = {}
+    for i, song in enumerate(wip_songs):
+        stem = _sanitize_filename(song["title"])
+        ext = _mix_extension(song)
+        if song.get("_side") is not None:
+            names[song["id"]] = f"{i + 1:02d}_{song['_side']}_{stem}{ext}"
+        else:
+            names[song["id"]] = f"99_unsequenced_{stem}{ext}"
+    return names
+
+
+def _validate_output_dir(output_dir: str) -> Path:
+    if not output_dir or not output_dir.strip():
+        raise ValueError("Playlist output_dir is not configured")
+    resolved = Path(output_dir).expanduser().resolve()
+    if str(resolved) in ("/", str(Path.home())):
+        raise ValueError(f"Refusing to sync to unsafe output_dir: {resolved}")
+    return resolved
+
+
+def _copy_if_needed(src: Path, dest: Path) -> None:
+    if dest.exists():
+        src_stat = src.stat()
+        dest_stat = dest.stat()
+        if (
+            dest_stat.st_size == src_stat.st_size
+            and dest_stat.st_mtime >= src_stat.st_mtime
+        ):
+            return
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dest)
+
+
+def _rebuild_folder(
+    folder: Path, target_names: dict[str, str], songs_by_id: dict[str, dict]
+) -> int:
+    """Make `folder` exactly match `target_names` {song_id: filename}. Returns count synced."""
+    folder.mkdir(parents=True, exist_ok=True)
+    target_filenames = set(target_names.values())
+
+    for existing in folder.iterdir():
+        if (
+            existing.is_file()
+            and existing.suffix.lower() in _AUDIO_EXTENSIONS
+            and existing.name not in target_filenames
+        ):
+            existing.unlink()
+
+    count = 0
+    for song_id, filename in target_names.items():
+        song = songs_by_id[song_id]
+        mix_path = read_mix_path(song["production_path"])
+        if mix_path is None:
+            continue
+        _copy_if_needed(mix_path, folder / filename)
+        count += 1
+    return count
+
+
+def sync_playlists(
+    songs: list[dict], sides_doc: SidesDocument, output_dir: str
+) -> dict[str, int]:
+    """Classify songs and rebuild the 3 playlist folders under output_dir.
+
+    Returns {"rejects": n, "review": n, "wip": n} — the number of files present in
+    each subfolder after the rebuild.
+    """
+    base = _validate_output_dir(output_dir)
+    buckets = classify_songs(songs, sides_doc)
+
+    rejects_names = _plain_bucket_filenames(buckets["rejects"], prefix="REJECT_")
+    review_names = _plain_bucket_filenames(buckets["review"])
+    wip_names = _wip_filenames(buckets["wip"])
+
+    songs_by_id = {s["id"]: s for s in songs}
+    for s in buckets["wip"]:
+        songs_by_id.setdefault(s["id"], s)
+
+    return {
+        "rejects": _rebuild_folder(base / REJECTS_DIRNAME, rejects_names, songs_by_id),
+        "review": _rebuild_folder(base / REVIEW_DIRNAME, review_names, songs_by_id),
+        "wip": _rebuild_folder(base / WIP_DIRNAME, wip_names, songs_by_id),
+    }

--- a/packages/composition/tests/test_playlist_sync.py
+++ b/packages/composition/tests/test_playlist_sync.py
@@ -213,6 +213,26 @@ class TestSyncPlaylists:
         names = sorted(p.name for p in wip_dir.iterdir())
         assert names == ["01_A_Beta.mp3", "02_B_Alpha.mp3"]
 
+    def test_unsequenced_wip_title_collision_gets_suffixed(self, tmp_path):
+        """Two unsequenced placed songs sharing a title both get the fixed
+        '99_unsequenced_' prefix — without collision suffixing they'd map to
+        the same filename and one copy would silently overwrite the other."""
+        song_1 = _make_song(tmp_path, "dup1", "Same Title", lp_consideration="placed")
+        song_2 = _make_song(tmp_path, "dup2", "Same Title", lp_consideration="placed")
+        output_dir = tmp_path / "Listening"
+
+        counts = sync_playlists(
+            [song_1, song_2], SidesDocument.empty(), str(output_dir)
+        )
+
+        assert counts["wip"] == 2
+        wip_dir = output_dir / "White Album WiP"
+        names = {p.name for p in wip_dir.iterdir()}
+        assert names == {
+            "99_unsequenced_Same Title_dup1.mp3",
+            "99_unsequenced_Same Title_dup2.mp3",
+        }
+
     def test_unchanged_file_not_recopied(self, tmp_path):
         song = _make_song(tmp_path, "r1", "Rejected", lifecycle_status="scrapped")
         output_dir = tmp_path / "Listening"

--- a/packages/composition/tests/test_playlist_sync.py
+++ b/packages/composition/tests/test_playlist_sync.py
@@ -1,0 +1,239 @@
+"""Tests for playlist_sync."""
+
+import yaml
+
+from white_composition.lp_sides import SidesDocument, assign_song
+from white_composition.playlist_sync import (
+    DEFAULT_OUTPUT_DIR,
+    PlaylistConfig,
+    classify_songs,
+    load_playlist_config,
+    save_playlist_config,
+    sync_playlists,
+)
+
+
+def _make_song(
+    tmp_path,
+    song_id: str,
+    title: str,
+    *,
+    has_mix: bool = True,
+    lifecycle_status: str | None = None,
+    lp_consideration: str = "not_considered",
+    mix_ext: str = ".mp3",
+    production_slug: str | None = None,
+) -> dict:
+    prod_dir = tmp_path / "productions" / song_id
+    prod_dir.mkdir(parents=True, exist_ok=True)
+    ctx: dict = {}
+    if has_mix:
+        mix_path = prod_dir / f"mix{mix_ext}"
+        mix_path.write_bytes(b"fake audio bytes")
+        ctx["mix_file"] = str(mix_path)
+    with open(prod_dir / "song_context.yml", "w") as f:
+        yaml.dump(ctx, f)
+    return {
+        "id": song_id,
+        "production_slug": production_slug or song_id,
+        "production_path": str(prod_dir),
+        "title": title,
+        "has_mix": has_mix,
+        "lifecycle_status": lifecycle_status,
+        "lp_consideration": lp_consideration,
+    }
+
+
+class TestPlaylistConfig:
+    def test_default_materialized_on_first_read(self, tmp_path):
+        config = load_playlist_config(tmp_path)
+        assert config.output_dir == DEFAULT_OUTPUT_DIR
+        assert (tmp_path / "playlist_config.yml").exists()
+
+    def test_round_trip(self, tmp_path):
+        save_playlist_config(tmp_path, PlaylistConfig(output_dir="/tmp/custom"))
+        loaded = load_playlist_config(tmp_path)
+        assert loaded.output_dir == "/tmp/custom"
+
+
+class TestClassifySongs:
+    def test_rejects_bucket(self, tmp_path):
+        scrapped = _make_song(
+            tmp_path, "s1", "Scrapped Song", lifecycle_status="scrapped"
+        )
+        abandoned = _make_song(
+            tmp_path, "s2", "Abandoned Song", lifecycle_status="abandoned"
+        )
+        result = classify_songs([scrapped, abandoned], SidesDocument.empty())
+        ids = {s["id"] for s in result["rejects"]}
+        assert ids == {"s1", "s2"}
+        assert result["review"] == []
+        assert result["wip"] == []
+
+    def test_review_bucket(self, tmp_path):
+        active = _make_song(tmp_path, "s1", "Active Song")
+        merged = _make_song(tmp_path, "s2", "Merged Song", lifecycle_status="merged")
+        result = classify_songs([active, merged], SidesDocument.empty())
+        ids = {s["id"] for s in result["review"]}
+        assert ids == {"s1", "s2"}
+
+    def test_placed_excluded_from_review_even_if_rejected_status(self, tmp_path):
+        """lp_consideration == placed always wins, regardless of lifecycle_status."""
+        song = _make_song(
+            tmp_path,
+            "s1",
+            "Placed Song",
+            lifecycle_status="scrapped",
+            lp_consideration="placed",
+        )
+        result = classify_songs([song], SidesDocument.empty())
+        assert result["rejects"] == []
+        assert result["review"] == []
+        assert [s["id"] for s in result["wip"]] == ["s1"]
+
+    def test_no_mix_excluded_from_all_buckets(self, tmp_path):
+        song = _make_song(tmp_path, "s1", "No Mix", has_mix=False)
+        result = classify_songs([song], SidesDocument.empty())
+        assert result["rejects"] == []
+        assert result["review"] == []
+        assert result["wip"] == []
+
+    def test_wip_ordered_by_side_and_position(self, tmp_path):
+        song_a = _make_song(tmp_path, "a", "Song A", lp_consideration="placed")
+        song_b = _make_song(tmp_path, "b", "Song B", lp_consideration="placed")
+        song_c = _make_song(tmp_path, "c", "Song C", lp_consideration="placed")
+        doc = SidesDocument.empty()
+        assign_song(doc, "b", "A", 0, 100.0)
+        assign_song(doc, "c", "A", 1, 100.0)
+        assign_song(doc, "a", "B", 0, 100.0)
+
+        result = classify_songs([song_a, song_b, song_c], doc)
+        ordered_ids = [s["id"] for s in result["wip"]]
+        assert ordered_ids == ["b", "c", "a"]
+        assert result["wip"][0]["_side"] == "A"
+        assert result["wip"][2]["_side"] == "B"
+
+    def test_unsequenced_placed_song_appended_at_end(self, tmp_path):
+        sequenced = _make_song(tmp_path, "seq", "Sequenced", lp_consideration="placed")
+        unsequenced = _make_song(
+            tmp_path, "unseq", "Unsequenced", lp_consideration="placed"
+        )
+        doc = SidesDocument.empty()
+        assign_song(doc, "seq", "A", 0, 100.0)
+
+        result = classify_songs([sequenced, unsequenced], doc)
+        ordered_ids = [s["id"] for s in result["wip"]]
+        assert ordered_ids == ["seq", "unseq"]
+        assert result["wip"][1]["_side"] is None
+
+
+class TestSyncPlaylists:
+    def test_full_rebuild_populates_each_bucket(self, tmp_path):
+        rejected = _make_song(tmp_path, "r1", "Rejected", lifecycle_status="scrapped")
+        reviewed = _make_song(tmp_path, "v1", "Reviewed")
+        placed = _make_song(tmp_path, "p1", "Placed", lp_consideration="placed")
+        output_dir = tmp_path / "Listening"
+
+        counts = sync_playlists(
+            [rejected, reviewed, placed], SidesDocument.empty(), str(output_dir)
+        )
+
+        assert counts == {"rejects": 1, "review": 1, "wip": 1}
+        assert (output_dir / "Rejects" / "REJECT_Rejected.mp3").exists()
+        assert (output_dir / "Review" / "Reviewed.mp3").exists()
+        assert (output_dir / "White Album WiP" / "99_unsequenced_Placed.mp3").exists()
+
+    def test_rejects_filenames_are_prefixed_review_is_not(self, tmp_path):
+        """Apple Music flattens folder structure on import, so Rejects and Review
+        tracks with similar titles are otherwise indistinguishable once synced."""
+        rejected = _make_song(tmp_path, "r1", "Overlap", lifecycle_status="scrapped")
+        reviewed = _make_song(tmp_path, "v1", "Overlap Too")
+        output_dir = tmp_path / "Listening"
+
+        sync_playlists([rejected, reviewed], SidesDocument.empty(), str(output_dir))
+
+        assert (output_dir / "Rejects" / "REJECT_Overlap.mp3").exists()
+        assert (output_dir / "Review" / "Overlap Too.mp3").exists()
+
+    def test_stale_file_removed_on_rebuild(self, tmp_path):
+        output_dir = tmp_path / "Listening"
+        song = _make_song(tmp_path, "r1", "Rejected", lifecycle_status="scrapped")
+
+        sync_playlists([song], SidesDocument.empty(), str(output_dir))
+        assert (output_dir / "Rejects" / "REJECT_Rejected.mp3").exists()
+
+        # Song no longer matches any bucket (mix removed) -> file should disappear.
+        song["has_mix"] = False
+        sync_playlists([song], SidesDocument.empty(), str(output_dir))
+        assert not (output_dir / "Rejects" / "REJECT_Rejected.mp3").exists()
+
+    def test_unrelated_file_outside_subfolders_untouched(self, tmp_path):
+        output_dir = tmp_path / "Listening"
+        output_dir.mkdir(parents=True)
+        sentinel = output_dir / "not_ours.txt"
+        sentinel.write_text("leave me alone")
+
+        song = _make_song(tmp_path, "r1", "Rejected", lifecycle_status="scrapped")
+        sync_playlists([song], SidesDocument.empty(), str(output_dir))
+
+        assert sentinel.exists()
+
+    def test_non_audio_file_inside_subfolder_untouched(self, tmp_path):
+        output_dir = tmp_path / "Listening"
+        (output_dir / "Rejects").mkdir(parents=True)
+        ds_store = output_dir / "Rejects" / ".DS_Store"
+        ds_store.write_text("finder metadata")
+
+        sync_playlists([], SidesDocument.empty(), str(output_dir))
+        assert ds_store.exists()
+
+    def test_title_collision_gets_suffixed(self, tmp_path):
+        song_1 = _make_song(tmp_path, "dup1", "Same Title", lifecycle_status="scrapped")
+        song_2 = _make_song(
+            tmp_path, "dup2", "Same Title", lifecycle_status="abandoned"
+        )
+        output_dir = tmp_path / "Listening"
+        sync_playlists([song_1, song_2], SidesDocument.empty(), str(output_dir))
+
+        rejects_dir = output_dir / "Rejects"
+        names = {p.name for p in rejects_dir.iterdir()}
+        assert names == {"REJECT_Same Title_dup1.mp3", "REJECT_Same Title_dup2.mp3"}
+
+    def test_wip_numeric_prefix_order(self, tmp_path):
+        song_a = _make_song(tmp_path, "a", "Alpha", lp_consideration="placed")
+        song_b = _make_song(tmp_path, "b", "Beta", lp_consideration="placed")
+        doc = SidesDocument.empty()
+        assign_song(doc, "b", "A", 0, 100.0)
+        assign_song(doc, "a", "B", 0, 100.0)
+        output_dir = tmp_path / "Listening"
+
+        sync_playlists([song_a, song_b], doc, str(output_dir))
+
+        wip_dir = output_dir / "White Album WiP"
+        names = sorted(p.name for p in wip_dir.iterdir())
+        assert names == ["01_A_Beta.mp3", "02_B_Alpha.mp3"]
+
+    def test_unchanged_file_not_recopied(self, tmp_path):
+        song = _make_song(tmp_path, "r1", "Rejected", lifecycle_status="scrapped")
+        output_dir = tmp_path / "Listening"
+        sync_playlists([song], SidesDocument.empty(), str(output_dir))
+
+        dest = output_dir / "Rejects" / "REJECT_Rejected.mp3"
+        first_mtime = dest.stat().st_mtime_ns
+
+        sync_playlists([song], SidesDocument.empty(), str(output_dir))
+        assert dest.stat().st_mtime_ns == first_mtime
+
+    def test_empty_output_dir_raises(self):
+        try:
+            sync_playlists([], SidesDocument.empty(), "")
+            raise AssertionError("expected ValueError")
+        except ValueError:
+            pass
+
+    def test_home_directory_output_dir_raises(self):
+        try:
+            sync_playlists([], SidesDocument.empty(), "~")
+            raise AssertionError("expected ValueError")
+        except ValueError:
+            pass

--- a/packages/generation/pyproject.toml
+++ b/packages/generation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "white-generation"
-version = "0.2.0"
+version = "0.3.0"
 description = "MIDI pattern templates and generation pipelines for White project"
 requires-python = ">=3.12"
 dependencies = [

--- a/packages/generation/pyproject.toml
+++ b/packages/generation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "white-generation"
-version = "0.3.0"
+version = "0.3.1"
 description = "MIDI pattern templates and generation pipelines for White project"
 requires-python = ">=3.12"
 dependencies = [

--- a/packages/generation/src/white_generation/patterns/bass_patterns.py
+++ b/packages/generation/src/white_generation/patterns/bass_patterns.py
@@ -948,6 +948,102 @@ TEMPLATES_5_4 = [
 ]
 
 # ---------------------------------------------------------------------------
+# 5/8 Templates
+# ---------------------------------------------------------------------------
+# 5/8 = 5 eighth notes = 2.5 quarter-note beats. Group positions: 0, 1.5
+# (3+2 grouping) — same convention as the 7/8 templates below.
+
+TEMPLATES_5_8 = [
+    BassPattern(
+        name="five_eight_root_sparse",
+        style=BassStyle.ROOT,
+        energy="low",
+        time_sig=(5, 8),
+        description="Root on 1, held entire bar — sparse anchor",
+        notes=[(0, "root", "normal")],
+        note_durations=[2.5],
+    ),
+    BassPattern(
+        name="five_eight_pedal",
+        style=BassStyle.PEDAL,
+        energy="low",
+        time_sig=(5, 8),
+        description="Root pedal held whole bar",
+        notes=[(0, "root", "normal")],
+        note_durations=[2.5],
+    ),
+    BassPattern(
+        name="five_eight_root_3_2",
+        style=BassStyle.ROOT,
+        energy="medium",
+        time_sig=(5, 8),
+        description="Root on group starts (0, 1.5) — 3+2 grouping",
+        notes=[(0, "root", "accent"), (1.5, "root", "normal")],
+        note_durations=[1.5, 1.0],
+    ),
+    BassPattern(
+        name="five_eight_walking",
+        style=BassStyle.WALKING,
+        energy="medium",
+        time_sig=(5, 8),
+        description="Walking 5/8 — root, passing tone, 5th on group starts",
+        notes=[
+            (0, "root", "accent"),
+            (1, "passing_tone", "normal"),
+            (1.5, "5th", "normal"),
+        ],
+        note_durations=[1.0, 0.5, 1.0],
+    ),
+    BassPattern(
+        name="five_eight_arp",
+        style=BassStyle.ARPEGGIATED,
+        energy="medium",
+        time_sig=(5, 8),
+        description="Root-3rd-5th arpeggio across the 3+2 grouping",
+        notes=[(0, "root", "accent"), (1, "3rd", "normal"), (1.5, "5th", "normal")],
+        note_durations=[1.0, 0.5, 1.0],
+    ),
+    BassPattern(
+        name="five_eight_octave",
+        style=BassStyle.OCTAVE,
+        energy="medium",
+        time_sig=(5, 8),
+        description="Root-octave bounce on group boundaries",
+        notes=[(0, "root", "accent"), (1.5, "octave_up", "normal")],
+        note_durations=[1.5, 1.0],
+    ),
+    BassPattern(
+        name="five_eight_root_pulse",
+        style=BassStyle.ROOT,
+        energy="high",
+        time_sig=(5, 8),
+        description="Root on every eighth — driving pulse",
+        notes=[
+            (0, "root", "accent"),
+            (0.5, "root", "normal"),
+            (1, "root", "normal"),
+            (1.5, "root", "normal"),
+            (2, "root", "normal"),
+        ],
+        note_durations=[0.5, 0.5, 0.5, 0.5, 0.5],
+    ),
+    BassPattern(
+        name="five_eight_synco",
+        style=BassStyle.SYNCOPATED,
+        energy="high",
+        time_sig=(5, 8),
+        description="Syncopated 5/8 — root on 1, ghost 5th on the offbeat, root on group 2",
+        notes=[
+            (0, "root", "accent"),
+            (0.5, "5th", "ghost"),
+            (1.5, "root", "normal"),
+            (2, "5th", "ghost"),
+        ],
+        note_durations=[0.5, 1.0, 0.5, 0.5],
+    ),
+]
+
+# ---------------------------------------------------------------------------
 # 7/8 Templates
 # ---------------------------------------------------------------------------
 # 7/8 = 3.5 quarter-note beats. Group positions: 0, 1.5, 2.5 (3+2+2 grouping)
@@ -1382,6 +1478,8 @@ ALL_TEMPLATES: list[BassPattern] = [
     *TEMPLATES_3_4,
     # 5/4
     *TEMPLATES_5_4,
+    # 5/8
+    *TEMPLATES_5_8,
     # 6/8 (compound duple)
     *TEMPLATES_6_8,
     # 7/8

--- a/packages/generation/src/white_generation/patterns/drum_patterns.py
+++ b/packages/generation/src/white_generation/patterns/drum_patterns.py
@@ -1922,6 +1922,143 @@ TEMPLATES_5_4_ROCK = [
 ]
 
 # ---------------------------------------------------------------------------
+# 5/8 Templates
+# ---------------------------------------------------------------------------
+# 5/8 = 5 eighth notes = 2.5 quarter-note beats. Positions are in quarter-note
+# beats: 0, 0.5, 1, 1.5, 2. Common grouping: 3+2 (strong on 1 and the 4th
+# eighth, i.e. position 1.5).
+
+TEMPLATES_5_8_AMBIENT = [
+    DrumPattern(
+        name="ambient_5_8_sparse",
+        genre_family="ambient",
+        energy="low",
+        time_sig=(5, 8),
+        description="Sparse 5/8 (3+2) — kick on 1, ghost hat on the 2-group",
+        voices={
+            "kick": [(0, "normal")],
+            "hh_closed": [(1.5, "ghost")],
+        },
+    ),
+    DrumPattern(
+        name="ambient_5_8_pulse",
+        genre_family="ambient",
+        energy="medium",
+        time_sig=(5, 8),
+        description="5/8 ambient pulse — kick on group starts (3+2), ghost hats on all five eighths",
+        voices={
+            "kick": [(0, "normal"), (1.5, "ghost")],
+            "hh_closed": [
+                (0, "ghost"),
+                (0.5, "ghost"),
+                (1, "ghost"),
+                (1.5, "ghost"),
+                (2, "ghost"),
+            ],
+        },
+    ),
+    DrumPattern(
+        name="ambient_5_8_wash",
+        genre_family="ambient",
+        energy="high",
+        time_sig=(5, 8),
+        description="5/8 ambient wash — crash on 1, kick on group starts, open hat swell",
+        voices={
+            "crash": [(0, "normal")],
+            "kick": [(0, "accent"), (1.5, "normal")],
+            "hh_open": [(2, "normal")],
+        },
+    ),
+]
+
+TEMPLATES_5_8_ELECTRONIC = [
+    DrumPattern(
+        name="electronic_5_8_minimal",
+        genre_family="electronic",
+        energy="low",
+        time_sig=(5, 8),
+        description="Minimal 5/8 — kick on 1, ghost hat on the 2-group",
+        voices={
+            "kick": [(0, "normal")],
+            "hh_closed": [(1.5, "ghost")],
+        },
+    ),
+    DrumPattern(
+        name="electronic_5_8_groove",
+        genre_family="electronic",
+        energy="medium",
+        time_sig=(5, 8),
+        description="5/8 electronic groove (3+2) — kick on group starts, clap on the 2-group, hats on eighths",
+        voices={
+            "kick": [(0, "accent"), (1.5, "normal")],
+            "clap": [(1.5, "normal")],
+            "hh_closed": [
+                (0, "normal"),
+                (0.5, "ghost"),
+                (1, "ghost"),
+                (1.5, "normal"),
+                (2, "ghost"),
+            ],
+        },
+    ),
+    DrumPattern(
+        name="electronic_5_8_driving",
+        genre_family="electronic",
+        energy="high",
+        time_sig=(5, 8),
+        description="Driving 5/8 — kick accented on both group starts, snare on the 2-group, eighths on hats",
+        voices={
+            "kick": [(0, "accent"), (1, "normal"), (1.5, "accent")],
+            "snare": [(1.5, "accent")],
+            "hh_closed": [
+                (0, "accent"),
+                (0.5, "normal"),
+                (1, "normal"),
+                (1.5, "accent"),
+                (2, "normal"),
+            ],
+        },
+    ),
+]
+
+TEMPLATES_5_8_EXPERIMENTAL = [
+    DrumPattern(
+        name="experimental_5_8_off_grid",
+        genre_family="experimental",
+        energy="low",
+        time_sig=(5, 8),
+        description="Off-grid 5/8 — single ghost kick displaced onto the 2-group, no fixed pulse",
+        voices={
+            "kick": [(1.5, "ghost")],
+        },
+        tags=["sparse"],
+    ),
+    DrumPattern(
+        name="experimental_5_8_stutter",
+        genre_family="experimental",
+        energy="medium",
+        time_sig=(5, 8),
+        description="Stuttered 5/8 — irregular kick/rimshot placement across the bar, no fixed grouping",
+        voices={
+            "kick": [(0, "accent"), (1, "ghost")],
+            "rimshot": [(0.5, "ghost"), (2, "normal")],
+        },
+    ),
+    DrumPattern(
+        name="experimental_5_8_glitch",
+        genre_family="experimental",
+        energy="high",
+        time_sig=(5, 8),
+        description="Glitch 5/8 — dense clap texture against sparse accented kick, cross-grouping tension",
+        voices={
+            "kick": [(0, "accent"), (1.5, "accent")],
+            "clap": [(0.5, "ghost"), (1, "ghost"), (2, "ghost")],
+            "hh_closed": [(0, "ghost"), (1, "ghost"), (1.5, "ghost")],
+        },
+    ),
+]
+
+# ---------------------------------------------------------------------------
 # 4/4 Breakbeat (classic breaks + energy variants)
 # ---------------------------------------------------------------------------
 # Grid mapping: 16th-note positions in quarter-beat floats
@@ -2845,6 +2982,10 @@ ALL_TEMPLATES: list[DrumPattern] = [
     *TEMPLATES_5_4_ELECTRONIC,
     *TEMPLATES_5_4_FOLK,
     *TEMPLATES_5_4_ROCK,
+    # 5/8
+    *TEMPLATES_5_8_AMBIENT,
+    *TEMPLATES_5_8_ELECTRONIC,
+    *TEMPLATES_5_8_EXPERIMENTAL,
     # 4/4 Breakbeat
     *TEMPLATES_4_4_BREAKBEAT,
     # 4/4 Sparse / Atmospheric

--- a/packages/generation/src/white_generation/patterns/melody_patterns.py
+++ b/packages/generation/src/white_generation/patterns/melody_patterns.py
@@ -981,6 +981,75 @@ TEMPLATES_5_4 = [
     ),
 ]
 
+# ---------------------------------------------------------------------------
+# 5/8 Templates
+# ---------------------------------------------------------------------------
+# 5/8 = 5 eighth notes = 2.5 quarter-note beats. Positions are in quarter-note
+# beats: 0, 0.5, 1, 1.5, 2. Common grouping: 3+2 (strong on 1 and position 1.5).
+
+TEMPLATES_5_8 = [
+    MelodyPattern(
+        name="five_eight_stepwise",
+        contour="stepwise",
+        energy="low",
+        time_sig=(5, 8),
+        description="Stepwise descent, held close — elegiac 5/8 phrase",
+        intervals=[0, -2, -1],
+        rhythm=[0.0, 1.0, 1.5],
+        durations=[1.0, 0.5, 1.0],
+    ),
+    MelodyPattern(
+        name="five_eight_stepwise_rise",
+        contour="stepwise",
+        energy="medium",
+        time_sig=(5, 8),
+        description="Ascending step across the 3+2 grouping",
+        intervals=[0, 2, 1, -1],
+        rhythm=[0.0, 0.5, 1.0, 1.5],
+        durations=[0.5, 0.5, 0.5, 1.0],
+    ),
+    MelodyPattern(
+        name="five_eight_arp",
+        contour="arpeggiated",
+        energy="medium",
+        time_sig=(5, 8),
+        description="Triad arpeggio up on group starts",
+        intervals=[0, 4, 3],
+        rhythm=[0.0, 1.5, 2.0],
+        durations=[1.5, 0.5, 0.5],
+    ),
+    MelodyPattern(
+        name="five_eight_arp_fall",
+        contour="arpeggiated",
+        energy="low",
+        time_sig=(5, 8),
+        description="Falling arpeggio — high note drifting down, held close",
+        intervals=[0, -3, -4],
+        rhythm=[0.0, 1.0, 1.5],
+        durations=[1.0, 0.5, 1.0],
+    ),
+    MelodyPattern(
+        name="five_eight_penta",
+        contour="pentatonic",
+        energy="high",
+        time_sig=(5, 8),
+        description="Pentatonic run across the full 5/8 bar in eighths",
+        intervals=[0, 2, 3, 2, -2],
+        rhythm=[0.0, 0.5, 1.0, 1.5, 2.0],
+        durations=[0.5, 0.5, 0.5, 0.5, 0.5],
+    ),
+    MelodyPattern(
+        name="five_eight_repeated",
+        contour="repeated",
+        energy="low",
+        time_sig=(5, 8),
+        description="Two-note motif, held close — 5/8 breath",
+        intervals=[0, 0, 2],
+        rhythm=[0.0, 1.0, 1.5],
+        durations=[1.0, 0.5, 1.0],
+    ),
+]
+
 _EXISTING_LEAD_TEMPLATES: list[MelodyPattern] = [
     *TEMPLATES_4_4_STEPWISE,
     *TEMPLATES_4_4_ARPEGGIATED,
@@ -990,6 +1059,7 @@ _EXISTING_LEAD_TEMPLATES: list[MelodyPattern] = [
     *TEMPLATES_4_4_SCALAR,
     *TEMPLATES_3_4,
     *TEMPLATES_5_4,
+    *TEMPLATES_5_8,
     *TEMPLATES_7_8,
     *TEMPLATES_6_8_LEAD,
 ]
@@ -1802,6 +1872,61 @@ VOCAL_5_4 = [
     ),
 ]
 
+# ---------------------------------------------------------------------------
+# 5/8 Vocal
+# (bar = 2.5 beats; >= 1 gap of >= 0.5 beats or anacrusis opening, >= 1 note
+# with duration >= 1.5 — see test_vocal_templates_have_rest_gap /
+# test_vocal_templates_have_held_note, which apply to every use_case="vocal"
+# template regardless of time signature)
+# ---------------------------------------------------------------------------
+
+VOCAL_5_8 = [
+    MelodyPattern(
+        name="vocal_5_8_hold_low",
+        contour="drone_and_step",
+        use_case="vocal",
+        energy="low",
+        time_sig=(5, 8),
+        description="5/8 held note, breath, short step-down close",
+        intervals=[0, -2],
+        rhythm=[0.0, 2.0],
+        durations=[1.5, 0.5],
+    ),
+    MelodyPattern(
+        name="vocal_5_8_call_rest_low",
+        contour="call_and_rest",
+        use_case="vocal",
+        energy="low",
+        time_sig=(5, 8),
+        description="5/8 short call, breath, long held resolution",
+        intervals=[0, -3],
+        rhythm=[0.0, 1.0],
+        durations=[0.5, 1.5],
+    ),
+    MelodyPattern(
+        name="vocal_5_8_haiku_med",
+        contour="haiku",
+        use_case="vocal",
+        energy="medium",
+        time_sig=(5, 8),
+        description="5/8 haiku — anacrusis opening, short-short-LONG resolution",
+        intervals=[0, 2, -3],
+        rhythm=[0.5, 0.75, 1.0],
+        durations=[0.25, 0.25, 1.5],
+    ),
+    MelodyPattern(
+        name="vocal_5_8_surge_high",
+        contour="declarative",
+        use_case="vocal",
+        energy="high",
+        time_sig=(5, 8),
+        description="5/8 surge — held opener, breath, three-note closing flourish",
+        intervals=[0, 2, 1, -2],
+        rhythm=[0.0, 2.0, 2.15, 2.3],
+        durations=[1.5, 0.15, 0.15, 0.2],
+    ),
+]
+
 ALL_TEMPLATES: list[MelodyPattern] = [
     # Existing templates reclassified as lead (instrument tracks)
     *_EXISTING_LEAD_TEMPLATES,
@@ -1817,6 +1942,7 @@ ALL_TEMPLATES: list[MelodyPattern] = [
     # New vocal templates for other time signatures
     *VOCAL_3_4,
     *VOCAL_5_4,
+    *VOCAL_5_8,
     *VOCAL_6_8,
     *VOCAL_7_8,
     # 4/4 Lamentful / Sparse

--- a/packages/generation/src/white_generation/patterns/pattern_evolution.py
+++ b/packages/generation/src/white_generation/patterns/pattern_evolution.py
@@ -208,6 +208,24 @@ def _tournament_select(
     return population[best]
 
 
+def _dedup_and_rank(
+    population: list[Any], midi_list: list[bytes], fitness: list[float], top_n: int
+) -> list[Any]:
+    """Collapse genomes that render to identical MIDI before taking the top_n.
+
+    Elitism and low-probability mutation let identical genomes persist across
+    generations unchanged; without this, `top_n` can be several copies of the
+    same pattern rather than distinct candidates.
+    """
+    best_by_midi: dict[bytes, tuple[float, int]] = {}
+    for idx, (midi, fit) in enumerate(zip(midi_list, fitness)):
+        current = best_by_midi.get(midi)
+        if current is None or fit > current[0]:
+            best_by_midi[midi] = (fit, idx)
+    ranked = sorted(best_by_midi.values(), key=lambda x: x[0], reverse=True)
+    return [population[idx] for _, idx in ranked[:top_n]]
+
+
 def _elite_indices(fitness: list[float], n: int = _ELITISM_N) -> list[int]:
     """Return indices of the top-n fittest individuals."""
     return sorted(range(len(fitness)), key=lambda i: fitness[i], reverse=True)[:n]
@@ -499,15 +517,7 @@ def breed_drum_patterns(
     # Final scoring and selection
     midi_list = [_drum_to_midi(p) for p in population]
     fitness = _score_population(midi_list, concept_emb)
-    sorted_pop = [
-        p
-        for _, _, p in sorted(
-            zip(fitness, range(len(population)), population),
-            key=lambda x: x[0],
-            reverse=True,
-        )
-    ]
-    return sorted_pop[:top_n]
+    return _dedup_and_rank(population, midi_list, fitness, top_n)
 
 
 def breed_bass_patterns(
@@ -566,15 +576,7 @@ def breed_bass_patterns(
         except Exception:
             midi_list.append(b"")
     fitness = _score_population(midi_list, concept_emb)
-    sorted_pop = [
-        p
-        for _, _, p in sorted(
-            zip(fitness, range(len(population)), population),
-            key=lambda x: x[0],
-            reverse=True,
-        )
-    ]
-    return sorted_pop[:top_n]
+    return _dedup_and_rank(population, midi_list, fitness, top_n)
 
 
 def breed_melody_patterns(
@@ -633,12 +635,4 @@ def breed_melody_patterns(
         except Exception:
             midi_list.append(b"")
     fitness = _score_population(midi_list, concept_emb)
-    sorted_pop = [
-        p
-        for _, _, p in sorted(
-            zip(fitness, range(len(population)), population),
-            key=lambda x: x[0],
-            reverse=True,
-        )
-    ]
-    return sorted_pop[:top_n]
+    return _dedup_and_rank(population, midi_list, fitness, top_n)

--- a/packages/generation/src/white_generation/patterns/pattern_evolution.py
+++ b/packages/generation/src/white_generation/patterns/pattern_evolution.py
@@ -368,15 +368,36 @@ def _mutate_bass(pattern: BassPattern) -> BassPattern:
 # ---------------------------------------------------------------------------
 
 
+def _clip_durations_to_next_onset(
+    rhythm: list[float], durations: list[float]
+) -> list[float]:
+    """Ensure no note's duration extends past the next note's onset.
+
+    Melody must be monophonic — a defensive clamp applied after any operation
+    that could combine onset/duration values from independent sources (e.g.
+    crossover splicing two parents, or a mutation shifting one onset).
+    """
+    clipped = list(durations)
+    for i in range(len(clipped) - 1):
+        gap = rhythm[i + 1] - rhythm[i]
+        clipped[i] = max(0.0, min(clipped[i], gap))
+    return clipped
+
+
 def _crossover_melody(
     parent_a: MelodyPattern, parent_b: MelodyPattern
 ) -> MelodyPattern:
     """Randomized bar-boundary splice on interval sequences.
 
-    Both parents split at the same proportional point so the A-prefix's last
-    onset and the B-suffix's first onset stay temporally aligned — intervals
-    are cumulative deltas applied in rhythm order, so a non-monotonic splice
-    would desync the interval sequence from actual time order.
+    B's suffix is re-anchored to start right after A's prefix's last note
+    actually ends, rather than concatenating each parent's absolute onset
+    values verbatim — the two parents' onsets come from independent rhythmic
+    contexts, so splicing them as-is doesn't guarantee the B-suffix's first
+    onset falls after (or even after in time at all) the A-prefix's last
+    note, which produced overlapping and out-of-order notes in evolved
+    output. Intervals are cumulative deltas applied in rhythm order, so
+    onsets must stay strictly increasing for the pitch sequence to render
+    correctly.
     """
     ivs_a = list(parent_a.intervals)
     ivs_b = list(parent_b.intervals)
@@ -388,10 +409,8 @@ def _crossover_melody(
     split_b = _split_index(len(ivs_b), frac)
 
     child_ivs = ivs_a[:split_a] + ivs_b[split_b:]
-    child_rhy = rhy_a[:split_a] + rhy_b[split_b:]
-    # Ensure first interval is 0 (starting pitch anchor)
-    if child_ivs:
-        child_ivs[0] = 0
+    a_prefix_rhy = rhy_a[:split_a]
+    b_suffix_rhy = rhy_b[split_b:]
 
     child_durs: list[float] | None = None
     durs_a = parent_a.durations or []
@@ -402,6 +421,37 @@ def _crossover_melody(
         child_durs = durs_a[: len(child_ivs)]
     elif durs_b:
         child_durs = durs_b[: len(child_ivs)]
+
+    if a_prefix_rhy and b_suffix_rhy:
+        a_last_idx = len(a_prefix_rhy) - 1
+        a_last_dur = (
+            child_durs[a_last_idx]
+            if child_durs and a_last_idx < len(child_durs)
+            else 0.5
+        )
+        min_next_onset = a_prefix_rhy[-1] + a_last_dur
+        deficit = min_next_onset - b_suffix_rhy[0]
+        if deficit > 0:
+            b_suffix_rhy = [round(t + deficit, 4) for t in b_suffix_rhy]
+
+    child_rhy = a_prefix_rhy + b_suffix_rhy
+
+    # Drop any trailing notes pushed past the bar by the re-anchoring shift —
+    # otherwise repeated crossbreeding could let a pattern's notes drift
+    # further past its own bar length with each generation.
+    bar_length = parent_a.bar_length_beats()
+    keep = len(child_rhy)
+    while keep > 1 and child_rhy[keep - 1] >= bar_length:
+        keep -= 1
+    child_ivs = child_ivs[:keep]
+    child_rhy = child_rhy[:keep]
+    if child_durs:
+        child_durs = child_durs[:keep]
+        child_durs = _clip_durations_to_next_onset(child_rhy, child_durs)
+
+    # Ensure first interval is 0 (starting pitch anchor)
+    if child_ivs:
+        child_ivs[0] = 0
 
     tags = _merge_tags(parent_a.tags, parent_b.tags)
     return replace(
@@ -421,6 +471,7 @@ def _mutate_melody(pattern: MelodyPattern) -> MelodyPattern:
 
     intervals = list(pattern.intervals)
     rhythm = list(pattern.rhythm)
+    durations = list(pattern.durations) if pattern.durations else None
 
     if random.random() < 0.5 and len(intervals) > 1:
         # Mutate a non-first interval (first must stay 0)
@@ -428,10 +479,23 @@ def _mutate_melody(pattern: MelodyPattern) -> MelodyPattern:
         intervals[idx] = intervals[idx] + random.choice([-2, -1, 1, 2])
     elif rhythm:
         idx = random.randrange(len(rhythm))
-        rhythm[idx] = max(0.0, rhythm[idx] + random.choice([-0.5, -0.25, 0.25, 0.5]))
-        rhythm.sort()  # Keep onsets ordered
+        lower = rhythm[idx - 1] if idx > 0 else 0.0
+        upper = rhythm[idx + 1] if idx + 1 < len(rhythm) else pattern.bar_length_beats()
+        margin = 0.05
+        # Clamp the shift so it can never cross a neighboring onset — this
+        # keeps `intervals`/`durations` correctly aligned with `rhythm` by
+        # index. Re-sorting rhythm after a crossing shift (the previous
+        # behavior) would silently desync which pitch/duration belongs to
+        # which onset for every note between the old and new position.
+        if upper - lower > 2 * margin:
+            shift = random.choice([-0.5, -0.25, 0.25, 0.5])
+            new_onset = max(lower + margin, min(upper - margin, rhythm[idx] + shift))
+            rhythm[idx] = round(max(0.0, new_onset), 4)
 
-    return replace(pattern, intervals=intervals, rhythm=rhythm)
+    if durations:
+        durations = _clip_durations_to_next_onset(rhythm, durations)
+
+    return replace(pattern, intervals=intervals, rhythm=rhythm, durations=durations)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/generation/src/white_generation/pipelines/bass_pipeline.py
+++ b/packages/generation/src/white_generation/pipelines/bass_pipeline.py
@@ -877,7 +877,14 @@ def run_bass_pipeline(
 
         # Rank and take top-k
         scored.sort(key=lambda x: x["composite"], reverse=True)
-        top = scored[:top_k]
+        seen_midi: set[bytes] = set()
+        deduped_scored = []
+        for item in scored:
+            if item["midi_bytes"] in seen_midi:
+                continue
+            seen_midi.add(item["midi_bytes"])
+            deduped_scored.append(item)
+        top = deduped_scored[:top_k]
 
         for rank, item in enumerate(top):
             item["rank"] = rank + 1

--- a/packages/generation/src/white_generation/pipelines/drum_pipeline.py
+++ b/packages/generation/src/white_generation/pipelines/drum_pipeline.py
@@ -595,7 +595,14 @@ def run_drum_pipeline(
 
         # Rank and take top-k
         scored.sort(key=lambda x: x["composite"], reverse=True)
-        top = scored[:top_k]
+        seen_midi: set[bytes] = set()
+        deduped_scored = []
+        for item in scored:
+            if item["midi_bytes"] in seen_midi:
+                continue
+            seen_midi.add(item["midi_bytes"])
+            deduped_scored.append(item)
+        top = deduped_scored[:top_k]
 
         for rank, item in enumerate(top):
             item["rank"] = rank + 1

--- a/packages/generation/src/white_generation/pipelines/lyric_pipeline.py
+++ b/packages/generation/src/white_generation/pipelines/lyric_pipeline.py
@@ -127,11 +127,13 @@ class Phrase:
 
 
 def extract_phrases(midi_path: Path, rest_threshold_beats: float = 0.5) -> list[Phrase]:
-    """Group note-on events into phrases separated by rests.
+    """Group notes into phrases separated by actual rests.
 
-    A new phrase begins when the gap between consecutive note-on events
-    exceeds rest_threshold_beats (default 0.5 beats = half a beat).
-    Single-note phrases are allowed.
+    A new phrase begins when the gap between one note's end (note-off) and the
+    next note's onset exceeds rest_threshold_beats (default 0.5 beats). Legato/
+    sustained melodies — where one note's onset immediately follows the prior
+    note's end with no rest — stay in a single phrase no matter how far apart
+    their onsets are; only real silence between notes splits a phrase.
 
     Returns a list of Phrase objects in order.
     """
@@ -143,43 +145,55 @@ def extract_phrases(midi_path: Path, rest_threshold_beats: float = 0.5) -> list[
     ticks_per_beat = mid.ticks_per_beat or 480
     threshold_ticks = int(rest_threshold_beats * ticks_per_beat)
 
-    # Collect all note-on absolute ticks across all tracks
-    note_ticks: list[int] = []
+    # Pair each note-on with its matching note-off (per channel+pitch, FIFO —
+    # handles retriggered/overlapping notes on the same pitch correctly) to get
+    # real (onset, end) spans rather than just onset points.
+    pending: dict[tuple[int, int], list[int]] = {}
+    note_spans: list[tuple[int, int]] = []
     for track in mid.tracks:
         abs_tick = 0
         for msg in track:
             abs_tick += msg.time
             if msg.type == "note_on" and msg.velocity > 0:
-                note_ticks.append(abs_tick)
+                pending.setdefault((msg.channel, msg.note), []).append(abs_tick)
+            elif msg.type == "note_off" or (
+                msg.type == "note_on" and msg.velocity == 0
+            ):
+                key = (msg.channel, msg.note)
+                if pending.get(key):
+                    start = pending[key].pop(0)
+                    note_spans.append((start, abs_tick))
 
-    if not note_ticks:
+    if not note_spans:
         return []
 
-    note_ticks.sort()
+    note_spans.sort(key=lambda span: span[0])
 
     phrases: list[Phrase] = []
-    phrase_start = note_ticks[0]
-    phrase_notes = [note_ticks[0]]
+    phrase_start = note_spans[0][0]
+    phrase_end = note_spans[0][1]
+    phrase_note_count = 1
 
-    for tick in note_ticks[1:]:
-        if tick - phrase_notes[-1] > threshold_ticks:
+    for start, end in note_spans[1:]:
+        if start - phrase_end > threshold_ticks:
             phrases.append(
                 Phrase(
                     start_tick=phrase_start,
-                    end_tick=phrase_notes[-1],
-                    note_count=len(phrase_notes),
+                    end_tick=phrase_end,
+                    note_count=phrase_note_count,
                 )
             )
-            phrase_start = tick
-            phrase_notes = [tick]
+            phrase_start = start
+            phrase_note_count = 1
         else:
-            phrase_notes.append(tick)
+            phrase_note_count += 1
+        phrase_end = max(phrase_end, end)
 
     phrases.append(
         Phrase(
             start_tick=phrase_start,
-            end_tick=phrase_notes[-1],
-            note_count=len(phrase_notes),
+            end_tick=phrase_end,
+            note_count=phrase_note_count,
         )
     )
 
@@ -590,14 +604,18 @@ _NO_RHYME_SCHEME = "none"
 def _default_rhyme_scheme(line_count: int) -> str:
     """Return the default scheme letters for a rhyme-eligible line count.
 
-    2 lines -> AA. 4 lines -> XAXA (lines 2 and 4 rhyme; the "ballad meter"
-    most real song lyrics use). Any other count is left unrhymed.
+    2 lines -> AA (couplet). 4 lines -> XAXA (lines 2 and 4 rhyme; the "ballad
+    meter" most real song lyrics use). Longer counts generalize the ballad
+    meter: every even-numbered line (2, 4, 6, ...) shares one rhyme, odd-
+    numbered lines are left free ("X") — this is what keeps real sections
+    (commonly 6-14 lines once phrases are extracted correctly) from silently
+    falling back to fully unrhymed. Fewer than 2 lines can't rhyme at all.
     """
+    if line_count < 2:
+        return _NO_RHYME_SCHEME
     if line_count == 2:
         return "AA"
-    if line_count == 4:
-        return "XAXA"
-    return _NO_RHYME_SCHEME
+    return "".join("A" if i % 2 == 1 else "X" for i in range(line_count))
 
 
 def _rhyme_base_label(label: str) -> str:
@@ -1503,7 +1521,7 @@ def _build_revision_message(issues: dict) -> str:
         lo, hi = issue["target"]
         if not issue["text"]:
             lines.append(
-                f'- [{issue["section"]}] line {issue["line_idx"]}: MISSING — add a'
+                f"- [{issue['section']}] line {issue['line_idx']}: MISSING — add a"
                 f" line with roughly {lo}-{hi} syllables."
             )
         else:
@@ -1513,9 +1531,9 @@ def _build_revision_message(issues: dict) -> str:
             )
     for issue in issues["rhyme_issues"]:
         lines.append(
-            f'- [{issue["section"]}] lines {issue["line_a"]} and {issue["line_b"]}'
-            f" (rhyme group {issue['letter']}): \"{issue['word_a']}\" and"
-            f" \"{issue['word_b']}\" do not rhyme."
+            f"- [{issue['section']}] lines {issue['line_a']} and {issue['line_b']}"
+            f' (rhyme group {issue["letter"]}): "{issue["word_a"]}" and'
+            f' "{issue["word_b"]}" do not rhyme.'
         )
     return "\n".join(lines)
 

--- a/packages/generation/src/white_generation/pipelines/melody_auto_split.py
+++ b/packages/generation/src/white_generation/pipelines/melody_auto_split.py
@@ -75,6 +75,47 @@ def assign_syllables_to_notes(
     ]
 
 
+def distribute_syllables_and_split(
+    notes: list[Note], syllables: list[str], min_split_ticks: int, ticks_per_beat: int
+) -> tuple[list[Note], list[str]]:
+    """Greedily distribute `syllables` (flattened across every word in a lyric
+    line) across `notes`, splitting a note into sub-notes whenever it must
+    carry more than one syllable.
+
+    This is syllable-indexed, not word-indexed: it doesn't assume one word per
+    note. At each note, the number of syllables it should carry is recomputed
+    as ceil(syllables_remaining / notes_remaining), so if an earlier note's
+    duration was too short to physically hold its share (see split_note's
+    duration cap), the shortfall is automatically redistributed across the
+    notes that follow rather than desyncing the rest of the line.
+
+    Returns (output_notes, assigned_syllable_per_output_note) — the second
+    list is parallel to output_notes; "" marks a melisma continuation slot.
+    """
+    output_notes: list[Note] = []
+    assigned: list[str] = []
+    syll_idx = 0
+    total = len(syllables)
+
+    for i, note in enumerate(notes):
+        notes_remaining = len(notes) - i
+        sylls_remaining = total - syll_idx
+        target = -(-sylls_remaining // notes_remaining) if sylls_remaining > 0 else 1
+        target = max(target, 1)
+
+        can_split = target > 1 and note.duration_ticks >= min_split_ticks
+        parts = split_note(note, target, ticks_per_beat) if can_split else [note]
+        for part in parts:
+            output_notes.append(part)
+            if syll_idx < total:
+                assigned.append(syllables[syll_idx])
+                syll_idx += 1
+            else:
+                assigned.append("")
+
+    return output_notes, assigned
+
+
 def split_note(note: Note, n: int, ticks_per_beat: int) -> list[Note]:
     """Divide note into n equal-duration sub-notes at the same pitch and velocity.
 
@@ -274,23 +315,19 @@ def auto_split_melody(
         line = lyric_lines[phrase_idx]
         words = line.split()
 
-        phrase_output: list[Note] = []
-        for note_idx, note in enumerate(phrase_notes):
-            if note_idx < len(words):
-                word_sylls = syllabify(words[note_idx])
-                n = len(word_sylls)
-                if n > 1 and note.duration_ticks >= min_split_ticks:
-                    phrase_output.extend(split_note(note, n, ticks_per_beat))
-                else:
-                    phrase_output.append(note)
-            else:
-                phrase_output.append(note)
-
         all_sylls: list[str] = []
         for word in words:
             all_sylls.extend(syllabify(word))
 
-        assignments = assign_syllables_to_notes(phrase_output, all_sylls)
+        # Syllable-indexed, not word-indexed: distributes the line's full
+        # syllable sequence across the phrase's notes left-to-right, splitting
+        # a note into sub-notes whenever it must carry more than one syllable.
+        # This correctly handles multi-word lines (a note doesn't have to line
+        # up with a single word) as well as melisma (more notes than syllables).
+        phrase_output, assigned_sylls = distribute_syllables_and_split(
+            phrase_notes, all_sylls, min_split_ticks, ticks_per_beat
+        )
+
         alignment.append(
             {
                 "phrase": phrase_idx,
@@ -298,7 +335,7 @@ def auto_split_melody(
                 "notes_in": len(phrase_notes),
                 "notes_out": len(phrase_output),
                 "syllables": len(all_sylls),
-                "assignments": [syl or "(melisma)" for _, syl in assignments],
+                "assignments": [syl or "(melisma)" for syl in assigned_sylls],
                 "uncovered": False,
             }
         )

--- a/packages/generation/src/white_generation/pipelines/melody_pipeline.py
+++ b/packages/generation/src/white_generation/pipelines/melody_pipeline.py
@@ -858,7 +858,14 @@ def run_melody_pipeline(
             )
 
         scored.sort(key=lambda x: x["composite"], reverse=True)
-        top = scored[:top_k]
+        seen_midi: set[bytes] = set()
+        deduped_scored = []
+        for item in scored:
+            if item["midi_bytes"] in seen_midi:
+                continue
+            seen_midi.add(item["midi_bytes"])
+            deduped_scored.append(item)
+        top = deduped_scored[:top_k]
 
         # Record the winning contour so subsequent sections are penalised for reuse
         if top:

--- a/packages/generation/tests/test_bass_patterns.py
+++ b/packages/generation/tests/test_bass_patterns.py
@@ -328,6 +328,32 @@ class TestTemplateSelection:
             first_energy = result[0].energy
             assert first_energy == "low"
 
+    def test_5_8_templates_exist_at_every_energy(self):
+        """Regression: bass_pipeline raised 'No bass templates for 5/8 time'
+        before these templates existed.
+        """
+        from white_generation.patterns.bass_patterns import (
+            ALL_TEMPLATES,
+            select_templates,
+        )
+
+        for energy in ("low", "medium", "high"):
+            result = select_templates(ALL_TEMPLATES, (5, 8), energy)
+            assert result, f"no 5/8 bass templates found at energy={energy}"
+            assert all(t.time_sig == (5, 8) for t in result)
+
+    def test_5_8_bar_length_and_durations_match(self):
+        from white_generation.patterns.bass_patterns import ALL_TEMPLATES
+
+        five_eight = [t for t in ALL_TEMPLATES if t.time_sig == (5, 8)]
+        assert five_eight
+        for t in five_eight:
+            assert t.bar_length_beats() == 2.5
+            if t.note_durations:
+                assert sum(t.note_durations) == 2.5, t.name
+            for pos, _tone, _velocity in t.notes:
+                assert 0 <= pos < 2.5, f"{t.name}: onset {pos} out of range"
+
 
 # ---------------------------------------------------------------------------
 # 4. Theory scoring

--- a/packages/generation/tests/test_drum_pipeline.py
+++ b/packages/generation/tests/test_drum_pipeline.py
@@ -405,6 +405,38 @@ class TestTemplateSelection:
         assert "ambient" in families
         assert "electronic" in families
 
+    def test_5_8_ambient_electronic_experimental(self):
+        """Regression: drum_pipeline raised 'No drum templates for 5/8 +
+        [ambient, electronic, experimental]' before these templates existed.
+        """
+        from white_generation.patterns.drum_patterns import (
+            ALL_TEMPLATES,
+            select_templates,
+        )
+
+        for energy in ("low", "medium", "high"):
+            result = select_templates(
+                ALL_TEMPLATES,
+                (5, 8),
+                ["ambient", "electronic", "experimental"],
+                energy,
+            )
+            assert result, f"no 5/8 templates found at energy={energy}"
+            for t in result:
+                assert t.time_sig == (5, 8)
+                assert t.genre_family in ("ambient", "electronic", "experimental")
+
+    def test_5_8_bar_length_and_onsets_in_range(self):
+        from white_generation.patterns.drum_patterns import ALL_TEMPLATES
+
+        five_eight = [t for t in ALL_TEMPLATES if t.time_sig == (5, 8)]
+        assert five_eight
+        for t in five_eight:
+            assert t.bar_length_beats() == 2.5
+            for onsets in t.voices.values():
+                for pos, _velocity in onsets:
+                    assert 0 <= pos < 2.5, f"{t.name}: onset {pos} out of range"
+
 
 # ---------------------------------------------------------------------------
 # 5. Drum MIDI generation

--- a/packages/generation/tests/test_lyric_pipeline.py
+++ b/packages/generation/tests/test_lyric_pipeline.py
@@ -92,6 +92,117 @@ class TestCountNotes:
         assert _count_notes(tmp_path / "nonexistent.mid") == 0
 
 
+def _make_notes_midi(spans: list[tuple[int, int]], ticks_per_beat: int = 480) -> bytes:
+    """Build a MIDI file from explicit (start_tick, duration_ticks) note spans,
+    so gaps (or their absence) between notes are exact and easy to reason about."""
+    mid = mido.MidiFile(ticks_per_beat=ticks_per_beat)
+    track = mido.MidiTrack()
+    mid.tracks.append(track)
+    track.append(mido.MetaMessage("set_tempo", tempo=mido.bpm2tempo(120), time=0))
+
+    events: list[tuple[int, bool]] = []
+    for start, dur in spans:
+        events.append((start, True))
+        events.append((start + dur, False))
+    events.sort(key=lambda e: (e[0], not e[1]))
+
+    prev = 0
+    for abs_tick, is_on in events:
+        msg_type = "note_on" if is_on else "note_off"
+        track.append(
+            mido.Message(
+                msg_type, note=60, velocity=80 if is_on else 0, time=abs_tick - prev
+            )
+        )
+        prev = abs_tick
+
+    track.append(mido.MetaMessage("end_of_track", time=0))
+    buf = io.BytesIO()
+    mid.save(file=buf)
+    return buf.getvalue()
+
+
+class TestExtractPhrases:
+    def test_legato_notes_merge_into_one_phrase(self, tmp_path):
+        """Zero-gap (legato) notes must stay in a single phrase regardless of
+        how far apart their onsets are — this is the exact bug that caused
+        every note in a sustained melody to be treated as its own phrase."""
+        from white_generation.pipelines.lyric_pipeline import extract_phrases
+
+        # 4 notes, each 2 beats long, perfectly back-to-back (no rest at all).
+        spans = [(i * 960, 960) for i in range(4)]
+        midi_path = tmp_path / "legato.mid"
+        midi_path.write_bytes(_make_notes_midi(spans))
+
+        phrases = extract_phrases(midi_path)
+        assert len(phrases) == 1
+        assert phrases[0].note_count == 4
+
+    def test_real_rest_splits_phrases(self, tmp_path):
+        from white_generation.pipelines.lyric_pipeline import extract_phrases
+
+        # Two notes with a full-beat rest (480 ticks) between them — well over
+        # the default 0.5-beat threshold.
+        spans = [(0, 240), (720, 240)]
+        midi_path = tmp_path / "gapped.mid"
+        midi_path.write_bytes(_make_notes_midi(spans))
+
+        phrases = extract_phrases(midi_path)
+        assert len(phrases) == 2
+        assert phrases[0].note_count == 1
+        assert phrases[1].note_count == 1
+
+    def test_rest_under_threshold_stays_one_phrase(self, tmp_path):
+        from white_generation.pipelines.lyric_pipeline import extract_phrases
+
+        # 100-tick rest, well under the default 240-tick (0.5-beat) threshold.
+        spans = [(0, 240), (340, 240)]
+        midi_path = tmp_path / "small_gap.mid"
+        midi_path.write_bytes(_make_notes_midi(spans))
+
+        phrases = extract_phrases(midi_path)
+        assert len(phrases) == 1
+        assert phrases[0].note_count == 2
+
+    def test_mixed_legato_and_rests(self, tmp_path):
+        """A realistic phrase shape: a run of legato notes, a real rest, then
+        another run of legato notes."""
+        from white_generation.pipelines.lyric_pipeline import extract_phrases
+
+        spans = [
+            (0, 480),
+            (480, 480),  # legato with previous
+            (960, 480),  # legato with previous
+            (2400, 480),  # 960 tick rest after previous note ends at 1440
+        ]
+        midi_path = tmp_path / "mixed.mid"
+        midi_path.write_bytes(_make_notes_midi(spans))
+
+        phrases = extract_phrases(midi_path)
+        assert len(phrases) == 2
+        assert phrases[0].note_count == 3
+        assert phrases[1].note_count == 1
+
+    def test_no_notes_returns_empty(self, tmp_path):
+        from white_generation.pipelines.lyric_pipeline import extract_phrases
+
+        mid = mido.MidiFile(ticks_per_beat=480)
+        track = mido.MidiTrack()
+        mid.tracks.append(track)
+        track.append(mido.MetaMessage("end_of_track", time=0))
+        path = tmp_path / "empty.mid"
+        buf = io.BytesIO()
+        mid.save(file=buf)
+        path.write_bytes(buf.getvalue())
+
+        assert extract_phrases(path) == []
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        from white_generation.pipelines.lyric_pipeline import extract_phrases
+
+        assert extract_phrases(tmp_path / "nonexistent.mid") == []
+
+
 # ---------------------------------------------------------------------------
 # 2. _fitting_verdict
 # ---------------------------------------------------------------------------
@@ -1467,12 +1578,33 @@ class TestDefaultRhymeScheme:
 
         assert _default_rhyme_scheme(4) == "XAXA"
 
-    def test_other_counts_unrhymed(self):
+    def test_fewer_than_two_lines_unrhymed(self):
         from white_generation.pipelines.lyric_pipeline import _default_rhyme_scheme
 
-        assert _default_rhyme_scheme(3) == "none"
-        assert _default_rhyme_scheme(5) == "none"
         assert _default_rhyme_scheme(0) == "none"
+        assert _default_rhyme_scheme(1) == "none"
+
+    def test_longer_counts_generalize_ballad_meter(self):
+        """Real sections commonly land at 6-14 lines once phrases are extracted
+        correctly (see extract_phrases) — these must not silently go unrhymed."""
+        from white_generation.pipelines.lyric_pipeline import _default_rhyme_scheme
+
+        assert _default_rhyme_scheme(3) == "XAX"
+        assert _default_rhyme_scheme(5) == "XAXAX"
+        assert _default_rhyme_scheme(6) == "XAXAXA"
+        assert _default_rhyme_scheme(14) == "XA" * 7
+
+    def test_longer_counts_still_produce_rhyme_pairs(self):
+        from white_generation.pipelines.lyric_pipeline import (
+            _default_rhyme_scheme,
+            rhyme_scheme_line_pairs,
+        )
+
+        pairs = rhyme_scheme_line_pairs(_default_rhyme_scheme(14))
+        assert len(pairs) > 0
+        # Every even line (2, 4, ..., 14) participates in at least one pair.
+        involved = {a for a, _, _ in pairs} | {b for _, b, _ in pairs}
+        assert involved == set(range(2, 15, 2))
 
 
 class TestAssignRhymeSchemes:

--- a/packages/generation/tests/test_melody_auto_split.py
+++ b/packages/generation/tests/test_melody_auto_split.py
@@ -9,6 +9,7 @@ from white_generation.pipelines.melody_auto_split import (
     Note,
     assign_syllables_to_notes,
     auto_split_melody,
+    distribute_syllables_and_split,
     split_note,
     syllabify,
 )
@@ -137,6 +138,74 @@ def test_assign_empty_notes():
 
 
 # ---------------------------------------------------------------------------
+# distribute_syllables_and_split
+# ---------------------------------------------------------------------------
+
+
+def test_distribute_equal_count_no_splitting():
+    notes, sylls = distribute_syllables_and_split(
+        _notes(3), ["one", "two", "three"], TICKS, TICKS
+    )
+    assert len(notes) == 3
+    assert sylls == ["one", "two", "three"]
+
+
+def test_distribute_more_notes_than_syllables_is_melisma():
+    notes, sylls = distribute_syllables_and_split(_notes(4), ["a", "b"], TICKS, TICKS)
+    assert len(notes) == 4
+    assert sylls == ["a", "b", "", ""]
+
+
+def test_distribute_more_syllables_than_notes_splits():
+    """3 syllables, 2 notes -> the first note splits to carry 2 syllables."""
+    notes, sylls = distribute_syllables_and_split(
+        _notes(2), ["a", "b", "c"], TICKS, TICKS
+    )
+    assert len(notes) == 3
+    assert sylls == ["a", "b", "c"]
+
+    original = _notes(2)
+    # First original note (index 0, duration TICKS) absorbed 2 syllables.
+    assert (
+        notes[0].duration_ticks + notes[1].duration_ticks == original[0].duration_ticks
+    )
+    # Second original note (index 1) kept its full duration, one syllable.
+    assert notes[2].duration_ticks == original[1].duration_ticks
+
+
+def test_distribute_short_note_shortfall_redistributes_to_later_notes():
+    """If a note is too short to split (below min_split_ticks), the syllable
+    it couldn't absorb rolls forward onto later notes instead of being lost."""
+    short_note = Note(start_tick=0, pitch=60, velocity=80, duration_ticks=10, channel=0)
+    long_note = Note(
+        start_tick=10, pitch=61, velocity=80, duration_ticks=TICKS * 2, channel=0
+    )
+    notes, sylls = distribute_syllables_and_split(
+        [short_note, long_note],
+        ["a", "b", "c"],
+        min_split_ticks=TICKS,
+        ticks_per_beat=TICKS,
+    )
+    # short_note couldn't split (below min_split_ticks) -> carries only "a".
+    # long_note absorbs both remaining syllables ("b", "c") by splitting.
+    assert sylls == ["a", "b", "c"]
+    assert len(notes) == 3
+    assert notes[0].duration_ticks == 10
+
+
+def test_distribute_empty_notes():
+    notes, sylls = distribute_syllables_and_split([], ["a"], TICKS, TICKS)
+    assert notes == []
+    assert sylls == []
+
+
+def test_distribute_empty_syllables_no_split():
+    notes, sylls = distribute_syllables_and_split(_notes(2), [], TICKS, TICKS)
+    assert len(notes) == 2
+    assert sylls == ["", ""]
+
+
+# ---------------------------------------------------------------------------
 # split_note
 # ---------------------------------------------------------------------------
 
@@ -179,15 +248,15 @@ def test_split_n1_is_noop():
 
 
 def test_auto_split_integration(tmp_path: Path):
-    """4-bar melody: 4 notes, lyrics with multi-syllable words → output has >= 4 notes."""
-    # Build a 4-note melody: each note is 2 beats long (enough to split)
+    """4 legato (back-to-back, no rest) notes form a single phrase; a
+    multi-syllable single-word line assigned to it should split notes to
+    surface all its syllables."""
     note_data = [(i * TICKS * 2, 60 + i, TICKS * 2) for i in range(4)]
     midi_bytes = make_melody_midi(note_data)
     midi_path = tmp_path / "verse.mid"
     midi_path.write_bytes(midi_bytes)
 
-    # Lyrics: 4 lines, each a multi-syllable word
-    lyrics = "[verse]\nbeautiful\ncataloging\neverything\nbelonging\n"
+    lyrics = "[verse]\nbeautiful\n"
     lyrics_path = tmp_path / "lyrics.txt"
     lyrics_path.write_text(lyrics)
 
@@ -208,9 +277,44 @@ def test_auto_split_integration(tmp_path: Path):
     output_pitches = set(pitches_from_midi(output_bytes))
     assert original_pitches.issubset(output_pitches)
 
-    # Alignment report has one entry per phrase
-    assert len(alignment) == 4
-    assert all(a["notes_in"] == 1 for a in alignment)
+    # The 4 notes are legato (zero rest) -> exactly one real phrase.
+    assert len(alignment) == 1
+    assert alignment[0]["notes_in"] == 4
+
+
+def test_auto_split_multiword_line_distributes_by_syllable_not_word(
+    tmp_path: Path,
+):
+    """Regression: a phrase with fewer notes than a lyric line has words used
+    to silently drop trailing words (word-indexed assignment). Syllables from
+    every word in the line must now be distributed across the phrase's notes
+    by syllable position, splitting notes as needed."""
+    # 2 legato notes (one phrase), each long enough to split into 2.
+    note_data = [(0, 60, TICKS * 2), (TICKS * 2, 61, TICKS * 2)]
+    midi_bytes = make_melody_midi(note_data)
+    midi_path = tmp_path / "verse.mid"
+    midi_path.write_bytes(midi_bytes)
+
+    # 3 one-syllable words across only 2 notes.
+    lyrics = "[verse]\nthree word phrase\n"
+    lyrics_path = tmp_path / "lyrics.txt"
+    lyrics_path.write_text(lyrics)
+
+    _, alignment = auto_split_melody(
+        midi_path=midi_path,
+        lyrics_path=lyrics_path,
+        section="verse",
+        min_split_ticks=TICKS,
+    )
+
+    assert len(alignment) == 1
+    entry = alignment[0]
+    assert entry["notes_in"] == 2
+    assert entry["syllables"] == 3
+    # All three words must survive into the assignment — none silently dropped.
+    assert entry["assignments"] == ["three", "word", "phrase"]
+    # A note had to be split to make room for the 3rd syllable.
+    assert entry["notes_out"] == 3
 
 
 def test_auto_split_output_path_convention(tmp_path: Path):

--- a/packages/generation/tests/test_melody_patterns.py
+++ b/packages/generation/tests/test_melody_patterns.py
@@ -402,6 +402,24 @@ class TestTemplateSelection:
         assert len(results) > 0
         assert all(t.time_sig == (6, 8) for t in results)
 
+    def test_5_8_templates_exist_vocal_and_lead(self):
+        """Regression: melody_pipeline raised 'No melody templates for 5/8
+        time (use_case=...)' before these templates existed.
+        """
+        from white_generation.patterns.melody_patterns import (
+            ALL_TEMPLATES,
+            select_templates,
+        )
+
+        for use_case in ("vocal", "lead"):
+            for energy in ("low", "medium", "high"):
+                results = select_templates(
+                    ALL_TEMPLATES, (5, 8), energy, use_case=use_case
+                )
+                assert results, f"no 5/8 {use_case} templates found at energy={energy}"
+                assert all(t.time_sig == (5, 8) for t in results)
+                assert all(t.use_case == use_case for t in results)
+
 
 # ---------------------------------------------------------------------------
 # 7. Theory scoring

--- a/packages/generation/tests/test_pattern_evolution.py
+++ b/packages/generation/tests/test_pattern_evolution.py
@@ -407,12 +407,25 @@ class TestMelodyMutation:
 )
 class TestBreedDrumPatterns:
     def test_returns_top_n(self, mock_score):
-        seeds = [_make_drum(f"d{i}") for i in range(5)]
+        seeds = []
+        for i in range(5):
+            seed = _make_drum(f"d{i}")
+            seed.voices = {
+                **seed.voices,
+                "kick": [(0.0, "accent"), (float(i), "normal")],
+            }
+            seeds.append(seed)
         concept_emb = np.zeros(768)
         result = breed_drum_patterns(
             concept_emb, seeds, generations=2, population_size=10, top_n=3
         )
-        assert len(result) == 3
+        # Elitism + low mutation probability can legitimately converge on
+        # fewer unique genomes than top_n; the invariant is no duplicates.
+        assert 1 <= len(result) <= 3
+        signatures = {
+            tuple(sorted((k, tuple(v)) for k, v in p.voices.items())) for p in result
+        }
+        assert len(signatures) == len(result)
 
     def test_all_are_drum_patterns(self, mock_score):
         seeds = [_make_drum(f"d{i}") for i in range(4)]
@@ -490,12 +503,24 @@ class TestBreedMelodyPatterns:
         assert result == []
 
     def test_fitness_ordering_preserved(self, mock_score):
-        """The first result should have the highest fitness (highest index in fake scorer)."""
-        seeds = [_make_melody(f"m{i}") for i in range(5)]
+        """Results never exceed top_n and never contain a duplicate genome.
+
+        Elitism (n=2) plus a 0.35 mutation probability means a small,
+        single-generation population can legitimately converge on fewer
+        unique genomes than top_n — the invariant that matters is that
+        whatever comes back has no duplicate (identical rendered MIDI)
+        entries, since a duplicate can never be musically distinguished
+        from another equally-fit candidate.
+        """
+        seeds = []
+        for i in range(5):
+            seed = _make_melody(f"m{i}")
+            seed.intervals = [0, i + 1, -(i + 1), 2, -2, 1]
+            seeds.append(seed)
         chord_prog = [{"root": 60, "notes": [60, 64, 67]}]
-        # With fake scorer, the last items get highest scores — but after sorting
-        # we just verify the returned list is ordered descending
         result = breed_melody_patterns(
             np.zeros(768), chord_prog, seeds, generations=1, population_size=5, top_n=5
         )
-        assert len(result) == 5
+        assert 1 <= len(result) <= 5
+        signatures = {(tuple(p.intervals), tuple(p.rhythm)) for p in result}
+        assert len(signatures) == len(result)

--- a/packages/generation/tests/test_pattern_evolution.py
+++ b/packages/generation/tests/test_pattern_evolution.py
@@ -349,6 +349,47 @@ class TestMelodyCrossover:
         }
         assert len(boundaries) > 1
 
+    def test_child_stays_monophonic_across_mismatched_parents(self):
+        """Regression: splicing two parents' rhythm/duration arrays verbatim
+        (without re-anchoring) let the B-suffix's first onset land before the
+        A-prefix's last note actually finished — producing overlapping notes
+        in real evolved output (confirmed against production data: up to 3
+        simultaneous notes). Parents here have deliberately mismatched
+        rhythmic density so the splice boundary is very likely to collide
+        without the fix."""
+        a = _make_melody("a")
+        a.intervals = [0, 1, 1, 1, 1]
+        a.rhythm = [0.0, 0.2, 0.4, 0.6, 0.8]
+        a.durations = [0.9, 0.9, 0.9, 0.9, 0.9]  # deliberately long, overlapping-prone
+
+        b = _make_melody("b")
+        b.intervals = [0, -1, -1, -1, -1]
+        b.rhythm = [0.0, 1.0, 2.0, 3.0, 3.9]
+        b.durations = [1.0, 1.0, 1.0, 1.0, 0.5]
+
+        for _ in range(100):
+            child = _crossover_melody(a, b)
+            assert child.rhythm == sorted(child.rhythm)
+            assert len(set(child.rhythm)) == len(child.rhythm)  # strictly increasing
+            if child.durations:
+                for i in range(len(child.rhythm) - 1):
+                    gap = child.rhythm[i + 1] - child.rhythm[i]
+                    assert child.durations[i] <= gap + 1e-9
+
+    def test_child_notes_fit_within_bar(self):
+        a = _make_melody("a")
+        a.intervals = [0, 1, 1, 1, 1]
+        a.rhythm = [0.0, 0.5, 1.0, 1.5, 3.9]
+        a.durations = [0.5, 0.5, 0.5, 0.5, 0.5]
+        b = _make_melody("b")
+        b.intervals = [0, -1, -1, -1, -1]
+        b.rhythm = [0.0, 0.1, 0.2, 0.3, 0.4]
+        b.durations = [2.0, 2.0, 2.0, 2.0, 2.0]
+
+        for _ in range(50):
+            child = _crossover_melody(a, b)
+            assert child.rhythm[-1] < child.bar_length_beats()
+
 
 class TestMelodyMutation:
     def test_returns_melody_pattern(self):
@@ -394,6 +435,38 @@ class TestMelodyMutation:
                 abs(r - o) for r, o in zip(sorted(result.rhythm), sorted(p.rhythm))
             ]
             assert max(deltas) <= 0.5 + 1e-9
+
+    def test_onset_shift_never_crosses_a_neighbor(self):
+        """Regression: shifting one onset then re-sorting the whole rhythm
+        array (the previous behavior) could move that onset past a neighbor,
+        silently desyncing `intervals`/`durations` from `rhythm` by index for
+        every note between the old and new position. The shift must instead
+        be clamped so onset order — and therefore note identity — never
+        changes."""
+        p = _make_melody()
+        p.rhythm = [0.0, 0.5, 1.0, 1.5, 2.0, 2.5]
+        for _ in range(200):
+            with patch(
+                "white_generation.patterns.pattern_evolution.random.random",
+                side_effect=[0.0, 0.9],  # trigger mutation, take onset-shift branch
+            ):
+                result = _mutate_melody(p)
+            assert result.rhythm == sorted(result.rhythm)
+            assert len(set(result.rhythm)) == len(result.rhythm)
+
+    def test_mutation_keeps_notes_monophonic(self):
+        p = _make_melody()
+        p.rhythm = [0.0, 0.5, 1.0, 1.5, 2.0, 2.5]
+        p.durations = [0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
+        for _ in range(200):
+            with patch(
+                "white_generation.patterns.pattern_evolution.random.random",
+                side_effect=[0.0, 0.9],
+            ):
+                result = _mutate_melody(p)
+            for i in range(len(result.rhythm) - 1):
+                gap = result.rhythm[i + 1] - result.rhythm[i]
+                assert result.durations[i] <= gap + 1e-9
 
 
 # ---------------------------------------------------------------------------
@@ -455,12 +528,25 @@ class TestBreedDrumPatterns:
 )
 class TestBreedBassPatterns:
     def test_returns_top_n(self, mock_score):
-        seeds = [_make_bass(f"b{i}") for i in range(5)]
+        seeds = []
+        for i in range(5):
+            seed = _make_bass(f"b{i}")
+            seed.notes = [
+                (0.0, BassChordTone.ROOT, "accent"),
+                (1.0, BassChordTone.FIFTH, "normal"),
+                (2.0, BassChordTone.ROOT, "normal"),
+                (3.0 - i * 0.1, BassChordTone.OCTAVE_UP, "ghost"),
+            ]
+            seeds.append(seed)
         chord_prog = [{"root": 36, "notes": [36, 43, 48]}]
         result = breed_bass_patterns(
             np.zeros(768), chord_prog, seeds, generations=2, population_size=10, top_n=3
         )
-        assert len(result) == 3
+        # Elitism + low mutation probability can legitimately converge on
+        # fewer unique genomes than top_n; the invariant is no duplicates.
+        assert 1 <= len(result) <= 3
+        signatures = {tuple(n for n in p.notes) for p in result}
+        assert len(signatures) == len(result)
 
     def test_all_are_bass_patterns(self, mock_score):
         seeds = [_make_bass(f"b{i}") for i in range(4)]

--- a/uv.lock
+++ b/uv.lock
@@ -7525,7 +7525,7 @@ requires-dist = [
 
 [[package]]
 name = "white-api"
-version = "0.2.1"
+version = "0.3.0"
 source = { editable = "packages/api" }
 dependencies = [
     { name = "fastapi" },
@@ -7558,7 +7558,7 @@ requires-dist = [
 
 [[package]]
 name = "white-composition"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "packages/composition" }
 dependencies = [
     { name = "anthropic" },
@@ -7642,7 +7642,7 @@ requires-dist = [
 
 [[package]]
 name = "white-generation"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "packages/generation" }
 dependencies = [
     { name = "mido" },

--- a/uv.lock
+++ b/uv.lock
@@ -7642,7 +7642,7 @@ requires-dist = [
 
 [[package]]
 name = "white-generation"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "packages/generation" }
 dependencies = [
     { name = "mido" },


### PR DESCRIPTION
## Summary

A batch of generation-pipeline bug fixes plus one new feature, all developed together on this branch:

**Bug fixes:**
- Melody evolution was producing many duplicate candidates (elitism + low mutation probability let identical genomes persist); added dedup-by-rendered-MIDI before final candidate selection across melody/drum/bass.
- Candidate review UI served MIDI/mix files by a bare id with no song/production scoping, so switching songs could play back a stale/wrong song's audio; added song-scoped routes.
- `drum_pipeline`/`bass_pipeline`/`melody_pipeline` all hard-failed with no fallback on unsupported time signatures (e.g. 5/8); added 5/8 templates for drums, bass, and melody (lead + vocal).
- Lyric generation was producing single-syllable, non-rhyming lines: `extract_phrases` fragmented every note of a legato melody into its own fake phrase (measuring onset-to-onset instead of actual rests), which forced tiny syllable budgets and starved the rhyme-scheme logic (which only had defaults for exactly 2/4 lines) of any real line count to work with.
- `auto_split_melody` assigned lyric syllables by word *position* instead of syllable position, silently dropping words whenever a phrase had fewer notes than a line had words.
- Evolved melody candidates could produce overlapping (polyphonic) notes: crossover spliced two parents' onset/duration arrays verbatim with no guarantee of temporal ordering at the splice boundary; mutation's onset-shift re-sorted `rhythm` without keeping `intervals`/`durations` aligned by index. Verified against real production data (previously up to 3 simultaneous notes, now consistently monophonic).
- Fixed incidental flaky tests in drum/bass/melody breeding hit while working on the above (identical-seed test fixtures colliding with the new dedup logic).

**New feature:**
- Listening-playlist sync (see `openspec/changes/add-listening-playlist-sync/`): a "Sync to Playlists" button on the Sides page that buckets every song with a finished mix into Rejects/Review/White Album WiP folders (full deterministic rebuild, WiP sequenced by Side A-D + position) at a configurable local output directory, for dragging into Apple Music.

## Test plan
- [x] Full `packages/generation`, `packages/api`, `packages/composition` test suites pass
- [x] `ruff check` / `ruff format --check` clean across touched packages
- [x] `tsc --noEmit` clean for client changes
- [x] Verified dedup, 5/8 templates, lyric-phrase detection, and monophonic-melody fixes against real production data (not just unit tests)
- [x] Playlist sync verified end-to-end against a fixture album via the real API + client dev server (browser extension wasn't available this session, so the button itself wasn't clicked in a live browser — worth a manual click-through before merging)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01FxeF94amCVXR2vg7Ljz7eS