### PR TITLE
Fix playlist sync stale duplicates and keep merged-with-mix tracks poolable

### DIFF
--- a/packages/client/app/sides/page.tsx
+++ b/packages/client/app/sides/page.tsx
@@ -22,9 +22,18 @@ import { NotesButton, SongNotesModal } from "@/components/SongNotes";
 
 const SIDE_NAMES: SideName[] = ["A", "B", "C", "D"];
 
-const EXCLUDED_LIFECYCLE_STATUSES = new Set<SongEntry["lifecycle_status"]>([
-  "abandoned", "scrapped", "merged",
+const ALWAYS_EXCLUDED_LIFECYCLE_STATUSES = new Set<SongEntry["lifecycle_status"]>([
+  "abandoned", "scrapped",
 ]);
+
+// Merged tracks are only hidden from the pool when they have no audio to
+// place on a side — a merged track that still has a mix should remain
+// selectable regardless of the "show unmixed" toggle.
+function isPoolEligible(s: SongEntry): boolean {
+  if (ALWAYS_EXCLUDED_LIFECYCLE_STATUSES.has(s.lifecycle_status)) return false;
+  if (s.lifecycle_status === "merged" && !s.has_mix) return false;
+  return true;
+}
 
 function sideEntryFromSongs(songs: SideSong[], limitSeconds: number): SideEntry {
   const total = songs.reduce((sum, s) => sum + s.duration_seconds, 0);
@@ -395,11 +404,11 @@ export default function SidesPage() {
   );
   const available = songs
     .filter((s) => !assignedIds.has(s.id))
-    .filter((s) => !EXCLUDED_LIFECYCLE_STATUSES.has(s.lifecycle_status))
+    .filter(isPoolEligible)
     .filter((s) => showUnmixed || s.has_mix)
     .filter((s) => !poolSearch || s.title.toLowerCase().includes(poolSearch.toLowerCase()));
   const unmixedHiddenCount = songs.filter(
-    (s) => !assignedIds.has(s.id) && !EXCLUDED_LIFECYCLE_STATUSES.has(s.lifecycle_status) && !s.has_mix,
+    (s) => !assignedIds.has(s.id) && isPoolEligible(s) && !s.has_mix,
   ).length;
   const allAssigned = songs.length > 0 && songs.every((s) => assignedIds.has(s.id));
 

--- a/packages/composition/pyproject.toml
+++ b/packages/composition/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "white-composition"
-version = "0.8.0"
+version = "0.8.1"
 description = "Production orchestration, pipeline runner, and candidate review for White project"
 requires-python = ">=3.12"
 dependencies = [

--- a/packages/composition/src/white_composition/playlist_sync.py
+++ b/packages/composition/src/white_composition/playlist_sync.py
@@ -216,32 +216,20 @@ def _validate_output_dir(output_dir: str) -> Path:
     return resolved
 
 
-def _copy_if_needed(src: Path, dest: Path) -> None:
-    if dest.exists():
-        src_stat = src.stat()
-        dest_stat = dest.stat()
-        if (
-            dest_stat.st_size == src_stat.st_size
-            and dest_stat.st_mtime >= src_stat.st_mtime
-        ):
-            return
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(src, dest)
-
-
 def _rebuild_folder(
     folder: Path, target_names: dict[str, str], songs_by_id: dict[str, dict]
 ) -> int:
-    """Make `folder` exactly match `target_names` {song_id: filename}. Returns count synced."""
+    """Empty `folder` of prior audio files, then copy in `target_names`
+    {song_id: filename} fresh. Returns count synced.
+
+    Rebuilding from an empty folder (rather than diffing against what's already
+    there) avoids stale duplicates left behind when a song moves between sides
+    or buckets and its filename changes.
+    """
     folder.mkdir(parents=True, exist_ok=True)
-    target_filenames = set(target_names.values())
 
     for existing in folder.iterdir():
-        if (
-            existing.is_file()
-            and existing.suffix.lower() in _AUDIO_EXTENSIONS
-            and existing.name not in target_filenames
-        ):
+        if existing.is_file() and existing.suffix.lower() in _AUDIO_EXTENSIONS:
             existing.unlink()
 
     count = 0
@@ -250,7 +238,7 @@ def _rebuild_folder(
         mix_path = read_mix_path(song["production_path"])
         if mix_path is None:
             continue
-        _copy_if_needed(mix_path, folder / filename)
+        shutil.copy2(mix_path, folder / filename)
         count += 1
     return count
 

--- a/uv.lock
+++ b/uv.lock
@@ -7555,7 +7555,7 @@ requires-dist = [
 
 [[package]]
 name = "white-composition"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "packages/composition" }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- `playlist_sync`: always rebuild side folders from empty rather than diffing against existing files, so a song that changes filename after moving sides/buckets no longer leaves a stale duplicate copy behind
- Sides UI: a "merged" track that still has a mix stays selectable in the pool instead of being hidden outright, since merging shouldn't destroy audio that's still usable
- Bumps `white-composition` to 0.8.1 (patch)

## Test plan
- [x] Move a song between sides/buckets and confirm the old-filename copy is removed from the output folder
- [x] Mark a track "merged" with an existing mix and confirm it still appears in the sides pool
- [x] Confirm a "merged" track with no mix is still hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015FiZT1tWaPhBBTh2SKSKv2