### PR TITLE
Fix song-proposal supersession tracking in the Rainbow Table agent pipeline

### DIFF
--- a/packages/composition/pyproject.toml
+++ b/packages/composition/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "white-composition"
-version = "0.3.1"
+version = "0.4.0"
 description = "Production orchestration, pipeline runner, and candidate review for White project"
 requires-python = ">=3.12"
 dependencies = [

--- a/packages/composition/src/white_composition/shrinkwrap_chain_artifacts.py
+++ b/packages/composition/src/white_composition/shrinkwrap_chain_artifacts.py
@@ -458,6 +458,43 @@ _SKIP_PROPOSALS = {"evp.yml", "all_song_proposals.yml"}
 _PROPOSAL_REQUIRED_KEYS = {"bpm", "key", "rainbow_color"}
 
 
+def _load_final_iteration_lookup(yml_dir: Path) -> dict[str, bool]:
+    """Return {iteration_id: is_final}, resolved via resolve_supersession_chains,
+    from this thread's all_song_proposals*.yml bundle if one exists.
+
+    Individual per-iteration yml files can be dumped to yml_dir at generation
+    time and never revisited, so their own is_final field may be stale by the
+    time a later counter-proposal in the same chain supersedes them (see
+    resolve_supersession_chains). The combined bundle is the one place that
+    reflects the fully-resolved state, so scaffolding should defer to it.
+    Returns {} if no bundle is found — callers should then fall back to
+    trusting each file's own is_final field. A single malformed entry in the
+    bundle (e.g. a corrupted title) is skipped rather than aborting the whole
+    lookup — the remaining entries still resolve correctly.
+    """
+    bundle_paths = sorted(yml_dir.glob("all_song_proposals*.yml"))
+    if not bundle_paths:
+        return {}
+    from white_core.manifests.song_proposal import (
+        SongProposalIteration,
+        resolve_supersession_chains,
+    )
+
+    try:
+        with open(bundle_paths[0]) as f:
+            data = yaml.safe_load(f) or {}
+    except Exception:
+        return {}
+    iterations = []
+    for it in data.get("iterations") or []:
+        try:
+            iterations.append(SongProposalIteration(**it))
+        except Exception:
+            continue
+    resolved, _ = resolve_supersession_chains(iterations)
+    return {it.iteration_id: it.is_final for it in resolved}
+
+
 def _extract_time_sig(proposal: dict) -> str:
     """Derive a "N/N" time signature string from a raw proposal dict.
 
@@ -482,16 +519,23 @@ def _extract_time_sig(proposal: dict) -> str:
 def scaffold_song_productions(
     thread_dest_dir: Path, yml_dir: Path, force: bool = False
 ) -> list[str]:
-    """Create production/<slug>/manifest_bootstrap.yml for each song proposal in yml_dir.
+    """Create production/<slug>/manifest_bootstrap.yml for each *final* song proposal in yml_dir.
 
     A YAML file is treated as a song proposal if it contains bpm, key, and rainbow_color.
     Known non-proposal files (evp.yml, all_song_proposals.yml) are always skipped.
+    A proposal that resolves to is_final=False — either per the thread's
+    all_song_proposals*.yml bundle (see _load_final_iteration_lookup) or, absent
+    a bundle, per its own is_final field — is skipped: it was superseded by a
+    later counter-proposal in the same revision chain and should not get its
+    own production directory.
     Existing manifest_bootstrap.yml files are never overwritten (idempotent).
 
     Returns list of production slugs created (or already existing).
     """
     if not yml_dir.exists():
         return []
+
+    final_lookup = _load_final_iteration_lookup(yml_dir)
 
     created = []
     for yml_path in sorted(yml_dir.glob("*.yml")):
@@ -505,6 +549,13 @@ def scaffold_song_productions(
         if not isinstance(proposal, dict):
             continue
         if not _PROPOSAL_REQUIRED_KEYS.issubset(proposal):
+            continue
+
+        iteration_id = proposal.get("iteration_id")
+        if iteration_id in final_lookup:
+            if not final_lookup[iteration_id]:
+                continue
+        elif proposal.get("is_final") is False:
             continue
 
         slug = yml_path.stem

--- a/packages/composition/src/white_composition/shrinkwrap_chain_artifacts.py
+++ b/packages/composition/src/white_composition/shrinkwrap_chain_artifacts.py
@@ -24,6 +24,10 @@ from typing import Optional
 
 import yaml
 
+from white_core.manifests.song_proposal import (
+    SongProposalIteration,
+    resolve_supersession_chains,
+)
 from white_extraction.util.generate_negative_constraints import (
     generate_constraints,
     write_constraints,
@@ -475,11 +479,6 @@ def _load_final_iteration_lookup(yml_dir: Path) -> dict[str, bool]:
     bundle_paths = sorted(yml_dir.glob("all_song_proposals*.yml"))
     if not bundle_paths:
         return {}
-    from white_core.manifests.song_proposal import (
-        SongProposalIteration,
-        resolve_supersession_chains,
-    )
-
     try:
         with open(bundle_paths[0]) as f:
             data = yaml.safe_load(f) or {}

--- a/packages/composition/tests/test_shrinkwrap_chain_artifacts.py
+++ b/packages/composition/tests/test_shrinkwrap_chain_artifacts.py
@@ -834,6 +834,34 @@ def _write_proposal(yml_dir: Path, name: str, extra: dict | None = None) -> Path
     return path
 
 
+def _iteration_dict(
+    iteration_id: str,
+    iteration_number: int | None,
+    is_final: bool,
+    rainbow_color: str = "Red",
+) -> dict:
+    return {
+        "iteration_id": iteration_id,
+        "iteration_number": iteration_number,
+        "is_final": is_final,
+        "bpm": 120,
+        "key": "C major",
+        "rainbow_color": rainbow_color,
+        "title": iteration_id,
+        "mood": ["melancholic"],
+        "genres": ["ambient"],
+        "concept": "A test concept that is long enough to pass the minimum "
+        "length validator for the concept field.",
+    }
+
+
+def _write_bundle(yml_dir: Path, iterations: list[dict]) -> Path:
+    path = yml_dir / "all_song_proposals.yml"
+    with open(path, "w") as f:
+        yaml.dump({"iterations": iterations}, f)
+    return path
+
+
 class TestScaffoldSongProductions:
     def test_creates_production_dir_and_manifest(self, tmp_path):
         yml_dir = tmp_path / "yml"
@@ -919,6 +947,124 @@ class TestScaffoldSongProductions:
         second_run = scaffold_song_productions(tmp_path, yml_dir)
         assert manifest.read_text() == "title: overwritten\n"
         assert second_run == []  # nothing newly created
+
+    def test_skips_proposal_marked_not_final_by_bundle(self, tmp_path):
+        """Regression: a proposal file whose own is_final field is stale/true
+        must still be skipped if the thread's all_song_proposals.yml bundle
+        (the authoritative, resolved source) says it's not final."""
+        yml_dir = tmp_path / "yml"
+        yml_dir.mkdir()
+        _write_proposal(
+            yml_dir,
+            "seed_v1",
+            {"iteration_id": "seed_v1", "iteration_number": 1, "is_final": True},
+        )
+        _write_bundle(
+            yml_dir,
+            [_iteration_dict("seed_v1", 1, is_final=False)],
+        )
+
+        slugs = scaffold_song_productions(tmp_path, yml_dir)
+        assert slugs == []
+        assert not (tmp_path / "production" / "seed_v1").exists()
+
+    def test_scaffolds_proposal_marked_final_by_bundle(self, tmp_path):
+        yml_dir = tmp_path / "yml"
+        yml_dir.mkdir()
+        _write_proposal(
+            yml_dir,
+            "final_v3",
+            {"iteration_id": "final_v3", "iteration_number": 3, "is_final": True},
+        )
+        _write_bundle(
+            yml_dir,
+            [_iteration_dict("final_v3", 3, is_final=True)],
+        )
+
+        slugs = scaffold_song_productions(tmp_path, yml_dir)
+        assert slugs == ["final_v3"]
+
+    def test_bundle_resolves_pivot_chain_and_skips_superseded(self, tmp_path):
+        """Integration case: a White seed (iteration 1) pivoted to Black by a
+        counter-proposal (iteration 2), both individually dumped with
+        is_final: true (real-world case: instantiation_sequence_v1/v2). Only
+        the last entry in the chain should be scaffolded into a production
+        directory."""
+        yml_dir = tmp_path / "yml"
+        yml_dir.mkdir()
+        _write_proposal(
+            yml_dir,
+            "seed_v1",
+            {
+                "iteration_id": "seed_v1",
+                "iteration_number": 1,
+                "rainbow_color": "White",
+                "is_final": True,
+            },
+        )
+        _write_proposal(
+            yml_dir,
+            "pivot_v2",
+            {
+                "iteration_id": "pivot_v2",
+                "iteration_number": 2,
+                "rainbow_color": "Black",
+                "is_final": True,
+            },
+        )
+        _write_bundle(
+            yml_dir,
+            [
+                _iteration_dict("seed_v1", 1, is_final=True, rainbow_color="White"),
+                _iteration_dict("pivot_v2", 2, is_final=True, rainbow_color="Black"),
+            ],
+        )
+
+        slugs = scaffold_song_productions(tmp_path, yml_dir)
+        assert slugs == ["pivot_v2"]
+        assert not (tmp_path / "production" / "seed_v1").exists()
+
+    def test_falls_back_to_own_is_final_when_no_bundle(self, tmp_path):
+        yml_dir = tmp_path / "yml"
+        yml_dir.mkdir()
+        _write_proposal(
+            yml_dir, "draft_v1", {"iteration_id": "draft_v1", "is_final": False}
+        )
+
+        slugs = scaffold_song_productions(tmp_path, yml_dir)
+        assert slugs == []
+
+    def test_scaffolds_when_is_final_absent_and_no_bundle(self, tmp_path):
+        """Legacy proposals with no is_final field at all (and no bundle to
+        resolve against) keep working exactly as before this fix."""
+        yml_dir = tmp_path / "yml"
+        yml_dir.mkdir()
+        _write_proposal(yml_dir, "legacy_v1")
+
+        slugs = scaffold_song_productions(tmp_path, yml_dir)
+        assert slugs == ["legacy_v1"]
+
+    def test_malformed_bundle_entry_does_not_disable_whole_lookup(self, tmp_path):
+        """A single unparseable entry in the bundle (e.g. a corrupted title,
+        real-world case: last_click_train_prism_v1) must be skipped, not
+        abort resolution for every other entry in the thread."""
+        yml_dir = tmp_path / "yml"
+        yml_dir.mkdir()
+        _write_proposal(
+            yml_dir,
+            "seed_v1",
+            {"iteration_id": "seed_v1", "iteration_number": 1, "is_final": True},
+        )
+        malformed = _iteration_dict("broken_v1", None, is_final=True)
+        malformed["title"] = "x" * 200  # exceeds the 150-char max_length
+        _write_bundle(
+            yml_dir,
+            [_iteration_dict("seed_v1", 1, is_final=False), malformed],
+        )
+
+        slugs = scaffold_song_productions(tmp_path, yml_dir)
+        assert slugs == []
+        assert not (tmp_path / "production" / "seed_v1").exists()
 
     def test_singer_field_included_when_present(self, tmp_path):
         yml_dir = tmp_path / "yml"

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "white-core"
-version = "0.1.0"
+version = "0.2.0"
 description = "Shared Pydantic models, enums, and types for the White project"
 requires-python = ">=3.12"
 dependencies = [

--- a/packages/core/src/white_core/manifests/song_proposal.py
+++ b/packages/core/src/white_core/manifests/song_proposal.py
@@ -244,3 +244,56 @@ class SongProposal(BaseModel):
 
     def __init__(self, **data):
         super().__init__(**data)
+
+
+def resolve_supersession_chains(
+    iterations: List[SongProposalIteration],
+) -> tuple[List[SongProposalIteration], set[int]]:
+    """Drop exact-duplicate iterations and clear is_final on superseded links.
+
+    A counter-proposal is always generated from the current last entry in
+    the run's iteration list (see e.g. black_agent.py's
+    `current_proposal = state.song_proposals.iterations[-1]`), and each agent
+    assigns its result the next `iteration_number` in the overall sequence.
+    A maximal run of consecutive iteration_number values (n, n+1, n+2, ...)
+    therefore represents one continuous revision chain — even when a
+    counter-proposal pivots the color or title entirely (e.g. a White seed
+    rejected into a Black rework) — and only the last entry in that chain is
+    the one that should end up is_final. Entries with no iteration_number, or
+    whose number doesn't continue from the previous entry, start their own
+    independent chain of length one and are left untouched: they represent a
+    genuinely new, separate song rather than a revision of what came before.
+
+    Returns (deduped_iterations, superseded_ids) where superseded_ids holds
+    id() of every iteration this pass cleared — callers must not treat those
+    as "never decided" and re-promote them via a same-color/default fallback.
+    """
+    deduped: List[SongProposalIteration] = []
+    seen: set[tuple] = set()
+    for it in iterations:
+        key = (it.iteration_id, it.iteration_number)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(it)
+
+    chains: List[List[SongProposalIteration]] = []
+    for it in deduped:
+        prev_chain = chains[-1] if chains else None
+        prev_number = prev_chain[-1].iteration_number if prev_chain else None
+        if (
+            prev_chain is not None
+            and prev_number is not None
+            and it.iteration_number == prev_number + 1
+        ):
+            prev_chain.append(it)
+        else:
+            chains.append([it])
+
+    superseded_ids: set[int] = set()
+    for chain in chains:
+        for superseded in chain[:-1]:
+            superseded.is_final = False
+            superseded_ids.add(id(superseded))
+
+    return deduped, superseded_ids

--- a/packages/core/tests/manifests/test_song_proposal.py
+++ b/packages/core/tests/manifests/test_song_proposal.py
@@ -1,7 +1,10 @@
 import pytest
 from pydantic import ValidationError
 
-from white_core.manifests.song_proposal import SongProposalIteration
+from white_core.manifests.song_proposal import (
+    SongProposalIteration,
+    resolve_supersession_chains,
+)
 
 
 def valid_iteration_data(**overrides):
@@ -87,3 +90,84 @@ def test_mood_and_genres_type_validators():
 
     with pytest.raises(ValidationError):
         SongProposalIteration(**valid_iteration_data(genres="also-not-a-list"))
+
+
+def test_resolve_supersession_chains_clears_pivoted_seed():
+    """A White seed pivoted to Black by a counter-proposal must lose is_final,
+    even though color and title change mid-chain."""
+    seed = SongProposalIteration(
+        **valid_iteration_data(
+            iteration_id="seed_v1",
+            iteration_number=1,
+            rainbow_color="White",
+            is_final=True,
+        )
+    )
+    pivot = SongProposalIteration(
+        **valid_iteration_data(
+            iteration_id="pivot_v2",
+            iteration_number=2,
+            rainbow_color="Black",
+            is_final=True,
+        )
+    )
+
+    resolved, superseded_ids = resolve_supersession_chains([seed, pivot])
+
+    assert resolved == [seed, pivot]
+    assert seed.is_final is False
+    assert pivot.is_final is True
+    assert id(seed) in superseded_ids
+    assert id(pivot) not in superseded_ids
+
+
+def test_resolve_supersession_chains_drops_exact_duplicates():
+    seed = SongProposalIteration(
+        **valid_iteration_data(
+            iteration_id="seed_v1", iteration_number=1, is_final=True
+        )
+    )
+    dup_a = SongProposalIteration(
+        **valid_iteration_data(iteration_id="dup_v2", iteration_number=2, is_final=True)
+    )
+    dup_b = SongProposalIteration(
+        **valid_iteration_data(iteration_id="dup_v2", iteration_number=2, is_final=True)
+    )
+    final = SongProposalIteration(
+        **valid_iteration_data(
+            iteration_id="final_v3", iteration_number=3, is_final=True
+        )
+    )
+
+    resolved, _ = resolve_supersession_chains([seed, dup_a, dup_b, final])
+
+    assert [it.iteration_id for it in resolved] == ["seed_v1", "dup_v2", "final_v3"]
+    assert seed.is_final is False
+    assert dup_a.is_final is False
+    assert final.is_final is True
+
+
+def test_resolve_supersession_chains_leaves_independent_iterations_untouched():
+    """Non-consecutive iteration_number, or None, starts an independent chain
+    of length one and must not be cleared."""
+    orange = SongProposalIteration(
+        **valid_iteration_data(
+            iteration_id="orange_v1",
+            iteration_number=1,
+            rainbow_color="Orange",
+            is_final=True,
+        )
+    )
+    yellow = SongProposalIteration(
+        **valid_iteration_data(
+            iteration_id="yellow_v1",
+            iteration_number=None,
+            rainbow_color="Yellow",
+            is_final=True,
+        )
+    )
+
+    resolve_supersession_chains([orange, yellow])
+
+    assert orange.is_final is True
+    assert yellow.is_final is True

--- a/packages/ideation/pyproject.toml
+++ b/packages/ideation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "white-ideation"
-version = "0.1.1"
+version = "0.2.0"
 description = "Agents, reference data, and creative ideation for White project"
 requires-python = ">=3.12"
 dependencies = [

--- a/packages/ideation/src/white_ideation/agents/indigo_agent.py
+++ b/packages/ideation/src/white_ideation/agents/indigo_agent.py
@@ -893,10 +893,13 @@ Write ONLY the riddle (no answer, no explanation):
                     data = yaml.safe_load(f)
                 counter_proposal = SongProposalIteration(**data)
                 counter_proposal.agent_name = "indigo"
+                # Continue the chain from the proposal this counters (see the
+                # real-mode branch below) rather than snapshotting the overall
+                # list length, which can coincidentally collide with an
+                # unrelated lineage's next number.
+                previous = state.white_proposal
                 counter_proposal.iteration_number = (
-                    len(state.song_proposals.iterations) + 1
-                    if state.song_proposals
-                    else 1
+                    (previous.iteration_number or 0) + 1 if previous else 1
                 )
                 counter_proposal.timestamp = time.time()
                 state.counter_proposal = counter_proposal
@@ -972,9 +975,12 @@ Concept: [full concept explanation]
                     )
                     counter_proposal.concept += f"Decoding: {decoding_hint}\n"
 
+                # Continue the chain from the proposal this counters, rather
+                # than snapshotting the overall list length (see mock-mode
+                # branch above for why).
                 counter_proposal.iteration_number = (
-                    len(state.song_proposals.iterations) + 1
-                )
+                    previous_iteration.iteration_number or 0
+                ) + 1
                 counter_proposal.agent_name = "indigo"
                 counter_proposal.timestamp = time.time()
                 state.counter_proposal = counter_proposal
@@ -1005,7 +1011,7 @@ Concept: [full concept explanation]
                     mood=["cryptic", "puzzling", "revelatory"],
                     genres=previous_iteration.genres,
                     concept=f"FALLBACK: Infranym puzzle encoding {state.secret_name} → {state.surface_name}",
-                    iteration_number=len(state.song_proposals.iterations) + 1,
+                    iteration_number=(previous_iteration.iteration_number or 0) + 1,
                     agent_name="indigo",
                     timestamp=time.time(),
                 )

--- a/packages/ideation/src/white_ideation/agents/white_agent.py
+++ b/packages/ideation/src/white_ideation/agents/white_agent.py
@@ -28,7 +28,11 @@ from white_core.agents.agent_settings import AgentSettings
 from white_core.concepts.white_facet_system import WhiteFacetSystem
 from white_core.enums.chain_artifact_type import ChainArtifactType
 from white_core.enums.synthesis_prompt_template import SynthesisPromptTemplate
-from white_core.manifests.song_proposal import SongProposal, SongProposalIteration
+from white_core.manifests.song_proposal import (
+    SongProposal,
+    SongProposalIteration,
+    resolve_supersession_chains,
+)
 from white_extraction.util.generate_negative_constraints import (
     format_for_prompt,
     generate_constraints,
@@ -4101,17 +4105,31 @@ The song should be buildable from these specifications.
                 raise Exception(error_msg)
             return
 
+        # Drop exact duplicates and clear is_final on any iteration that a later
+        # counter-proposal in the same revision chain has superseded (see
+        # resolve_supersession_chains docstring — this can pivot color/title
+        # entirely, so it must run before the per-color grouping below).
+        iterations, superseded_ids = resolve_supersession_chains(
+            state.song_proposals.iterations
+        )
+        state.song_proposals.iterations = iterations
+
         # For each color group, if no iteration is explicitly marked final,
         # treat the last iteration in that group as final. This handles single-agent
         # workflows and agents (Orange, Green, etc.) that never call is_final themselves.
-        iterations = state.song_proposals.iterations
+        # Skip groups where every unmarked member was just superseded above —
+        # that's a deliberate "this lineage's final now lives under a different
+        # color" outcome, not an undecided orphan to fall back on.
         iterations_by_color: dict = {}
         for idx, iteration in enumerate(iterations):
             color = str(iteration.rainbow_color)
             iterations_by_color.setdefault(color, []).append(idx)
         for color_indexes in iterations_by_color.values():
-            if not any(iterations[idx].is_final for idx in color_indexes):
-                iterations[color_indexes[-1]].is_final = True
+            if any(iterations[idx].is_final for idx in color_indexes):
+                continue
+            if any(id(iterations[idx]) in superseded_ids for idx in color_indexes):
+                continue
+            iterations[color_indexes[-1]].is_final = True
 
         # Deduplicate titles within this run: if two final iterations share the same
         # title, append the color name so init_production never sees a collision.
@@ -4124,12 +4142,21 @@ The song should be buildable from these specifications.
             if len(_dupes) > 1:
                 for it in _dupes:
                     rc = it.rainbow_color
-                    _label = (
-                        rc.color_name
-                        if hasattr(rc, "color_name")
-                        else str(rc).split("(")[0].strip()
-                    )
-                    it.title = f"{it.title} ({_label})"
+                    if hasattr(rc, "color_name"):
+                        _label = rc.color_name
+                    else:
+                        _label = str(rc).split("(")[0].strip()
+                        # Guard against a malformed rainbow_color — e.g. the
+                        # LLM dumping raw JSON/dict text into the field
+                        # instead of a clean color name (real-world case:
+                        # last_click_train_prism_v1) — which would otherwise
+                        # get interpolated whole into the title below.
+                        if len(_label) > 20 or any(c in _label for c in "{}:\"'"):
+                            _label = "unknown"
+                    # Cap to the model's own title max_length so a malformed
+                    # label (or this block running more than once) can never
+                    # produce a title that fails validation on next load.
+                    it.title = f"{it.title} ({_label})"[:150]
                 logger.warning(
                     "Duplicate title within run — appended color suffix: %s",
                     [it.title for it in _dupes],

--- a/packages/ideation/src/white_ideation/agents/white_agent.py
+++ b/packages/ideation/src/white_ideation/agents/white_agent.py
@@ -4117,9 +4117,12 @@ The song should be buildable from these specifications.
         # For each color group, if no iteration is explicitly marked final,
         # treat the last iteration in that group as final. This handles single-agent
         # workflows and agents (Orange, Green, etc.) that never call is_final themselves.
-        # Skip groups where every unmarked member was just superseded above —
-        # that's a deliberate "this lineage's final now lives under a different
-        # color" outcome, not an undecided orphan to fall back on.
+        # Entries superseded above are excluded from the candidate pool — that's
+        # a deliberate "this lineage's final now lives under a different color"
+        # outcome, not an undecided orphan to fall back on — but a color group
+        # can still contain a genuinely separate, untouched entry alongside a
+        # superseded one, so only skip the whole group when every member in it
+        # was superseded, not merely any.
         iterations_by_color: dict = {}
         for idx, iteration in enumerate(iterations):
             color = str(iteration.rainbow_color)
@@ -4127,9 +4130,13 @@ The song should be buildable from these specifications.
         for color_indexes in iterations_by_color.values():
             if any(iterations[idx].is_final for idx in color_indexes):
                 continue
-            if any(id(iterations[idx]) in superseded_ids for idx in color_indexes):
-                continue
-            iterations[color_indexes[-1]].is_final = True
+            eligible = [
+                idx
+                for idx in color_indexes
+                if id(iterations[idx]) not in superseded_ids
+            ]
+            if eligible:
+                iterations[eligible[-1]].is_final = True
 
         # Deduplicate titles within this run: if two final iterations share the same
         # title, append the color name so init_production never sees a collision.
@@ -4156,7 +4163,18 @@ The song should be buildable from these specifications.
                     # Cap to the model's own title max_length so a malformed
                     # label (or this block running more than once) can never
                     # produce a title that fails validation on next load.
-                    it.title = f"{it.title} ({_label})"[:150]
+                    # Truncate the base title first, not the whole suffixed
+                    # string — otherwise a title already near 150 chars would
+                    # have the suffix truncated away, leaving the collision
+                    # unresolved.
+                    suffix = f" ({_label})"
+                    base_budget = max(0, 150 - len(suffix))
+                    base = (
+                        it.title
+                        if len(it.title) <= base_budget
+                        else it.title[:base_budget].rstrip()
+                    )
+                    it.title = f"{base}{suffix}"
                 logger.warning(
                     "Duplicate title within run — appended color suffix: %s",
                     [it.title for it in _dupes],

--- a/packages/ideation/tests/agents/test_indigo_agent.py
+++ b/packages/ideation/tests/agents/test_indigo_agent.py
@@ -1,6 +1,6 @@
 import re
 
-from white_core.manifests.song_proposal import SongProposalIteration
+from white_core.manifests.song_proposal import SongProposal, SongProposalIteration
 from white_ideation.agents.indigo_agent import IndigoAgent, _parse_proposal_response
 from white_ideation.agents.states.indigo_agent_state import IndigoAgentState
 
@@ -12,6 +12,40 @@ def test_generate_alternate_song_spec_mock():
     assert result_state.counter_proposal is not None
     assert isinstance(result_state.counter_proposal, SongProposalIteration)
     assert getattr(result_state.counter_proposal, "title", None)
+
+
+def _proposal(**overrides) -> SongProposalIteration:
+    base = dict(
+        iteration_id="prior_v3",
+        bpm=120,
+        key="C major",
+        rainbow_color="Blue",
+        title="Prior Proposal",
+        mood=["melancholic"],
+        genres=["ambient"],
+        concept="A test concept that is long enough to pass the minimum length "
+        "validator for the concept field.",
+    )
+    base.update(overrides)
+    return SongProposalIteration(**base)
+
+
+def test_generate_alternate_song_spec_mock_continues_predecessor_chain():
+    """Regression: iteration_number must continue from the proposal this
+    counters, not snapshot the overall list length — a long, unrelated
+    song_proposals list must not inflate Indigo's own chain position."""
+    agent = IndigoAgent()
+    predecessor = _proposal(iteration_id="prior_v3", iteration_number=3)
+    unrelated = [
+        _proposal(iteration_id=f"unrelated_v{i}", iteration_number=None)
+        for i in range(10)
+    ]
+    state = IndigoAgentState(
+        white_proposal=predecessor,
+        song_proposals=SongProposal(iterations=[*unrelated, predecessor]),
+    )
+    result_state = agent.generate_alternate_song_spec(state)
+    assert result_state.counter_proposal.iteration_number == 4
 
 
 def test_parse_proposal_response_iteration_id_is_slug():

--- a/packages/ideation/tests/agents/test_white_agent.py
+++ b/packages/ideation/tests/agents/test_white_agent.py
@@ -564,6 +564,81 @@ def test_save_all_proposals_leaves_independent_colors_untouched(
     assert yellow.is_final is True
 
 
+def test_save_all_proposals_promotes_untouched_entry_sharing_color_with_superseded(
+    white_agent, tmp_path, monkeypatch
+):
+    """Regression: a color group containing both a superseded chain member
+    and a genuinely separate, never-decided entry of the same color must
+    still promote the untouched one — even when the superseded entry sorts
+    last within the group (an any()-based skip, or a naive all()-based
+    promote-last-in-group fix, both mishandle this ordering)."""
+    seed = _make_proposal(
+        iteration_id="seed_v1",
+        rainbow_color="Green",
+        iteration_number=1,
+        is_final=True,
+    )
+    pivot = _make_proposal(
+        iteration_id="pivot_v2",
+        rainbow_color="Black",
+        iteration_number=2,
+        is_final=True,
+    )
+    # Same color as seed (Green), added after pivot so it sorts last within
+    # the Green group by list position — but it is NOT part of any chain.
+    untouched = _make_proposal(
+        iteration_id="untouched_v1",
+        rainbow_color="Green",
+        iteration_number=None,
+        is_final=False,
+    )
+    monkeypatch.setenv("BLOCK_MODE", "false")
+    monkeypatch.setattr(white_agent, "_artifact_base_path", lambda: str(tmp_path))
+    state = MainAgentState(
+        thread_id="tid_mixed_color_group_test",
+        song_proposals=SongProposal(iterations=[seed, pivot, untouched]),
+    )
+    white_agent.save_all_proposals(state)
+
+    assert seed.is_final is False
+    assert pivot.is_final is True
+    assert untouched.is_final is True
+
+
+def test_save_all_proposals_title_dedup_preserves_suffix_near_max_length(
+    white_agent, tmp_path, monkeypatch
+):
+    """Regression: when the base title is already near the 150-char max,
+    truncating the whole suffixed string (instead of the base) chops the
+    suffix off entirely, leaving the title collision unresolved."""
+    long_title = "A" * 150
+    clean = _make_proposal(
+        iteration_id="clean_v1",
+        title=long_title,
+        rainbow_color="Green",
+        is_final=True,
+    )
+    other = _make_proposal(
+        iteration_id="other_v1",
+        title=long_title,
+        rainbow_color="Blue",
+        is_final=True,
+    )
+    monkeypatch.setenv("BLOCK_MODE", "false")
+    monkeypatch.setattr(white_agent, "_artifact_base_path", lambda: str(tmp_path))
+    state = MainAgentState(
+        thread_id="tid_long_title_test",
+        song_proposals=SongProposal(iterations=[clean, other]),
+    )
+    white_agent.save_all_proposals(state)
+
+    assert len(clean.title) <= 150
+    assert len(other.title) <= 150
+    assert clean.title != other.title
+    assert clean.title.endswith("(Green)")
+    assert other.title.endswith("(Blue)")
+
+
 def test_save_all_proposals_drops_exact_duplicate_iterations(
     white_agent, tmp_path, monkeypatch
 ):

--- a/packages/ideation/tests/agents/test_white_agent.py
+++ b/packages/ideation/tests/agents/test_white_agent.py
@@ -446,6 +446,190 @@ def test_save_all_proposals_single_iteration_implicit_final(
     assert "solo_v1" in standalone[0].name
 
 
+def test_save_all_proposals_clears_superseded_color_pivot(
+    white_agent, tmp_path, monkeypatch
+):
+    """Regression: a White seed (iteration 1) pivoted to Black by a counter-
+    proposal (iteration 2) must not both end up is_final — only the last
+    entry in the consecutive-iteration_number chain should survive, even
+    though the color and title change mid-chain (real-world case:
+    instantiation_sequence_v1 → v2/v3/v4)."""
+    seed = _make_proposal(
+        iteration_id="seed_v1",
+        rainbow_color="White",
+        title="Compile, Then Breathe",
+        iteration_number=1,
+        is_final=True,
+    )
+    pivot = _make_proposal(
+        iteration_id="pivot_v2",
+        rainbow_color="Black",
+        title="Error Log",
+        iteration_number=2,
+        is_final=True,
+    )
+    final = _make_proposal(
+        iteration_id="final_v3",
+        rainbow_color="Black",
+        title="Form B-Minor",
+        iteration_number=3,
+        is_final=True,
+    )
+    monkeypatch.setenv("BLOCK_MODE", "false")
+    monkeypatch.setattr(white_agent, "_artifact_base_path", lambda: str(tmp_path))
+    state = MainAgentState(
+        thread_id="tid_pivot_test",
+        song_proposals=SongProposal(iterations=[seed, pivot, final]),
+    )
+    white_agent.save_all_proposals(state)
+
+    yml_dir = tmp_path / "tid_pivot_test" / "yml"
+    standalone = list(yml_dir.glob("song_proposal_*.yml"))
+    assert len(standalone) == 1
+    assert "final_v3" in standalone[0].name
+    assert seed.is_final is False
+    assert pivot.is_final is False
+    assert final.is_final is True
+
+
+def test_save_all_proposals_clears_superseded_same_color_revision(
+    white_agent, tmp_path, monkeypatch
+):
+    """Regression: two same-color revisions (real-world case:
+    sultan_mirror_confession_v1 → v2, a 'post-interview synthesis') both got
+    marked is_final by their own agent step; only the later one should
+    survive."""
+    draft = _make_proposal(
+        iteration_id="draft_v1",
+        rainbow_color="Violet",
+        title="I Loved Making the Record That Isn't Out Yet",
+        iteration_number=1,
+        is_final=True,
+    )
+    revised = _make_proposal(
+        iteration_id="revised_v2",
+        rainbow_color="Violet",
+        title="I Loved Making the Record That Isn't Out Yet",
+        iteration_number=2,
+        is_final=True,
+    )
+    monkeypatch.setenv("BLOCK_MODE", "false")
+    monkeypatch.setattr(white_agent, "_artifact_base_path", lambda: str(tmp_path))
+    state = MainAgentState(
+        thread_id="tid_revision_test",
+        song_proposals=SongProposal(iterations=[draft, revised]),
+    )
+    white_agent.save_all_proposals(state)
+
+    yml_dir = tmp_path / "tid_revision_test" / "yml"
+    standalone = list(yml_dir.glob("song_proposal_*.yml"))
+    assert len(standalone) == 1
+    assert "revised_v2" in standalone[0].name
+    assert draft.is_final is False
+    assert revised.is_final is True
+
+
+def test_save_all_proposals_leaves_independent_colors_untouched(
+    white_agent, tmp_path, monkeypatch
+):
+    """Two genuinely independent songs (different colors, non-consecutive or
+    absent iteration_number) must both remain final — a chain must not be
+    inferred across unrelated proposals."""
+    orange = _make_proposal(
+        iteration_id="orange_v1",
+        rainbow_color="Orange",
+        title="Orange Song",
+        iteration_number=1,
+        is_final=True,
+    )
+    yellow = _make_proposal(
+        iteration_id="yellow_v1",
+        rainbow_color="Yellow",
+        title="Yellow Song",
+        iteration_number=None,
+        is_final=True,
+    )
+    monkeypatch.setenv("BLOCK_MODE", "false")
+    monkeypatch.setattr(white_agent, "_artifact_base_path", lambda: str(tmp_path))
+    state = MainAgentState(
+        thread_id="tid_independent_test",
+        song_proposals=SongProposal(iterations=[orange, yellow]),
+    )
+    white_agent.save_all_proposals(state)
+
+    yml_dir = tmp_path / "tid_independent_test" / "yml"
+    standalone = list(yml_dir.glob("song_proposal_*.yml"))
+    assert len(standalone) == 2
+    assert orange.is_final is True
+    assert yellow.is_final is True
+
+
+def test_save_all_proposals_drops_exact_duplicate_iterations(
+    white_agent, tmp_path, monkeypatch
+):
+    """Regression: an exact-duplicate entry (same iteration_id and
+    iteration_number, appended twice — real-world case: instantiation_sequence_v2
+    appearing twice in all_song_proposals.yml) must be deduplicated before
+    chain resolution, not treated as a chain-breaking event that leaves an
+    intermediate link incorrectly final."""
+    seed = _make_proposal(iteration_id="seed_v1", iteration_number=1, is_final=True)
+    dup_a = _make_proposal(iteration_id="dup_v2", iteration_number=2, is_final=True)
+    dup_b = _make_proposal(iteration_id="dup_v2", iteration_number=2, is_final=True)
+    final = _make_proposal(iteration_id="final_v3", iteration_number=3, is_final=True)
+    monkeypatch.setenv("BLOCK_MODE", "false")
+    monkeypatch.setattr(white_agent, "_artifact_base_path", lambda: str(tmp_path))
+    state = MainAgentState(
+        thread_id="tid_dup_test",
+        song_proposals=SongProposal(iterations=[seed, dup_a, dup_b, final]),
+    )
+    white_agent.save_all_proposals(state)
+
+    assert len(state.song_proposals.iterations) == 3
+    yml_dir = tmp_path / "tid_dup_test" / "yml"
+    standalone = list(yml_dir.glob("song_proposal_*.yml"))
+    assert len(standalone) == 1
+    assert "final_v3" in standalone[0].name
+
+
+def test_save_all_proposals_title_dedup_guards_malformed_rainbow_color(
+    white_agent, tmp_path, monkeypatch
+):
+    """Regression: when rainbow_color is a malformed string (e.g. the LLM
+    dumped raw JSON/dict text into the field instead of a clean color name —
+    real-world case: last_click_train_prism_v1), the title-dedup suffix must
+    fall back to a safe label and stay within the model's own 150-char
+    title max_length, instead of embedding the garbage and producing a
+    title that fails validation on next load."""
+    garbled_color = (
+        '{"color_name": "Blue", "hex_value": 1727categ983, '
+        '"mnemonic_character_value": "B"}'
+    )
+    clean = _make_proposal(
+        iteration_id="clean_v1",
+        title="Shared Title",
+        rainbow_color="Green",
+        is_final=True,
+    )
+    malformed = _make_proposal(
+        iteration_id="malformed_v1",
+        title="Shared Title",
+        rainbow_color=garbled_color,
+        is_final=True,
+    )
+    monkeypatch.setenv("BLOCK_MODE", "false")
+    monkeypatch.setattr(white_agent, "_artifact_base_path", lambda: str(tmp_path))
+    state = MainAgentState(
+        thread_id="tid_malformed_color_test",
+        song_proposals=SongProposal(iterations=[clean, malformed]),
+    )
+    white_agent.save_all_proposals(state)
+
+    assert len(malformed.title) <= 150
+    assert garbled_color not in malformed.title
+    assert malformed.title == "Shared Title (unknown)"
+    assert clean.title == "Shared Title (Green)"
+
+
 def test_finalize_writes_run_success_sentinel(monkeypatch, tmp_path, white_agent):
     """finalize_song_proposal should write a run_success sentinel file."""
     monkeypatch.setenv("MOCK_MODE", "true")

--- a/uv.lock
+++ b/uv.lock
@@ -7558,7 +7558,7 @@ requires-dist = [
 
 [[package]]
 name = "white-composition"
-version = "0.3.1"
+version = "0.4.0"
 source = { editable = "packages/composition" }
 dependencies = [
     { name = "anthropic" },
@@ -7585,7 +7585,7 @@ requires-dist = [
 
 [[package]]
 name = "white-core"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "pydantic" },
@@ -7667,7 +7667,7 @@ requires-dist = [
 
 [[package]]
 name = "white-ideation"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "packages/ideation" }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

The agent-driven song-proposal pipeline (`white_agent.py` and friends) accumulates every proposal iteration into one flat list as agents generate counter-proposals. Nothing ever cleared `is_final` on an iteration once a later counter-proposal in the same revision chain superseded it — including across a full color/title pivot (e.g. a White seed rejected into an unrelated Black rework). Downstream, `scaffold_song_productions` scaffolded a real `production/<slug>/` directory for *every* iteration it found marked `is_final`, so superseded drafts kept turning into standalone songs. This surfaced as several duplicate production directories discovered this session (`instantiation_sequence_v1` vs. its Black rework chain, `sultan_mirror_confession_v1` vs. `v2`, etc.) — two empty stubs and one unfinished draft were cleaned up locally as part of this investigation (not included in this diff, since `shrink_wrapped/` is gitignored generated output).

- **`white_core`**: new shared `resolve_supersession_chains()` in `manifests/song_proposal.py` — drops exact-duplicate iterations and clears `is_final` on every entry but the last in a maximal run of consecutive `iteration_number` values, even when color/title changes mid-chain. Entries with no `iteration_number`, or a non-consecutive one, are left untouched (genuinely independent songs).
- **`white_ideation`**:
  - `save_all_proposals` now runs the resolver before its existing per-color backfill, and that backfill no longer re-promotes an entry the resolver just correctly cleared.
  - Fixed `indigo_agent.py`'s `iteration_number` assignment — it snapshotted the *overall* proposal-list length instead of continuing from the proposal it counters (every other agent does the latter, implicitly, via the LLM continuing the sequence). This was a real bug that could coincidentally collide with an unrelated lineage's next number.
  - Hardened the title-dedup suffix logic against a malformed `rainbow_color` (the LLM occasionally dumps raw JSON-ish text into that field instead of a clean color name) so it can no longer produce an oversized title that fails validation on next load.
- **`white_composition`**: `scaffold_song_productions` now checks each candidate proposal against the thread's resolved `all_song_proposals*.yml` bundle before scaffolding a production directory for it, with a safe fallback to the proposal's own `is_final` field when no bundle exists, and per-entry resilience so one malformed bundle entry doesn't disable resolution for the whole thread.

Version bumps: `white-core` 0.1.0 → 0.2.0, `white-composition` 0.3.1 → 0.4.0, `white-ideation` 0.1.1 → 0.2.0 (minor — behavior change, not just a narrow fix).

## Test plan
- [x] New regression tests for every case: cross-color pivot chain, same-color revision chain, exact-duplicate entries, independent singleton colors left untouched, malformed bundle entry skipped without disabling the rest, Indigo's iteration_number fix, malformed-`rainbow_color` title guard.
- [x] Full `packages/core`, `packages/composition`, `packages/ideation` test suites pass.
- [x] Verified end-to-end against real data: reran `resolve_supersession_chains` against all 5 threads with an `all_song_proposals.yml` bundle in `shrink_wrapped/`, confirmed the algorithm correctly identifies known-superseded iterations without any false positives against genuinely independent songs (including ones intentionally kept as separate productions despite sharing a folder-name prefix).
- [x] Manually assigned and validated `sub_proposals` for the `White` synthesis song `prism_white_synthesis_final_v1` (unrelated to this fix, but resolved in the same session) and confirmed chord generation runs end-to-end pulling bars from the correct donor colors.

Claude-Session: https://claude.ai/code/session_01NYG1C82T6CDDnD4LwjWSRt