### PR TITLE
Fix White pipeline chord donor wiring, promotion error surfacing, and LLM schema mismatches

### DIFF
--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "white-api"
-version = "0.4.0"
+version = "0.4.1"
 description = "Candidate browser server and song dashboard for White project"
 requires-python = ">=3.12"
 dependencies = [

--- a/packages/api/src/white_api/candidate_server.py
+++ b/packages/api/src/white_api/candidate_server.py
@@ -1934,7 +1934,7 @@ def create_app(
         )
 
         captured = io.StringIO()
-        with contextlib.redirect_stdout(captured):
+        with contextlib.redirect_stdout(captured), contextlib.redirect_stderr(captured):
             result = cmd_promote(prod, body.phase, yes=True)
         if result != 0:
             reason_lines = [

--- a/packages/api/src/white_api/candidate_server.py
+++ b/packages/api/src/white_api/candidate_server.py
@@ -1933,11 +1933,22 @@ def create_app(
             len(list(approved_dir.glob("*.mid"))) if approved_dir.exists() else 0
         )
 
-        result = cmd_promote(prod, body.phase, yes=True)
+        captured = io.StringIO()
+        with contextlib.redirect_stdout(captured):
+            result = cmd_promote(prod, body.phase, yes=True)
         if result != 0:
+            reason_lines = [
+                line
+                for line in captured.getvalue().splitlines()
+                if "ERROR" in line or "No approved candidates" in line
+            ]
+            reason = (
+                " ".join(reason_lines)
+                or "ensure review.yml contains approved candidates"
+            )
             raise HTTPException(
                 status_code=409,
-                detail=f"Promotion could not be completed for phase '{body.phase}' — ensure review.yml contains approved candidates",
+                detail=f"Promotion could not be completed for phase '{body.phase}' — {reason}",
             )
         count_after = (
             len(list(approved_dir.glob("*.mid"))) if approved_dir.exists() else 0

--- a/packages/client/app/candidates/page.tsx
+++ b/packages/client/app/candidates/page.tsx
@@ -331,6 +331,7 @@ export default function CandidatesPage() {
           <Link href="/" className="text-zinc-400 underline decoration-zinc-700 underline-offset-2 hover:text-zinc-200 hover:decoration-zinc-500 transition-colors">← Songs</Link>
           <span>/</span>
           <span className="text-zinc-300 font-medium">{activeSong.title}</span>
+          {activeSong.key && <span className="text-zinc-600">{activeSong.key}</span>}
           {activeSong.bpm && (
             <span className="text-zinc-600">
               {activeSong.bpm} BPM{activeSong.time_sig ? ` · ${activeSong.time_sig}` : ""}

--- a/packages/client/app/sides/page.tsx
+++ b/packages/client/app/sides/page.tsx
@@ -22,6 +22,10 @@ import { NotesButton, SongNotesModal } from "@/components/SongNotes";
 
 const SIDE_NAMES: SideName[] = ["A", "B", "C", "D"];
 
+const EXCLUDED_LIFECYCLE_STATUSES = new Set<SongEntry["lifecycle_status"]>([
+  "abandoned", "scrapped", "merged",
+]);
+
 function sideEntryFromSongs(songs: SideSong[], limitSeconds: number): SideEntry {
   const total = songs.reduce((sum, s) => sum + s.duration_seconds, 0);
   return { songs, total_seconds: total, over_limit: total > limitSeconds };
@@ -391,11 +395,11 @@ export default function SidesPage() {
   );
   const available = songs
     .filter((s) => !assignedIds.has(s.id))
-    .filter((s) => s.lifecycle_status !== "abandoned")
+    .filter((s) => !EXCLUDED_LIFECYCLE_STATUSES.has(s.lifecycle_status))
     .filter((s) => showUnmixed || s.has_mix)
     .filter((s) => !poolSearch || s.title.toLowerCase().includes(poolSearch.toLowerCase()));
   const unmixedHiddenCount = songs.filter(
-    (s) => !assignedIds.has(s.id) && s.lifecycle_status !== "abandoned" && !s.has_mix,
+    (s) => !assignedIds.has(s.id) && !EXCLUDED_LIFECYCLE_STATUSES.has(s.lifecycle_status) && !s.has_mix,
   ).length;
   const allAssigned = songs.length > 0 && songs.every((s) => assignedIds.has(s.id));
 

--- a/packages/composition/pyproject.toml
+++ b/packages/composition/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "white-composition"
-version = "0.7.0"
+version = "0.8.0"
 description = "Production orchestration, pipeline runner, and candidate review for White project"
 requires-python = ">=3.12"
 dependencies = [

--- a/packages/composition/src/white_composition/pipeline_runner.py
+++ b/packages/composition/src/white_composition/pipeline_runner.py
@@ -72,6 +72,21 @@ _STATUS_ICONS = {
 }
 
 
+def _find_donor_production_dirs(production_dir: Path) -> list[Path]:
+    """Return sibling production dirs (same thread) with promoted chord material.
+
+    White mode synthesizes its chords by cutting up bars donated by other
+    already-produced songs in the same thread, so any sibling with a
+    chords/review.yml is a valid donor.
+    """
+    siblings_root = production_dir.parent
+    return sorted(
+        d
+        for d in siblings_root.iterdir()
+        if d.is_dir() and d != production_dir and (d / "chords" / "review.yml").exists()
+    )
+
+
 def _build_phase_command(
     phase: str, production_dir: Path, ctx: dict, song_proposal: str = ""
 ) -> list[str]:
@@ -99,6 +114,10 @@ def _build_phase_command(
         ]
         if proposal:
             cmd += ["--song", proposal]
+        if str(ctx.get("color", "")).strip().lower() == "white":
+            donors = _find_donor_production_dirs(production_dir)
+            if donors:
+                cmd += ["--sub-proposals"] + [str(d) for d in donors]
         return cmd
     if phase == "drums":
         return base + [

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "white-core"
-version = "0.6.0"
+version = "0.6.1"
 description = "Shared Pydantic models, enums, and types for the White project"
 requires-python = ">=3.12"
 dependencies = [

--- a/packages/core/src/white_core/artifacts/last_human_artifact.py
+++ b/packages/core/src/white_core/artifacts/last_human_artifact.py
@@ -81,6 +81,16 @@ class LastHumanFields(BaseModel):
             "year_documented must be 1975 or between 2028 and 2350 (inclusive)"
         )
 
+    @field_validator("adaptation_attempts", mode="before")
+    @classmethod
+    def _coerce_adaptation_attempts(cls, v):
+        """The LLM occasionally answers this field with a single prose
+        string instead of a list, which used to fail validation outright
+        and burn a retry (see get_human retry loop in green_agent.py)."""
+        if isinstance(v, str):
+            return [v]
+        return v
+
 
 class LastHumanArtifact(ChainArtifact, LastHumanFields, ABC):
     """

--- a/packages/core/src/white_core/concepts/vanity_interview_question.py
+++ b/packages/core/src/white_core/concepts/vanity_interview_question.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel, Field
+import json
+
+from pydantic import BaseModel, Field, field_validator
 
 
 class VanityInterviewQuestion(BaseModel):
@@ -10,3 +12,21 @@ class VanityInterviewQuestionOutput(BaseModel):
     questions: list[VanityInterviewQuestion] = Field(
         description="Three interview questions"
     )
+
+    @field_validator("questions", mode="before")
+    @classmethod
+    def _coerce_stringified_questions(cls, v):
+        """The model occasionally calls this tool with the entire payload
+        JSON-encoded as a string under this field (e.g.
+        '{"questions": [{"number": 1, ...}]}') instead of passing the list
+        directly. Unwrap that shape rather than fail validation outright."""
+        if isinstance(v, str):
+            try:
+                parsed = json.loads(v)
+            except (ValueError, TypeError):
+                return v
+            if isinstance(parsed, dict) and "questions" in parsed:
+                return parsed["questions"]
+            if isinstance(parsed, list):
+                return parsed
+        return v

--- a/packages/core/src/white_core/manifests/song_proposal.py
+++ b/packages/core/src/white_core/manifests/song_proposal.py
@@ -1,3 +1,4 @@
+import ast
 import re
 from typing import List
 
@@ -132,6 +133,21 @@ class SongProposalIteration(BaseModel):
             raise ValueError("Concept cannot contain placeholder text")
 
         return v_stripped
+
+    @field_validator("mood", "genres", mode="before")
+    @classmethod
+    def _coerce_stringified_list(cls, v):
+        """The LLM occasionally answers a list field with its Python repr
+        (e.g. "['wary', 'defiant']") instead of an actual list — coerce it
+        back rather than fail validation outright."""
+        if isinstance(v, str):
+            try:
+                parsed = ast.literal_eval(v)
+            except (ValueError, SyntaxError):
+                return v
+            if isinstance(parsed, list):
+                return parsed
+        return v
 
     @field_validator("mood")
     @classmethod

--- a/packages/ideation/pyproject.toml
+++ b/packages/ideation/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "white-ideation"
-version = "0.6.2"
+version = "0.6.3"
 description = "Agents, reference data, and creative ideation for White project"
 requires-python = ">=3.12"
 dependencies = [

--- a/packages/ideation/src/white_ideation/agents/violet_agent.py
+++ b/packages/ideation/src/white_ideation/agents/violet_agent.py
@@ -359,15 +359,7 @@ Example authentic questions:
 - "That sound at 2:34 - is that a broken tape deck or are you just fucking with us?"
 - "You've talked about 'rebracketing' — is that like... sampling yourself? Or more conceptual?"
 - "Nine albums in one color series is pretty intense — when does dedication become obsession?"
-
-Output as JSON with structure:
-{{
-  "questions": [
-    {{"number": 1, "question": "..."}},
-    {{"number": 2, "question": "..."}},
-    {{"number": 3, "question": "..."}}
-  ]
-}}"""
+"""
 
         try:
             result = self._invoke_structured(
@@ -498,8 +490,7 @@ Bad: Pure theory without the undercut. Pure confidence without the vulnerability
 The interviewer might not get the academic stuff, but you don't dumb it down—you just
 immediately acknowledge how ridiculous it sounds by pivoting to something lowbrow.
 
-Keep response 2-4 sentences. Output as JSON:
-{{"question_number": {q.number}, "response": "..."}}"""
+Keep response 2-4 sentences. The response is for question number {q.number}."""
 
             try:
                 # Structured output

--- a/packages/ideation/src/white_ideation/agents/white_agent.py
+++ b/packages/ideation/src/white_ideation/agents/white_agent.py
@@ -658,26 +658,43 @@ class WhiteAgent(BaseModel):
                 "Indigo Agent - Decider Tangents. A fool and a spy who masterfully hides the secret name of all he surveys",
                 "Violet Agent - The Sultan of Solipsism. A self-absorbed Pop star who is so 'now' he's already past.",
             ]
+            baton_colors: List[str] = [
+                "Black",
+                "Red",
+                "Orange",
+                "Yellow",
+                "Green",
+                "Blue",
+                "Indigo",
+                "Violet",
+            ]
             agent_a_description = baton_list[0]
             agent_b_description = baton_list[1]
+            agent_b_color = baton_colors[1]
             if state.ready_for_orange:
                 agent_a_description = baton_list[1]
                 agent_b_description = baton_list[2]
+                agent_b_color = baton_colors[2]
             elif state.ready_for_yellow:
                 agent_a_description = baton_list[2]
                 agent_b_description = baton_list[3]
+                agent_b_color = baton_colors[3]
             elif state.ready_for_green:
                 agent_a_description = baton_list[3]
                 agent_b_description = baton_list[4]
+                agent_b_color = baton_colors[4]
             elif state.ready_for_blue:
                 agent_a_description = baton_list[4]
                 agent_b_description = baton_list[5]
+                agent_b_color = baton_colors[5]
             elif state.ready_for_indigo:
                 agent_a_description = baton_list[5]
                 agent_b_description = baton_list[6]
+                agent_b_color = baton_colors[6]
             elif state.ready_for_violet:
                 agent_a_description = baton_list[6]
                 agent_b_description = baton_list[7]
+                agent_b_color = baton_colors[7]
             if not state.ready_for_white:
                 prompt = f"""
 You are the Prism, the Architect of INFORMATION.
@@ -708,6 +725,7 @@ You must provide:
 - **mood**: List of mood descriptors
 - **genres**: List of genre tags
 - **concept**: The complete conceptual framework for this song
+- **rainbow_color**: Set this to "{agent_b_color}" — the color of the next agent this proposal is being prepared for.
 
 Focus on clarity, coherence, and creative possibility - make it ready for the next agent to build upon.
 """
@@ -757,6 +775,7 @@ You must provide a complete, final song proposal with:
 - **mood**: List of mood descriptors capturing the full spectrum
 - **genres**: List of genre tags
 - **concept**: The complete, final conceptual framework
+- **rainbow_color**: Set this to "White" — this is the final synthesis.
 
 Structure your proposal as the final, complete vision - ready for human implementation.
 """

--- a/packages/ideation/src/white_ideation/agents/white_agent.py
+++ b/packages/ideation/src/white_ideation/agents/white_agent.py
@@ -648,53 +648,55 @@ class WhiteAgent(BaseModel):
                 logger.info(f"Mock reworked proposal not found:{e!s}")
             return state
         else:
-            baton_list: List[str] = [
-                "Black Agent - ThreadKeepr. He is obsessed with the occult, hacking, and uncovering hidden patterns in reality.",
-                "Red Agent - The Light Reader. It is an Archivist of books both mundane and obscure.",
-                "Orange Agent - Rows Bud. A journalist whose factual articles about New Jersey in 80s and 90s have been mis-remembered by the injection of a symbolic object.",
-                "Yellow Agent - Lord Pulsimore. A hypnagogic game-master whose stately manor resides between the flickering of all RGB pixels, He's concerned with FUTURE, IMAGINED, PLACE",
-                "Green Agent - Sub-Arbitrary. A forked version of The Culture Mind Arbitrary, sent to observe Earth's climate collapse.",
-                "Blue Agent - The Cassette Bearer. Witness to the oblivion that awaits when we fall out of our own timelines.",
-                "Indigo Agent - Decider Tangents. A fool and a spy who masterfully hides the secret name of all he surveys",
-                "Violet Agent - The Sultan of Solipsism. A self-absorbed Pop star who is so 'now' he's already past.",
+            baton: List[tuple[str, str]] = [
+                (
+                    "Black",
+                    "Black Agent - ThreadKeepr. He is obsessed with the occult, hacking, and uncovering hidden patterns in reality.",
+                ),
+                (
+                    "Red",
+                    "Red Agent - The Light Reader. It is an Archivist of books both mundane and obscure.",
+                ),
+                (
+                    "Orange",
+                    "Orange Agent - Rows Bud. A journalist whose factual articles about New Jersey in 80s and 90s have been mis-remembered by the injection of a symbolic object.",
+                ),
+                (
+                    "Yellow",
+                    "Yellow Agent - Lord Pulsimore. A hypnagogic game-master whose stately manor resides between the flickering of all RGB pixels, He's concerned with FUTURE, IMAGINED, PLACE",
+                ),
+                (
+                    "Green",
+                    "Green Agent - Sub-Arbitrary. A forked version of The Culture Mind Arbitrary, sent to observe Earth's climate collapse.",
+                ),
+                (
+                    "Blue",
+                    "Blue Agent - The Cassette Bearer. Witness to the oblivion that awaits when we fall out of our own timelines.",
+                ),
+                (
+                    "Indigo",
+                    "Indigo Agent - Decider Tangents. A fool and a spy who masterfully hides the secret name of all he surveys",
+                ),
+                (
+                    "Violet",
+                    "Violet Agent - The Sultan of Solipsism. A self-absorbed Pop star who is so 'now' he's already past.",
+                ),
             ]
-            baton_colors: List[str] = [
-                "Black",
-                "Red",
-                "Orange",
-                "Yellow",
-                "Green",
-                "Blue",
-                "Indigo",
-                "Violet",
-            ]
-            agent_a_description = baton_list[0]
-            agent_b_description = baton_list[1]
-            agent_b_color = baton_colors[1]
+            agent_a_index = 0
             if state.ready_for_orange:
-                agent_a_description = baton_list[1]
-                agent_b_description = baton_list[2]
-                agent_b_color = baton_colors[2]
+                agent_a_index = 1
             elif state.ready_for_yellow:
-                agent_a_description = baton_list[2]
-                agent_b_description = baton_list[3]
-                agent_b_color = baton_colors[3]
+                agent_a_index = 2
             elif state.ready_for_green:
-                agent_a_description = baton_list[3]
-                agent_b_description = baton_list[4]
-                agent_b_color = baton_colors[4]
+                agent_a_index = 3
             elif state.ready_for_blue:
-                agent_a_description = baton_list[4]
-                agent_b_description = baton_list[5]
-                agent_b_color = baton_colors[5]
+                agent_a_index = 4
             elif state.ready_for_indigo:
-                agent_a_description = baton_list[5]
-                agent_b_description = baton_list[6]
-                agent_b_color = baton_colors[6]
+                agent_a_index = 5
             elif state.ready_for_violet:
-                agent_a_description = baton_list[6]
-                agent_b_description = baton_list[7]
-                agent_b_color = baton_colors[7]
+                agent_a_index = 6
+            agent_a_description = baton[agent_a_index][1]
+            agent_b_color, agent_b_description = baton[agent_a_index + 1]
             if not state.ready_for_white:
                 prompt = f"""
 You are the Prism, the Architect of INFORMATION.

--- a/uv.lock
+++ b/uv.lock
@@ -7522,7 +7522,7 @@ requires-dist = [
 
 [[package]]
 name = "white-api"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "packages/api" }
 dependencies = [
     { name = "fastapi" },
@@ -7555,7 +7555,7 @@ requires-dist = [
 
 [[package]]
 name = "white-composition"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "packages/composition" }
 dependencies = [
     { name = "anthropic" },
@@ -7582,7 +7582,7 @@ requires-dist = [
 
 [[package]]
 name = "white-core"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "packages/core" }
 dependencies = [
     { name = "pydantic" },
@@ -7664,7 +7664,7 @@ requires-dist = [
 
 [[package]]
 name = "white-ideation"
-version = "0.6.2"
+version = "0.6.3"
 source = { editable = "packages/ideation" }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- `pipeline_runner`: auto-pass sibling production dirs as `--sub-proposals` for White-colored songs so the `chords` phase runs through the normal automated pipeline instead of requiring manual invocation with donor paths.
- `candidate_server`: `/promote` now surfaces the actual `promote_part` failure reason (e.g. duplicate-label conflicts) instead of a generic "no approved candidates" message.
- `white_agent`: `rainbow_color` is now explicitly required in the Prism's synthesis prompts and computed from state (the target agent's color / "White" for the final synthesis), rather than left for the LLM to infer — it was a required field the prompt never asked for.
- `violet_agent`: removed a prose "Output as JSON" instruction that conflicted with `_invoke_structured`'s tool-calling framing; added matching structured framing to `simulate_response`, which had the same latent issue.
- `song_proposal.py` / `last_human_artifact.py` / `vanity_interview_question.py`: added coercion validators for stringified/malformed list fields the LLM occasionally returns (Python-repr strings, JSON-encoded strings, bare strings) instead of failing Pydantic validation outright.
- Version bumps: `white-api` 0.4.0→0.4.1, `white-composition` 0.7.0→0.8.0, `white-core` 0.6.0→0.6.1, `white-ideation` 0.6.2→0.6.3 (+ `uv.lock` sync).
- Two small pending frontend tweaks bundled in: show key on the candidates page header, and exclude scrapped/merged (not just abandoned) songs from the sides song pool.

## Test plan
- [x] `packages/composition/tests/test_pipeline_runner.py` — 21 passed
- [x] `packages/api/tests/test_candidate_server.py -k promote` — 6 passed
- [x] `packages/ideation/tests/agents/test_green_agent.py` — 28 passed
- [x] `packages/ideation/tests/agents/test_violet_agent.py`, `test_white_agent_chord_kickoff.py` — 61 passed
- [x] `packages/ideation/tests/agents/test_white_agent.py`, state tests, mock artifact tests — all passed
- [x] `packages/core/tests/manifests/test_song_proposal.py` — 10 passed
- [x] `packages/core/tests/concepts/test_vanity_interview_question.py` (+ related) — all passed
- [x] Verified live: ran the White LangChain agent twice end-to-end; first run surfaced the `adaptation_attempts`/`mood`/`genres`/`rainbow_color`/Violet-question bugs fixed here, second run confirmed the fixes held (with one residual intermittent `rainbow_color` miss — LLM compliance, not a schema bug)
- [x] Manually promoted the real duplicate-label conflict this branch was built to diagnose (`genus_nemo_redacted_v3` chords) and confirmed the new error message would have surfaced the real cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JD7EZZBehPW4LQKXRnXZf